### PR TITLE
Pass editorState getter & setter as param to keyBinding func fix #126

### DIFF
--- a/draft-js-plugins-editor/src/Editor/index.js
+++ b/draft-js-plugins-editor/src/Editor/index.js
@@ -123,7 +123,7 @@ export default class PluginEditor extends Component {
     preventDefaultBehaviour = this.plugins
       .map((plugin) => {
         if (plugin.handleKeyCommand) {
-          const handled = plugin.handleKeyCommand(command);
+          const handled = plugin.handleKeyCommand(command, this.getEditorState, this.onChange);
           if (handled === true) {
             return handled;
           }
@@ -168,7 +168,7 @@ export default class PluginEditor extends Component {
     let command = this.plugins
       .map((plugin) => {
         if (plugin.keyBindingFn) {
-          const pluginCommand = plugin.keyBindingFn(keyboardEvent);
+          const pluginCommand = plugin.keyBindingFn(keyboardEvent, this.getEditorState, this.onChange);
           if (pluginCommand) {
             return pluginCommand;
           }


### PR DESCRIPTION
This PR allows to update the editor state from keyBinding functions such as  `handleKeyCommand` or `keyBindingFn`.

## Example

    import {RichUtils} from 'draft-js';

    const createDefaultKeyCommandPlugin = (config = {}) => {
      return {
        pluginProps: {
          handleKeyCommand: (command, getEditorState, updateEditorState) => {
            return false;
            const editorState = getEditorState();
            const newState = RichUtils.handleKeyCommand(editorState, command);
            if (newState) {
              updateEditorState(newState);
              return true;
            }
            return false;
          }
        },
      };
    };

    export default createDefaultKeyCommandPlugin;
