### PR TITLE
Editor patch

### DIFF
--- a/draft-js-emoji-plugin/src/emojiSearchStrategy.js
+++ b/draft-js-emoji-plugin/src/emojiSearchStrategy.js
@@ -2,7 +2,7 @@
 
 import findWithRegex from 'find-with-regex';
 
-const EMOJI_REGEX = /\s:[\w]*/g;
+const EMOJI_REGEX = /(\s|^):[\w]*/g;
 
 export default (contentBlock: Object, callback: Function) => {
   findWithRegex(EMOJI_REGEX, contentBlock, callback);

--- a/draft-js-plugins-editor/src/Editor/__test__/index.js
+++ b/draft-js-plugins-editor/src/Editor/__test__/index.js
@@ -358,8 +358,38 @@ describe('Editor', () => {
       );
       const draftEditor = result.node;
       draftEditor.props.blockRendererFn();
-      expect(plugin.blockRendererFn).has.not.been.called();
+      expect(plugin.blockRendererFn).has.been.called();
       expect(customHook).has.been.called();
+    });
+
+    it('blockRendererFnWithDecorator', () => {
+      const decorator = (Component) => (props) => <Component {...props} />;
+      const component = () => null;
+      const plugin = {
+        blockRendererFn: () => ({
+          decorators: [decorator],
+          props: { pluginProp: true },
+        }),
+      };
+      customHook = () => ({
+        component,
+        props: { editorProp: true },
+      });
+      const result = mount(
+        <PluginEditor
+          editorState={ editorState }
+          onChange={ onChange }
+          plugins={ [plugin] }
+          blockRendererFn={ customHook }
+        />
+      );
+      /*
+      should result in blockRendererFn returning {
+        component: <decorator><component/></decorator>,
+        props: { pluginProp: true, editorProps: true }
+      }
+       */
+      expect(!!result);
     });
   });
 });

--- a/draft-js-plugins-editor/src/Editor/index.js
+++ b/draft-js-plugins-editor/src/Editor/index.js
@@ -88,14 +88,18 @@ class PluginEditor extends Component {
         if (typeof plugin[methodName] !== 'function') continue;
         const result = plugin[methodName](...newArgs);
         if (result !== undefined) {
-          const { decorators: pluginDecorators, props, ...rest } = result;
+          const { decorators: pluginDecorators, props, ...rest } = result; // eslint-disable-line no-use-before-define
           if (pluginDecorators) decorators = [...decorators, ...pluginDecorators];
           block = { ...block, ...rest, props: { ...block.props, ...props } };
         }
-      } if (block.component) {
+      }
+
+      if (block.component) {
         decorators.forEach(decorator => { block.component = decorator(block.component); });
         return block;
-      } return false;
+      }
+
+      return false;
     } else if (methodName === 'blockStyleFn') {
       let styles;
       for (const plugin of plugins) {
@@ -105,15 +109,17 @@ class PluginEditor extends Component {
           styles = (styles ? (`${styles} `) : '') + result;
         }
       } return styles || false;
-    } else {
-      for (const plugin of plugins) {
-        if (typeof plugin[methodName] !== 'function') continue;
-        const result = plugin[methodName](...newArgs);
-        if (result !== undefined) {
-          return result;
-        }
+    }
+
+    for (const plugin of plugins) {
+      if (typeof plugin[methodName] !== 'function') continue;
+      const result = plugin[methodName](...newArgs);
+      if (result !== undefined) {
+        return result;
       }
-    } return false;
+    }
+
+    return false;
   };
 
   createPluginHooks = () => {

--- a/draft-js-plugins-editor/src/Editor/index.js
+++ b/draft-js-plugins-editor/src/Editor/index.js
@@ -82,15 +82,17 @@ class PluginEditor extends Component {
       setEditorState: this.onChange,
     });
     if (methodName === 'blockRendererFn') {
-      let block = { };
+      let block = { props: {} };
       let decorators = [];
       for (const plugin of plugins) {
         if (typeof plugin[methodName] !== 'function') continue;
         const result = plugin[methodName](...newArgs);
         if (result !== undefined) {
-          const { decorators: pluginDecorators, props, ...rest } = result; // eslint-disable-line no-use-before-define
+          const { decorators: pluginDecorators, props: pluginProps, ...pluginRest } = result; // eslint-disable-line no-use-before-define
+          const { props, ...rest } = block; // eslint-disable-line no-use-before-define
           if (pluginDecorators) decorators = [...decorators, ...pluginDecorators];
-          block = { ...block, ...rest, props: { ...block.props, ...props } };
+          console.log(props, pluginProps);
+          block = { ...rest, ...pluginRest, props: { ...props, ...pluginProps } };
         }
       }
 

--- a/draft-js-plugins-editor/src/Editor/index.js
+++ b/draft-js-plugins-editor/src/Editor/index.js
@@ -91,7 +91,6 @@ class PluginEditor extends Component {
           const { decorators: pluginDecorators, props: pluginProps, ...pluginRest } = result; // eslint-disable-line no-use-before-define
           const { props, ...rest } = block; // eslint-disable-line no-use-before-define
           if (pluginDecorators) decorators = [...decorators, ...pluginDecorators];
-          console.log(props, pluginProps);
           block = { ...rest, ...pluginRest, props: { ...props, ...pluginProps } };
         }
       }

--- a/draft-js-plugins-editor/src/Editor/index.js
+++ b/draft-js-plugins-editor/src/Editor/index.js
@@ -94,7 +94,7 @@ class PluginEditor extends Component {
     const pluginHooks = {};
     const eventHookKeys = [];
     const fnHookKeys = [];
-    const plugins = this.resolvePlugins();
+    const plugins = [this.props, ...this.resolvePlugins()];
 
     plugins.forEach((plugin) => {
       Object.keys(plugin).forEach((attrName) => {
@@ -168,9 +168,9 @@ class PluginEditor extends Component {
     const customStyleMap = this.resolveCustomStyleMap();
     return (
       <Editor
+        { ...this.props }
         { ...pluginProps }
         { ...pluginHooks }
-        { ...this.props }
         customStyleMap={ customStyleMap }
         onChange={ this.onChange }
         editorState={ this.props.editorState }


### PR DESCRIPTION

- Allow https://github.com/draft-js-plugins/draft-js-plugins/issues/156#issuecomment-207060175
- Allow for props to behave like the plugins instead of them overwriting plugin behaviour

I know `createFnHooks` isn't as beautiful as it used to be, but this is an important step. If you come up with a more clever way, please help refactoring it!

The changes will allow something like this:
```
export default function DndPlugin = (options) => {
    return {
        blockRendererFn: (contentBlock) => {
            return {
                decorators: [Draggable],
                props: {
                    allowDrag: options.allowDag !== false
                }
            }
        }
    }
}
```

The plugin will apply a decorator to all blocks, and also append the allowDrag prop.