### PR TITLE
Fix rendering empty avatars

### DIFF
--- a/draft-js-mention-plugin/src/MentionSuggestions/Entry/Avatar/index.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/Entry/Avatar/index.js
@@ -11,7 +11,7 @@ const Avatar = ({ mention, theme = {} }) => {
     );
   }
 
-  return null;
+  return <noscript />;
 };
 
 export default Avatar;


### PR DESCRIPTION
React v0.14 doesn't support `null`s as render return value in stateless components.