### PR TITLE
[Counter Plugin] Complete Docs

### DIFF
--- a/docs/client/components/pages/Counter/CustomCounterEditor/counterStyles.css
+++ b/docs/client/components/pages/Counter/CustomCounterEditor/counterStyles.css
@@ -1,0 +1,9 @@
+.counter {
+  color: white;
+  background-color: grey;
+}
+
+.counterOverLimit {
+  color: tomato;
+  background-color: grey;
+}

--- a/docs/client/components/pages/Counter/CustomCounterEditor/counterStyles.css
+++ b/docs/client/components/pages/Counter/CustomCounterEditor/counterStyles.css
@@ -1,9 +1,21 @@
 .counter {
   color: white;
-  background-color: grey;
+  background-color: #353535;
+  display: inline-block;
+  min-width: 50px;
+  border-radius: 10px;
+  padding: 2px;
+  text-align: center;
+  margin-bottom: 5px;
 }
 
 .counterOverLimit {
   color: tomato;
-  background-color: grey;
+  background-color: #353535;
+  display: inline-block;
+  min-width: 50px;
+  border-radius: 10px;
+  padding: 2px;
+  text-align: center;
+  margin-bottom: 5px;
 }

--- a/docs/client/components/pages/Counter/CustomCounterEditor/editorStyles.css
+++ b/docs/client/components/pages/Counter/CustomCounterEditor/editorStyles.css
@@ -1,0 +1,13 @@
+.editor {
+  border: 1px solid #ddd;
+  cursor: text;
+  padding: 16px;
+  border-radius: 4px;
+  margin-bottom: 2em;
+  box-shadow: inset 0px 1px 8px -3px #ABABAB;
+  background: #fefefe;
+}
+
+.editor :global(.public-DraftEditor-content) {
+  min-height: 140px;
+}

--- a/docs/client/components/pages/Counter/CustomCounterEditor/index.js
+++ b/docs/client/components/pages/Counter/CustomCounterEditor/index.js
@@ -1,0 +1,68 @@
+import React, { Component } from 'react';
+import Editor, { createEditorStateWithText } from 'draft-js-plugins-editor';
+import createCounterPlugin from 'draft-js-counter-plugin';
+import editorStyles from './editorStyles.css';
+import counterStyles from './counterStyles.css';
+
+const theme = {
+  counter: counterStyles.counter,
+  counterOverLimit: counterStyles.counterOverLimit,
+};
+const counterPlugin = createCounterPlugin({ theme });
+const { CharCounter, WordCounter, LineCounter, CustomCounter } = counterPlugin;
+const plugins = [counterPlugin];
+const text = `This editor has counters below!
+Try typing here and watch the numbers go up. 🙌
+
+Note that the color changes when you pass one of the following limits:
+- 200 characters
+- 30 words
+- 10 lines
+`;
+
+export default class CustomCounterEditor extends Component {
+
+  state = {
+    editorState: createEditorStateWithText(text),
+  };
+
+  onChange = (editorState) => {
+    this.setState({ editorState });
+  };
+
+  focus = () => {
+    this.refs.editor.focus();
+  };
+
+  customCountFunction(str) {
+    const wordArray = str.match(/\S+/g);  // matches words according to whitespace
+    return wordArray ? wordArray.length : 0;
+  }
+
+  render() {
+    return (
+      <div>
+        <div className={ editorStyles.editor } onClick={ this.focus }>
+          <Editor
+            editorState={this.state.editorState}
+            onChange={this.onChange}
+            plugins={plugins}
+            ref="editor"
+          />
+        </div>
+        <div>Characters: <CharCounter editorState={ this.state.editorState } limit={200} /></div>
+        <div>Words: <WordCounter editorState={ this.state.editorState } limit={30} /></div>
+        <div>Lines: <LineCounter editorState={ this.state.editorState } limit={10} /></div>
+        <div><span>Custom (words): </span>
+          <CustomCounter
+            editorState={ this.state.editorState }
+            limit={40}
+            countFunction={ this.customCountFunction }
+          />
+        </div>
+        <br />
+        <br />
+      </div>
+    );
+  }
+}

