### PR TITLE
Exposed History component for the Undo/Redo plugin

### DIFF
--- a/docs/client/components/pages/Undo/CustomUndoEditor/historyStyles.css
+++ b/docs/client/components/pages/Undo/CustomUndoEditor/historyStyles.css
@@ -1,0 +1,7 @@
+.historyItem {
+  color: #aaa;
+}
+
+.historyItemActive {
+  color: blue;
+}

--- a/docs/client/components/pages/Undo/CustomUndoEditor/index.js
+++ b/docs/client/components/pages/Undo/CustomUndoEditor/index.js
@@ -5,10 +5,13 @@ import Editor from 'draft-js-plugins-editor';
 import createUndoPlugin from 'draft-js-undo-plugin';
 import editorStyles from './editorStyles.css';
 import buttonStyles from './buttonStyles.css';
+import historyStyles from './historyStyles.css';
 
 const theme = Map({
   undo: buttonStyles.button,
   redo: buttonStyles.button,
+  historyItem: historyStyles.historyItem,
+  historyItemActive: historyStyles.historyItemActive,
 });
 const undoPlugin = createUndoPlugin({
   undoContent: 'Undo',

--- a/docs/client/components/pages/Undo/CustomUndoEditor/index.js
+++ b/docs/client/components/pages/Undo/CustomUndoEditor/index.js
@@ -15,7 +15,7 @@ const undoPlugin = createUndoPlugin({
   redoContent: 'Redo',
   theme,
 });
-const { UndoButton, RedoButton } = undoPlugin;
+const { UndoButton, RedoButton, History } = undoPlugin;
 
 export default class CustomUndoEditor extends Component {
 
@@ -52,6 +52,7 @@ export default class CustomUndoEditor extends Component {
             editorState={ this.state.editorState }
             onChange={ this.onChange }
           />
+          <History editorState={ this.state.editorState } />
         </div>
       </div>
     );

--- a/draft-js-undo-plugin/CHANGELOG.md
+++ b/draft-js-undo-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To Be Released
 
+### Added
+
+- Exposed the History component
+
 ## 0.0.5 - 2016-03-25
 ### Released the first working of DraftJS Undo Plugin
 

--- a/draft-js-undo-plugin/src/History/index.js
+++ b/draft-js-undo-plugin/src/History/index.js
@@ -1,29 +1,35 @@
 import React, { Component, PropTypes } from 'react';
 import { EditorState } from 'draft-js';
+import unionClassNames from 'union-class-names';
+import { Map } from 'immutable';
 
 import HistoryEntry from './HistoryEntry';
 
 class History extends Component {
 
   generateHistoryEntries(stack) {
+    const { theme = Map(), className } = this.props; // eslint-disable-line no-use-before-define
+    const combinedClassName = unionClassNames(theme.get('historyItem'), className);
     return stack.map((entry) => (
-      <HistoryEntry>
+      <HistoryEntry className={ combinedClassName }>
         { entry.getPlainText() }
       </HistoryEntry>
     ));
   }
 
   render() {
-    const undoStack = this.props.editorState.getUndoStack();
-    const redoStack = this.props.editorState.getRedoStack().reverse();
+    const { theme = Map(), editorState = EditorState.createEmpty(), className } = this.props; // eslint-disable-line no-use-before-define
+    const undoStack = editorState.getUndoStack();
+    const redoStack = editorState.getRedoStack().reverse();
     const undoHistory = this.generateHistoryEntries(undoStack);
     const redoHistory = this.generateHistoryEntries(redoStack);
+    const combinedClassName = unionClassNames(theme.get('historyItemActive'), className);
 
     return (
       <div>
         { redoHistory }
-        <HistoryEntry>
-          { this.props.editorState.getCurrentContent().getPlainText() }
+        <HistoryEntry className={ combinedClassName }>
+          { editorState.getCurrentContent().getPlainText() }
         </HistoryEntry>
         { undoHistory }
       </div>
@@ -33,10 +39,6 @@ class History extends Component {
 
 History.propTypes = {
   editorState: PropTypes.any.isRequired,
-};
-
-History.defaultProps = {
-  editorState: EditorState.createEmpty(),
 };
 
 export default History;

--- a/draft-js-undo-plugin/src/History/index.js
+++ b/draft-js-undo-plugin/src/History/index.js
@@ -1,4 +1,5 @@
 import React, { Component, PropTypes } from 'react';
+import { EditorState } from 'draft-js';
 
 import HistoryEntry from './HistoryEntry';
 
@@ -32,6 +33,10 @@ class History extends Component {
 
 History.propTypes = {
   editorState: PropTypes.any.isRequired,
+};
+
+History.defaultProps = {
+  editorState: EditorState.createEmpty(),
 };
 
 export default History;

--- a/draft-js-undo-plugin/src/History/index.js
+++ b/draft-js-undo-plugin/src/History/index.js
@@ -8,8 +8,9 @@ import HistoryEntry from './HistoryEntry';
 class History extends Component {
 
   generateHistoryEntries(stack) {
-    const { theme = Map(), className } = this.props; // eslint-disable-line no-use-before-define
+    const { theme = Map(), className } = this.props;
     const combinedClassName = unionClassNames(theme.get('historyItem'), className);
+
     return stack.map((entry) => (
       <HistoryEntry className={ combinedClassName }>
         { entry.getPlainText() }
@@ -18,11 +19,17 @@ class History extends Component {
   }
 
   render() {
-    const { theme = Map(), editorState = EditorState.createEmpty(), className } = this.props; // eslint-disable-line no-use-before-define
+    const {
+      theme = Map(),
+      editorState = EditorState.createEmpty(),
+      className,
+    } = this.props;
+
     const undoStack = editorState.getUndoStack();
     const redoStack = editorState.getRedoStack().reverse();
     const undoHistory = this.generateHistoryEntries(undoStack);
     const redoHistory = this.generateHistoryEntries(redoStack);
+
     const combinedClassName = unionClassNames(theme.get('historyItemActive'), className);
 
     return (

--- a/draft-js-undo-plugin/src/index.js
+++ b/draft-js-undo-plugin/src/index.js
@@ -1,5 +1,6 @@
 import UndoButton from './UndoButton';
 import RedoButton from './RedoButton';
+import History from './History';
 import { Map } from 'immutable';
 import styles from './styles.css';
 import decorateComponentWithProps from 'decorate-component-with-props';
@@ -23,6 +24,7 @@ const historyPlugin = (config = {}) => {
   return {
     UndoButton: decorateComponentWithProps(UndoButton, { theme, children: undoContent }),
     RedoButton: decorateComponentWithProps(RedoButton, { theme, children: redoContent }),
+    History: decorateComponentWithProps(History, { theme }),
   };
 };
 

--- a/draft-js-undo-plugin/src/index.js
+++ b/draft-js-undo-plugin/src/index.js
@@ -8,6 +8,8 @@ import decorateComponentWithProps from 'decorate-component-with-props';
 const defaultTheme = Map({
   redo: styles.button,
   undo: styles.button,
+  historyItem: styles.historyItem,
+  historyItemActive: styles.historyItemActive,
 });
 
 const historyPlugin = (config = {}) => {

--- a/draft-js-undo-plugin/src/styles.css
+++ b/draft-js-undo-plugin/src/styles.css
@@ -36,3 +36,11 @@
   background-color: #F5F5F5;
   color: #ccc;
 }
+
+.historyItem {
+  color: rgba(0,0,0,0.5);
+}
+
+.historyItemActive {
+  color: rgba(0,0,0,1);
+}


### PR DESCRIPTION
I saw that the History component was not being used in any of the examples. Not only that, it wasn't being properly exposed so I couldn't even try it. Not sure how much value is in this, but at least it's no longer dead code with this PR.

Reference: #48 and #53 

Here's what the new example looks like:

![History example](http://i.imgur.com/rdKMUHE.gif)