### PR TITLE
fix mention regex if content block starts with @

### DIFF
--- a/draft-js-mention-plugin/src/mentionSearchStrategy.js
+++ b/draft-js-mention-plugin/src/mentionSearchStrategy.js
@@ -2,7 +2,7 @@
 
 import findWithRegex from 'find-with-regex';
 
-const MENTION_REGEX = /\s\@[\w]*/g;
+const MENTION_REGEX = /(\s|^)\@[\w]*/g;
 
 export default (contentBlock: Object, callback: Function) => {
   findWithRegex(MENTION_REGEX, contentBlock, callback);


### PR DESCRIPTION
**Bug:**
if you type `@` at the start of content block it will not show mention search. 
**Fix:**
regex now checks if user type `@` as first content block char or after whitespace char