### PR TITLE
Remove unnecessary parameter from addEmoji and addMention modifiers

### DIFF
--- a/draft-js-emoji-plugin/src/EmojiSearch/index.js
+++ b/draft-js-emoji-plugin/src/EmojiSearch/index.js
@@ -112,8 +112,7 @@ export default class EmojiSearch extends Component {
 
   onEmojiSelect = (emoji) => {
     this.updateAriaCloseDropdown();
-    const selection = this.props.getEditorState().getSelection();
-    const newEditorState = addEmoji(this.props.getEditorState(), emoji, selection);
+    const newEditorState = addEmoji(this.props.getEditorState(), emoji);
     this.props.updateEditorState(newEditorState);
   };
 

--- a/draft-js-emoji-plugin/src/modifiers/addEmoji.js
+++ b/draft-js-emoji-plugin/src/modifiers/addEmoji.js
@@ -3,11 +3,12 @@ import getSearchText from '../utils/getSearchText';
 import emojioneList from '../utils/emojioneList';
 import convertShortNameToUnicode from '../utils/convertShortNameToUnicode';
 
-const addEmoji = (editorState, emojiShortName, selection) => {
-  const { begin, end } = getSearchText(editorState, selection);
+const addEmoji = (editorState, emojiShortName) => {
+  const currentSelectionState = editorState.getSelection();
+  const { begin, end } = getSearchText(editorState, currentSelectionState);
 
   // get selection of the @mention search text
-  const mentionTextSelection = editorState.getSelection().merge({
+  const mentionTextSelection = currentSelectionState.merge({
     anchorOffset: begin,
     focusOffset: end,
   });

--- a/draft-js-mention-plugin/src/MentionSearch/index.js
+++ b/draft-js-mention-plugin/src/MentionSearch/index.js
@@ -112,8 +112,7 @@ export default class MentionSearch extends Component {
 
   onMentionSelect = (mention) => {
     this.updateAriaCloseDropdown();
-    const selection = this.props.getEditorState().getSelection();
-    const newEditorState = addMention(this.props.getEditorState(), mention, selection);
+    const newEditorState = addMention(this.props.getEditorState(), mention);
     this.props.updateEditorState(newEditorState);
   };
 

--- a/draft-js-mention-plugin/src/modifiers/addMention.js
+++ b/draft-js-mention-plugin/src/modifiers/addMention.js
@@ -1,14 +1,15 @@
 import { Modifier, EditorState, Entity } from 'draft-js';
 import getSearchText from '../utils/getSearchText';
 
-const addMention = (editorState, mention, selection) => {
+const addMention = (editorState, mention) => {
   // TODO allow the user to override if the mentions are SEGMENTED, IMMUTABLE or MUTABLE
   const entityKey = Entity.create('mention', 'SEGMENTED', { mention });
 
-  const { begin, end } = getSearchText(editorState, selection);
+  const currentSelectionState = editorState.getSelection();
+  const { begin, end } = getSearchText(editorState, currentSelectionState);
 
   // get selection of the @mention search text
-  const mentionTextSelection = editorState.getSelection().merge({
+  const mentionTextSelection = currentSelectionState.merge({
     anchorOffset: begin,
     focusOffset: end,
   });


### PR DESCRIPTION
I suggest we remove the parameter selection from the addEmoji and the addMention modifiers as we can get it from the editorState. Whenever the modifiers are used, we retrieve the selection from the editorState just to pass it on to the function, and it seems better to me to just retrieve it inside the function. 

You could argue that it is possible to pass in another selection than what is in the current editorState (as is done in getSearchText), but for all use cases of the addEmoji and the addMention modifiers we just retrieve the selection from the current editorState. 

(I'm new to doing pull requests, so any feedback to improve is appreciated.)