--- a/docs/client/components/pages/Counter/CustomCounterEditor/index.js
+++ b/docs/client/components/pages/Counter/CustomCounterEditor/index.js
@@ -50,15 +50,16 @@ export default class CustomCounterEditor extends Component {
             ref="editor"
           />
         </div>
-        <div>Characters: <CharCounter editorState={ this.state.editorState } limit={200} /></div>
-        <div>Words: <WordCounter editorState={ this.state.editorState } limit={30} /></div>
-        <div>Lines: <LineCounter editorState={ this.state.editorState } limit={10} /></div>
-        <div><span>Custom (words): </span>
+        <div><CharCounter editorState={ this.state.editorState } limit={200} /> characters</div>
+        <div><WordCounter editorState={ this.state.editorState } limit={30} /> words</div>
+        <div><LineCounter editorState={ this.state.editorState } limit={10} /> lines</div>
+        <div>
           <CustomCounter
             editorState={ this.state.editorState }
             limit={40}
             countFunction={ this.customCountFunction }
           />
+          <span> words (custom function)</span>
         </div>
         <br />
         <br />

--- a/docs/client/components/pages/Counter/SimpleCounterEditor/index.js
+++ b/docs/client/components/pages/Counter/SimpleCounterEditor/index.js
@@ -7,7 +7,7 @@ const counterPlugin = createCounterPlugin();
 const { CharCounter, WordCounter, LineCounter, CustomCounter } = counterPlugin;
 const plugins = [counterPlugin];
 const text = `This editor has counters below!
-Try typing here and watch the numbers go up.
+Try typing here and watch the numbers go up. 🙌
 
 Note that the color changes when you pass one of the following limits:
 - 200 characters
@@ -57,6 +57,8 @@ export default class SimpleCounterEditor extends Component {
             countFunction={ this.customCountFunction }
           />
         </div>
+        <br />
+        <br />
       </div>
     );
   }

--- a/docs/client/components/pages/Counter/SimpleCounterEditor/index.js
+++ b/docs/client/components/pages/Counter/SimpleCounterEditor/index.js
@@ -22,9 +22,7 @@ export default class SimpleCounterEditor extends Component {
   };
 
   onChange = (editorState) => {
-    this.setState({
-      editorState,
-    });
+    this.setState({ editorState });
   };
 
   focus = () => {

--- a/docs/client/components/pages/Counter/SimpleCounterEditor/index.js
+++ b/docs/client/components/pages/Counter/SimpleCounterEditor/index.js
@@ -45,15 +45,16 @@ export default class SimpleCounterEditor extends Component {
             ref="editor"
           />
         </div>
-        <div>Characters: <CharCounter editorState={ this.state.editorState } limit={200} /></div>
-        <div>Words: <WordCounter editorState={ this.state.editorState } limit={30} /></div>
-        <div>Lines: <LineCounter editorState={ this.state.editorState } limit={10} /></div>
-        <div><span>Custom (words): </span>
+        <div><CharCounter editorState={ this.state.editorState } limit={200} /> characters</div>
+        <div><WordCounter editorState={ this.state.editorState } limit={30} /> words</div>
+        <div><LineCounter editorState={ this.state.editorState } limit={10} /> lines</div>
+        <div>
           <CustomCounter
             editorState={ this.state.editorState }
             limit={40}
             countFunction={ this.customCountFunction }
           />
+          <span> words (custom function)</span>
         </div>
         <br />
         <br />

--- a/docs/client/components/pages/Counter/gettingStarted.js
+++ b/docs/client/components/pages/Counter/gettingStarted.js
@@ -1,0 +1,20 @@
+// It is important to import the Editor which accepts plugins.
+import Editor from 'draft-js-plugins-editor';
+import createCounterPlugin from 'draft-js-counter-plugin';
+import React from 'react';
+
+// Creates an Instance. At this step, a configuration object can be passed in
+// as an argument.
+const counterPlugin = createCounterPlugin();
+
+// The Editor accepts an array of plugins. In this case, only the emojiPlugin is
+// passed in, although it is possible to pass in multiple plugins.
+const MyEditor = ({ editorState, onChange }) => (
+  <Editor
+    editorState={ editorState }
+    onChange={ onChange }
+    plugins={ [counterPlugin] }
+  />
+);
+
+export default MyEditor;

--- a/docs/client/components/pages/Counter/gettingStarted.js
+++ b/docs/client/components/pages/Counter/gettingStarted.js
@@ -7,14 +7,21 @@ import React from 'react';
 // as an argument.
 const counterPlugin = createCounterPlugin();
 
-// The Editor accepts an array of plugins. In this case, only the emojiPlugin is
+// Extract a counter from the plugin.
+const { CharCounter } = counterPlugin;
+
+// The Editor accepts an array of plugins. In this case, only the counterPlugin is
 // passed in, although it is possible to pass in multiple plugins.
+// The Counter is placed after the Editor.
 const MyEditor = ({ editorState, onChange }) => (
-  <Editor
-    editorState={ editorState }
-    onChange={ onChange }
-    plugins={ [counterPlugin] }
-  />
+  <div>
+    <Editor
+      editorState={ editorState }
+      onChange={ onChange }
+      plugins={ [counterPlugin] }
+    />
+    <CharCounter editorState={ this.state.editorState } limit={200} />
+  </div>
 );
 
 export default MyEditor;

--- a/docs/client/components/pages/Counter/index.js
+++ b/docs/client/components/pages/Counter/index.js
@@ -1,9 +1,23 @@
 import React, { Component } from 'react';
+import styles from './styles.css';
+
 import Container from '../../shared/Container';
+import AlternateContainer from '../../shared/AlternateContainer';
 import Heading from '../../shared/Heading';
 import SimpleCounterEditor from './SimpleCounterEditor';
 import NavBar from '../../shared/NavBar';
 import Separator from '../../shared/Separator';
+import SocialBar from '../../shared/SocialBar';
+import Code from '../../shared/Code';
+import ExternalLink from '../../shared/Link';
+import InlineCode from '../../shared/InlineCode';
+
+import gettingStarted from '!!../../../loaders/prism-loader?language=javascript!./gettingStarted';
+
+import simpleExampleCode from '!!../../../loaders/prism-loader?language=javascript!./SimpleCounterEditor';
+import simpleEditorStylesCode from '!!../../../loaders/prism-loader?language=css!./SimpleCounterEditor/editorStyles.css';
+import webpackConfig from '!!../../../loaders/prism-loader?language=javascript!./webpackConfig';
+import webpackImport from '!!../../../loaders/prism-loader?language=javascript!./webpackImport';
 
 export default class App extends Component {
   render() {
@@ -13,11 +27,84 @@ export default class App extends Component {
         <Separator />
         <Container>
           <Heading level={ 2 }>Counter</Heading>
+          <p>
+            A simple counter plugin for all your counting needs. You can even set a limit to change the color past a certain threshold.
+          </p>
+          <Heading level={ 3 }>Usage</Heading>
+          <p>
+            To use, simply import and instantiate the counter plugin, and then use one of the available counter components in your JSX. Out of the box, the following counters are included:
+          </p>
+          <ul>
+            <li>Character Counter</li>
+            <li>Word Counter</li>
+            <li>Line Counter</li>
+            <li>Custom Counter</li>
+          </ul>
+          <p>The Custom Counter allows you to bring your own counting function. This will be a function that takes plain text (as a string) from the editor as input and returns a numerical value.</p>
+        </Container>
+        <AlternateContainer>
+          <Heading level={ 2 }>Getting Started</Heading>
+          <Code code="npm install draft-js-plugins-editor@1.0.0-beta1 --save" />
+          <Code code="npm install draft-js-counter-plugin@1.0.0-beta1 --save" />
+          <Code code={ gettingStarted } name="gettingStarted.js" />
+          <Heading level={ 3 }>Importing the default styles</Heading>
+          <p>
+            The plugin ships with a default styling available at this location in the installed package:
+            &nbsp;
+            <InlineCode code={ 'node_modules/draft-js-counter-plugin/lib/plugin.css' } />
+          </p>
+          <Heading level={ 4 }>Webpack Usage</Heading>
+          <ul className={ styles.list }>
+            <li className={ styles.listEntry }>
+              1. Install Webpack loaders:
+              &nbsp;
+              <InlineCode code={ 'npm i style-loader css-loader --save-dev' } />
+            </li>
+            <li className={ styles.listEntry }>
+              2. Add the below section to Webpack config (if your config already has a loaders array, simply add the below loader object to your existing list.
+              <Code code={ webpackConfig } className={ styles.guideCodeBlock } />
+            </li>
+            <li className={ styles.listEntry }>
+              3. Add the below import line to your component to tell Webpack to inject the style to your component.
+              <Code code={ webpackImport } className={ styles.guideCodeBlock } />
+            </li>
+            <li className={ styles.listEntry }>
+              4. Restart Webpack.
+            </li>
+          </ul>
+          <Heading level={ 4 }>Browserify Usage</Heading>
+          <p>
+            Please help, by submiting a Pull Request to the <ExternalLink href="https://github.com/draft-js-plugins/draft-js-plugins/blob/master/docs/client/components/pages/Counter/index.js">documention</ExternalLink>.
+          </p>
+        </AlternateContainer>
+        <Container>
+          <Heading level={ 2 }>Configuration Parameters</Heading>
+          <div className={ styles.param }>
+            <div className={ styles.paramName }>theme</div>
+            <div>Immutable.js Map of CSS classes with the following keys.
+              <div className={ styles.subParams }>
+                <div className={ styles.subParam }><span className={ styles.subParamName }>counter:</span> CSS class to be applied to the number displayed when not over the specified limit</div>
+                <div className={ styles.subParam }><span className={ styles.subParamName }>counterOverLimit:</span> CSS class to be applied to the number displayed when over the specified limit</div>
+              </div>
+            </div>
+          </div>
+          <Heading level={ 2 }>Component Properties</Heading>
+          <div className={ styles.param }>
+            <div className={ styles.paramName }>limit</div>
+            <div>A limit to indicate to the user that a threshold has passed.</div>
+          </div>
+          <div className={ styles.param }>
+            <div className={ styles.paramName }>countFunction</div>
+            <div>A custom counting function for the Custom Counter. The function will receive plain text from the editor (as a string) as input and should return a numerical value.</div>
+          </div>
         </Container>
         <Container>
           <Heading level={ 2 }>Simple Example</Heading>
           <SimpleCounterEditor />
+          <Code code={ simpleExampleCode } name="SimpleEmojiEditor.js" />
+          <Code code={ simpleEditorStylesCode } name="editorStyles.css" />
         </Container>
+        <SocialBar />
       </div>
     );
   }

--- a/docs/client/components/pages/Counter/index.js
+++ b/docs/client/components/pages/Counter/index.js
@@ -85,7 +85,7 @@ export default class App extends Component {
           <Heading level={ 2 }>Configuration Parameters</Heading>
           <div className={ styles.param }>
             <div className={ styles.paramName }>theme</div>
-            <div>Immutable.js Map of CSS classes with the following keys.
+            <div>Javascript object of CSS classes with the following keys.
               <div className={ styles.subParams }>
                 <div className={ styles.subParam }><span className={ styles.subParamName }>counter:</span> CSS class to be applied to the number displayed when not over the specified limit</div>
                 <div className={ styles.subParam }><span className={ styles.subParamName }>counterOverLimit:</span> CSS class to be applied to the number displayed when over the specified limit</div>

--- a/docs/client/components/pages/Counter/index.js
+++ b/docs/client/components/pages/Counter/index.js
@@ -16,6 +16,10 @@ import gettingStarted from '!!../../../loaders/prism-loader?language=javascript!
 
 import simpleExampleCode from '!!../../../loaders/prism-loader?language=javascript!./SimpleCounterEditor';
 import simpleEditorStylesCode from '!!../../../loaders/prism-loader?language=css!./SimpleCounterEditor/editorStyles.css';
+import CustomCounterEditor from './CustomCounterEditor';
+import customExampleCode from '!!../../../loaders/prism-loader?language=javascript!./CustomCounterEditor';
+import customExampleEditorStylesCode from '!!../../../loaders/prism-loader?language=css!./CustomCounterEditor/editorStyles.css';
+import customExampleCounterStylesCode from '!!../../../loaders/prism-loader?language=css!./CustomCounterEditor/counterStyles.css';
 import webpackConfig from '!!../../../loaders/prism-loader?language=javascript!./webpackConfig';
 import webpackImport from '!!../../../loaders/prism-loader?language=javascript!./webpackImport';
 
@@ -103,6 +107,13 @@ export default class App extends Component {
           <SimpleCounterEditor />
           <Code code={ simpleExampleCode } name="SimpleEmojiEditor.js" />
           <Code code={ simpleEditorStylesCode } name="editorStyles.css" />
+        </Container>
+        <Container>
+          <Heading level={ 2 }>Themed Example</Heading>
+          <CustomCounterEditor />
+          <Code code={ customExampleCode } name="CustomCounterEditor.js" />
+          <Code code={ customExampleCounterStylesCode } name="counterStyles.css" />
+          <Code code={ customExampleEditorStylesCode } name="editorStyles.css" />
         </Container>
         <SocialBar />
       </div>

--- a/docs/client/components/pages/Counter/styles.css
+++ b/docs/client/components/pages/Counter/styles.css
@@ -3,24 +3,24 @@
   padding-top: 10em;
 }
 
-.param {
-  margin: 10px 0;
+.center {
+  text-align: center;
 }
 
-.paramBig {
+
+.param {
   margin: 10px 0;
   display: flex;
 }
 
 .paramName {
   font-weight: bold;
-  width: 175px;
-  min-width: 175px;
+  width: 125px;
   display: inline-block;
+  flex-shrink: 0;
 }
 
 .subParams {
-  margin-left: 175px;
   margin-top: 10px;
 }
 
@@ -32,4 +32,18 @@
 .subParamName {
   font-weight: bold;
   margin-right: 5px;
+}
+
+.list {
+  list-style-type: none;
+  padding-left: 0;
+}
+
+.listEntry {
+  margin-top: 1rem;
+}
+
+.guideCodeBlock {
+  margin-top: 1rem;
+  margin-bottom: 1rem !important;
 }

--- a/docs/client/components/pages/Counter/webpackConfig.js
+++ b/docs/client/components/pages/Counter/webpackConfig.js
@@ -1,0 +1,12 @@
+module.exports = {
+  module: {
+    loaders: [
+      {
+        test: /plugin\.css$/,
+        loaders: [
+          'style', 'css',
+        ],
+      },
+    ],
+  },
+};

--- a/docs/client/components/pages/Counter/webpackImport.js
+++ b/docs/client/components/pages/Counter/webpackImport.js
@@ -1,0 +1,1 @@
+import 'draft-js-counter-plugin/lib/plugin.css';

--- a/draft-js-counter-plugin/src/CustomCounter/index.js
+++ b/draft-js-counter-plugin/src/CustomCounter/index.js
@@ -6,6 +6,7 @@ class CustomCounter extends Component {
   static propTypes = {
     editorState: PropTypes.any.isRequired,
     theme: PropTypes.any,
+    limit: PropTypes.number,
     countFunction: PropTypes.function,
   };
 

--- a/draft-js-counter-plugin/src/LineCounter/index.js
+++ b/draft-js-counter-plugin/src/LineCounter/index.js
@@ -6,6 +6,7 @@ class LineCounter extends Component {
   static propTypes = {
     editorState: PropTypes.any.isRequired,
     theme: PropTypes.any,
+    limit: PropTypes.number,
   };
 
   getLineCount(editorState) {

--- a/draft-js-counter-plugin/src/WordCounter/index.js
+++ b/draft-js-counter-plugin/src/WordCounter/index.js
@@ -6,6 +6,7 @@ class WordCounter extends Component {
   static propTypes = {
     editorState: PropTypes.any.isRequired,
     theme: PropTypes.any,
+    limit: PropTypes.number,
   };
 
   getWordCount(editorState) {


### PR DESCRIPTION
I've typed up some docs for the counter plugin. In this PR, I also did the following specific things:

1. Used flex box to better layout the configuration parameters section
2. Used normal JS Object instead of Map for the themed editor example

I do want to say that the whole process was kind of tedious and confusing. There are so many import statements required, and I had to do a lot of copy and paste from the other plugins. I think we should improve this in the future. I assume we'll overhaul the entire process after we cut the next release, so I'm excited for that 😄 