### PR TITLE
Hook arguments

### DIFF
--- a/draft-js-dnd-plugin/src/blockRendererFn.js
+++ b/draft-js-dnd-plugin/src/blockRendererFn.js
@@ -2,7 +2,7 @@ import { Entity } from 'draft-js';
 import removeBlock from './modifiers/removeBlock';
 import refreshEditorState from './modifiers/refreshEditorState';
 
-export default (config) => (contentBlock, getEditorState, setEditorState) => {
+export default (config) => (contentBlock, { getEditorState, setEditorState }) => {
   const type = contentBlock.getType();
   if (type === 'image') {
     const entityKey = contentBlock.getEntityAt(0);

--- a/draft-js-dnd-plugin/src/modifiers/onDropBlock.js
+++ b/draft-js-dnd-plugin/src/modifiers/onDropBlock.js
@@ -4,7 +4,7 @@ import { Entity } from 'draft-js';
 import { DRAFTJS_BLOCK_KEY, DRAFTJS_BLOCK_TYPE } from '../constants';
 
 export default function onDropBlock() {
-  return function onDropBlockInner(selection, dataTransfer, isInternal, getEditorState, setEditorState) {
+  return function onDropBlockInner(selection, dataTransfer, isInternal, { getEditorState, setEditorState }) {
     const state = getEditorState();
 
     // Get data 'text' (anything else won't move the cursor) and expecting kind of data (text/key)

--- a/draft-js-dnd-plugin/src/modifiers/onDropFile.js
+++ b/draft-js-dnd-plugin/src/modifiers/onDropFile.js
@@ -37,7 +37,7 @@ function getBlocksWhereEntityData(state, query) {
 }
 
 export default function onDropFile(config) {
-  return function onDropFileInner(selection, files, getEditorState, setEditorState) {
+  return function onDropFileInner(selection, files, { getEditorState, setEditorState }) {
     // Get upload function from config or editor props
     const upload = config.upload;
     const progress = config.progress || (percent => config.emitter.emit('progress', percent));

--- a/draft-js-plugins-editor/src/Editor/__test__/index.js
+++ b/draft-js-plugins-editor/src/Editor/__test__/index.js
@@ -136,18 +136,22 @@ describe('Editor', () => {
       const pluginEditor = result.instance();
       const draftEditor = result.node;
       const plugin = plugins[0];
+      const expectedSecondArgument = {
+        getEditorState: pluginEditor.getEditorState,
+        setEditorState: pluginEditor.onChange,
+      };
       draftEditor.props.handleKeyCommand('command');
       expect(plugin.handleKeyCommand).has.been.calledOnce();
-      expect(plugin.handleKeyCommand).has.been.calledWith('command', pluginEditor.getEditorState, pluginEditor.onChange);
+      expect(plugin.handleKeyCommand).has.been.calledWith('command', expectedSecondArgument);
       draftEditor.props.handlePastedText('command');
       expect(plugin.handlePastedText).has.been.calledOnce();
-      expect(plugin.handlePastedText).has.been.calledWith('command', pluginEditor.getEditorState, pluginEditor.onChange);
+      expect(plugin.handlePastedText).has.been.calledWith('command', expectedSecondArgument);
       draftEditor.props.handleReturn('command');
       expect(plugin.handleReturn).has.been.calledOnce();
-      expect(plugin.handleReturn).has.been.calledWith('command', pluginEditor.getEditorState, pluginEditor.onChange);
+      expect(plugin.handleReturn).has.been.calledWith('command', expectedSecondArgument);
       draftEditor.props.handleDrop('command');
       expect(plugin.handleDrop).has.been.calledOnce();
-      expect(plugin.handleDrop).has.been.calledWith('command', pluginEditor.getEditorState, pluginEditor.onChange);
+      expect(plugin.handleDrop).has.been.calledWith('command', expectedSecondArgument);
     });
 
     it('calls the handle- and on-hooks of the first plugin and not the second in case it was handeled', () => {
@@ -232,12 +236,16 @@ describe('Editor', () => {
       const pluginEditor = result.instance();
       const draftEditor = result.node;
       const plugin = plugins[0];
+      const expectedSecondArgument = {
+        getEditorState: pluginEditor.getEditorState,
+        setEditorState: pluginEditor.onChange,
+      };
       draftEditor.props.blockRendererFn('command');
       expect(plugin.blockRendererFn).has.been.calledOnce();
-      expect(plugin.blockRendererFn).has.been.calledWith('command', pluginEditor.getEditorState, pluginEditor.onChange);
+      expect(plugin.blockRendererFn).has.been.calledWith('command', expectedSecondArgument);
       draftEditor.props.keyBindingFn('command');
       expect(plugin.keyBindingFn).has.been.calledOnce();
-      expect(plugin.keyBindingFn).has.been.calledWith('command', pluginEditor.getEditorState, pluginEditor.onChange);
+      expect(plugin.keyBindingFn).has.been.calledWith('command', expectedSecondArgument);
     });
 
     it('combines the customStyleMaps from all plugins', () => {

--- a/draft-js-plugins-editor/src/Editor/index.js
+++ b/draft-js-plugins-editor/src/Editor/index.js
@@ -62,8 +62,10 @@ class PluginEditor extends Component {
 
   createEventHooks = (methodName, plugins) => (...args) => {
     const newArgs = [].slice.apply(args);
-    newArgs.push(this.getEditorState);
-    newArgs.push(this.onChange);
+    newArgs.push({
+      getEditorState: this.getEditorState,
+      setEditorState: this.onChange,
+    });
     for (const plugin of plugins) {
       if (typeof plugin[methodName] !== 'function') continue;
       const result = plugin[methodName](...newArgs);
@@ -75,8 +77,10 @@ class PluginEditor extends Component {
 
   createFnHooks = (methodName, plugins) => (...args) => {
     const newArgs = [].slice.apply(args);
-    newArgs.push(this.getEditorState);
-    newArgs.push(this.onChange);
+    newArgs.push({
+      getEditorState: this.getEditorState,
+      setEditorState: this.onChange,
+    });
     for (const plugin of plugins) {
       if (typeof plugin[methodName] !== 'function') continue;
       const result = plugin[methodName](...newArgs);

--- a/draft-js-sticker-plugin/src/blockRendererFn.js
+++ b/draft-js-sticker-plugin/src/blockRendererFn.js
@@ -1,6 +1,6 @@
 import removeSticker from './modifiers/removeSticker';
 
-export default (config) => (contentBlock, getEditorState, setEditorState) => {
+export default (config) => (contentBlock, { getEditorState, setEditorState }) => {
   const type = contentBlock.getType();
   if (type === 'sticker') {
     return {


### PR DESCRIPTION
This will make plugin system more flexible for future changes.

In the future we can easily extend out the arguments depending on new features that will be available in DraftJS. We even could pass in the whole pluginEditor context (as we had it in the first implementation & @ianstormtaylor suggested) and it would not result in a braking the API.

Yet I don't feel comfortable to expand the API and pass down the whole pluginEditor context until there is a valid use-case.`focus()` came up as a suggestion, but this can easily be done with `forceSelection` on the editorState as well.

I'm curious how you guys feel about it? @juliankrispel @ianstormtaylor @bkniffler 

P.S. I merged it already so I can move on with some refactoring. If there are good arguments against this change I'm happy to revert back.