### PR TITLE
[Counter Plugin] Added ability to incorporate custom counting functions

### DIFF
--- a/docs/client/components/pages/Counter/SimpleCounterEditor/index.js
+++ b/docs/client/components/pages/Counter/SimpleCounterEditor/index.js
@@ -4,7 +4,7 @@ import createCounterPlugin from 'draft-js-counter-plugin';
 import editorStyles from './editorStyles.css';
 
 const counterPlugin = createCounterPlugin();
-const { CharCounter, WordCounter, LineCounter } = counterPlugin;
+const { CharCounter, WordCounter, LineCounter, CustomCounter } = counterPlugin;
 const plugins = [counterPlugin];
 const text = `This editor has counters below!
 Try typing here and watch the numbers go up.
@@ -31,6 +31,11 @@ export default class SimpleCounterEditor extends Component {
     this.refs.editor.focus();
   };
 
+  customCountFunction(str) {
+    const wordArray = str.match(/\S+/g);  // matches words according to whitespace
+    return wordArray ? wordArray.length : 0;
+  }
+
   render() {
     return (
       <div>
@@ -45,6 +50,13 @@ export default class SimpleCounterEditor extends Component {
         <div>Characters: <CharCounter editorState={ this.state.editorState } limit={200} /></div>
         <div>Words: <WordCounter editorState={ this.state.editorState } limit={30} /></div>
         <div>Lines: <LineCounter editorState={ this.state.editorState } limit={10} /></div>
+        <div><span>Custom (words): </span>
+          <CustomCounter
+            editorState={ this.state.editorState }
+            limit={40}
+            countFunction={ this.customCountFunction }
+          />
+        </div>
       </div>
     );
   }

--- a/draft-js-counter-plugin/src/CustomCounter/__test__/index.js
+++ b/draft-js-counter-plugin/src/CustomCounter/__test__/index.js
@@ -38,8 +38,8 @@ describe('CounterPlugin Line Counter', () => {
 
     // a function that takes a string and returns the number of number characters
     const countFunction = (str) => {
-      const wordArray = str.match(/\d/g);  // matches only number characters
-      return wordArray ? wordArray.length : 0;
+      const numArray = str.match(/\d/g);  // matches only number characters
+      return numArray ? numArray.length : 0;
     };
 
     const text = 'I am a 1337 h4x0r';

--- a/draft-js-counter-plugin/src/CustomCounter/__test__/index.js
+++ b/draft-js-counter-plugin/src/CustomCounter/__test__/index.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import createCounterPlugin from '../../index';
+import { expect } from 'chai';
+import { EditorState, ContentState } from 'draft-js';
+
+describe('CounterPlugin Line Counter', () => {
+  const createEditorStateFromText = (text) => {
+    const contentState = ContentState.createFromText(text);
+    return EditorState.createWithContent(contentState);
+  };
+
+  let counterPlugin;
+
+  beforeEach(() => {
+    counterPlugin = createCounterPlugin();
+  });
+
+  it('instantiates plugin with word counter and counts 5 words', () => {
+    const { CustomCounter } = counterPlugin;
+
+    // a function that takes a string and returns the number of words
+    const countFunction = (str) => {
+      const wordArray = str.match(/\S+/g);  // matches words according to whitespace
+      return wordArray ? wordArray.length : 0;
+    };
+
+    const text = 'Hello there, how are you?';
+    const editorState = createEditorStateFromText(text);
+    const result = mount(
+      <CustomCounter editorState={ editorState } countFunction={ countFunction } />
+    );
+    expect(result).to.have.text('5');
+  });
+
+  it('instantiates plugin with number counter and counts 6 number characters', () => {
+    const { CustomCounter } = counterPlugin;
+
+    // a function that takes a string and returns the number of number characters
+    const countFunction = (str) => {
+      const wordArray = str.match(/\d/g);  // matches only number characters
+      return wordArray ? wordArray.length : 0;
+    };
+
+    const text = 'I am a 1337 h4x0r';
+    const editorState = createEditorStateFromText(text);
+    const result = mount(
+      <CustomCounter editorState={ editorState } countFunction={ countFunction } />
+    );
+    expect(result).to.have.text('6');
+  });
+});

--- a/draft-js-counter-plugin/src/CustomCounter/index.js
+++ b/draft-js-counter-plugin/src/CustomCounter/index.js
@@ -1,0 +1,30 @@
+import React, { Component, PropTypes } from 'react';
+import unionClassNames from 'union-class-names';
+import { Map } from 'immutable';
+
+class CustomCounter extends Component {
+
+  static propTypes = {
+    editorState: PropTypes.any.isRequired,
+    theme: PropTypes.any,
+    countFunction: PropTypes.function,
+  };
+
+  getClassNames(count, limit) {
+    const { theme = Map(), className } = this.props;
+    const defaultStyle = unionClassNames(theme.get('counter'), className);
+    const overLimitStyle = unionClassNames(theme.get('overLimit'), className);
+    return count > limit ? overLimitStyle : defaultStyle;
+  }
+
+  render() {
+    const { editorState, limit, countFunction } = this.props;
+    const plainText = editorState.getCurrentContent().getPlainText('');
+    const count = countFunction(plainText);
+    const classNames = this.getClassNames(count, limit);
+
+    return <span className={ classNames }>{count}</span>;
+  }
+}
+
+export default CustomCounter;

--- a/draft-js-counter-plugin/src/index.js
+++ b/draft-js-counter-plugin/src/index.js
@@ -1,6 +1,7 @@
 import CharCounter from './CharCounter';
 import WordCounter from './WordCounter';
 import LineCounter from './LineCounter';
+import CustomCounter from './CustomCounter';
 import { Map } from 'immutable';
 import styles from './styles.css';
 import decorateComponentWithProps from 'decorate-component-with-props';
@@ -22,6 +23,7 @@ const counterPlugin = (config = {}) => {
     CharCounter: decorateComponentWithProps(CharCounter, { theme }),
     WordCounter: decorateComponentWithProps(WordCounter, { theme }),
     LineCounter: decorateComponentWithProps(LineCounter, { theme }),
+    CustomCounter: decorateComponentWithProps(CustomCounter, { theme }),
   };
 };
 


### PR DESCRIPTION
I was looking at the counter plugin and thinking about how rigid it is, so I decided to try to implement a BYOF (Bring Your Own Function) feature so that the user can have more flexibility.

With this PR, the user can simply drop in their own function that takes a plaintext string as input and outputs a numerical count.

I've added tests to illustrate this.

What do you guys think? Yay or nay?