### PR TITLE
Plugin editor changes for wysiwyg plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ High quality plugins with great UX on top of [DraftJS](https://github.com/facebo
 
 [![Build Status](https://travis-ci.org/draft-js-plugins/draft-js-plugins.svg?branch=master)](https://travis-ci.org/draft-js-plugins/draft-js-plugins)
 
+## Important Note
+
+We currently prepare for a 2.0 beta. The `master` branch already contains unpublished features & plugins.
+
 ## Available Plugins
 
 - [Emoji](https://www.draft-js-plugins.com/plugin/emoji)

--- a/draft-js-plugins-editor/CHANGELOG.md
+++ b/draft-js-plugins-editor/CHANGELOG.md
@@ -5,6 +5,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To Be Released
 
+### Added
+
+- `onChange` & and all handlers now also receive: `getPlugins`, `getProps`, `getReadOnly`, `setReadOnly`.
+
+### Removed
+
+- `decorators` don't decorate plugins anymore.
+
 ## 1.0.1 - 2016-05-03
 
 ### Fixed

--- a/draft-js-plugins-editor/package.json
+++ b/draft-js-plugins-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "draft-js-plugins-editor",
-  "version": "1.0.1",
+  "version": "2.0.0-beta1",
   "description": "Editor for DraftJS Plugins",
   "author": {
     "name": "Nik Graf",

--- a/draft-js-plugins-editor/src/Editor/__test__/index.js
+++ b/draft-js-plugins-editor/src/Editor/__test__/index.js
@@ -163,8 +163,7 @@ describe('Editor', () => {
       const draftEditor = result.node;
       const plugin = plugins[0];
       const expectedSecondArgument = {
-        getEditorState: pluginEditor.getEditorState,
-        setEditorState: pluginEditor.onChange,
+        ...pluginEditor
       };
       draftEditor.props.handleKeyCommand('command');
       expect(plugin.handleKeyCommand).has.been.calledOnce();
@@ -263,8 +262,7 @@ describe('Editor', () => {
       const draftEditor = result.node;
       const plugin = plugins[0];
       const expectedSecondArgument = {
-        getEditorState: pluginEditor.getEditorState,
-        setEditorState: pluginEditor.onChange,
+        ...pluginEditor
       };
       draftEditor.props.blockRendererFn('command');
       expect(plugin.blockRendererFn).has.been.calledOnce();
@@ -434,36 +432,6 @@ describe('Editor', () => {
       draftEditor.props.blockRendererFn();
       expect(plugin.blockRendererFn).has.been.called();
       expect(customHook).has.been.called();
-    });
-
-    it('renders block component using blockRenderFn prop and decorators', () => {
-      const decorator = (Comp) => (props) => <div className="decorator"><Comp {...props} /></div>;
-      const component = () => null;
-
-      const plugin = {
-        blockRendererFn: () => ({
-          decorators: [decorator],
-          props: { pluginProp: true },
-        }),
-      };
-
-      customHook = () => ({
-        component,
-        props: { editorProp: true },
-      });
-
-      const wrapper = mount(
-        <PluginEditor
-          editorState={ editorState }
-          onChange={ onChange }
-          plugins={ [plugin] }
-          blockRendererFn={ customHook }
-        />
-      );
-
-      const decorators = wrapper.findWhere(n => n.hasClass('decorator'));
-      expect(decorators.length).to.equal(1);
-      expect(wrapper.find(component).length).to.equal(1);
     });
   });
 

--- a/draft-js-plugins-editor/src/Editor/__test__/index.js
+++ b/draft-js-plugins-editor/src/Editor/__test__/index.js
@@ -163,7 +163,12 @@ describe('Editor', () => {
       const draftEditor = result.node;
       const plugin = plugins[0];
       const expectedSecondArgument = {
-        ...pluginEditor
+        getEditorState: pluginEditor.getEditorState,
+        setEditorState: pluginEditor.onChange,
+        getPlugins: pluginEditor.getPlugins,
+        getProps: pluginEditor.getProps,
+        getReadOnly: pluginEditor.getReadOnly,
+        setReadOnly: pluginEditor.setReadOnly,
       };
       draftEditor.props.handleKeyCommand('command');
       expect(plugin.handleKeyCommand).has.been.calledOnce();
@@ -262,7 +267,12 @@ describe('Editor', () => {
       const draftEditor = result.node;
       const plugin = plugins[0];
       const expectedSecondArgument = {
-        ...pluginEditor
+        getEditorState: pluginEditor.getEditorState,
+        setEditorState: pluginEditor.onChange,
+        getPlugins: pluginEditor.getPlugins,
+        getProps: pluginEditor.getProps,
+        getReadOnly: pluginEditor.getReadOnly,
+        setReadOnly: pluginEditor.setReadOnly,
       };
       draftEditor.props.blockRendererFn('command');
       expect(plugin.blockRendererFn).has.been.calledOnce();

--- a/draft-js-plugins-editor/src/Editor/index.js
+++ b/draft-js-plugins-editor/src/Editor/index.js
@@ -34,8 +34,8 @@ class PluginEditor extends Component {
   constructor(props) {
     super(props);
 
-    const plugins = [this.props, ...this.resolvePlugins()];
-    for (const plugin of plugins) {
+    this.plugins = [this.props, ...this.resolvePlugins()];
+    for (const plugin of this.plugins) {
       if (typeof plugin.initialize !== 'function') continue;
       plugin.initialize({
         getEditorState: this.getEditorState,

--- a/draft-js-plugins-editor/src/Editor/index.js
+++ b/draft-js-plugins-editor/src/Editor/index.js
@@ -37,10 +37,7 @@ class PluginEditor extends Component {
     this.plugins = [this.props, ...this.resolvePlugins()];
     for (const plugin of this.plugins) {
       if (typeof plugin.initialize !== 'function') continue;
-      plugin.initialize({
-        getEditorState: this.getEditorState,
-        setEditorState: this.onChange,
-      });
+      plugin.initialize({ ...this });
     }
 
     // attach proxy methods like `focus` or `blur`
@@ -66,12 +63,12 @@ class PluginEditor extends Component {
     let newEditorState = editorState;
     this.resolvePlugins().forEach((plugin) => {
       if (plugin.onChange) {
-        newEditorState = plugin.onChange(newEditorState);
+        newEditorState = plugin.onChange(newEditorState, { ...this });
       }
     });
 
     if (this.props.onChange) {
-      this.props.onChange(newEditorState);
+      this.props.onChange(newEditorState, { ...this });
     }
   };
 
@@ -79,10 +76,7 @@ class PluginEditor extends Component {
 
   createEventHooks = (methodName, plugins) => (...args) => {
     const newArgs = [].slice.apply(args);
-    newArgs.push({
-      getEditorState: this.getEditorState,
-      setEditorState: this.onChange,
-    });
+    newArgs.push({ ...this });
     for (const plugin of plugins) {
       if (typeof plugin[methodName] !== 'function') continue;
       const result = plugin[methodName](...newArgs);
@@ -95,10 +89,7 @@ class PluginEditor extends Component {
   createFnHooks = (methodName, plugins) => (...args) => {
     const newArgs = [].slice.apply(args);
 
-    newArgs.push({
-      getEditorState: this.getEditorState,
-      setEditorState: this.onChange,
-    });
+    newArgs.push({ ...this });
 
     if (methodName === 'blockRendererFn') {
       let block = { props: {} };

--- a/draft-js-plugins-editor/src/Editor/index.js
+++ b/draft-js-plugins-editor/src/Editor/index.js
@@ -46,6 +46,8 @@ class PluginEditor extends Component {
         this.refs.editor[method](...args)
       );
     }
+
+    this.state = {};
   }
 
   componentWillMount() {
@@ -74,6 +76,12 @@ class PluginEditor extends Component {
 
   setEditorState = this.onChange;
   getEditorState = () => this.props.editorState;
+
+  getReadOnly = () => this.props.readOnly;
+
+  setReadOnly = (readOnly) => {
+    if (readOnly !== this.state.readOnly) this.setState({ readOnly });
+  };
 
   createEventHooks = (methodName, plugins) => (...args) => {
     const newArgs = [].slice.apply(args);
@@ -235,6 +243,7 @@ class PluginEditor extends Component {
         { ...this.props }
         { ...accessibilityProps }
         { ...pluginHooks }
+        readOnly={this.props.readOnly || this.state.readOnly}
         customStyleMap={ customStyleMap }
         onChange={ this.onChange }
         editorState={ this.props.editorState }

--- a/draft-js-plugins-editor/src/Editor/index.js
+++ b/draft-js-plugins-editor/src/Editor/index.js
@@ -72,6 +72,7 @@ class PluginEditor extends Component {
     }
   };
 
+  setEditorState = this.onChange;
   getEditorState = () => this.props.editorState;
 
   createEventHooks = (methodName, plugins) => (...args) => {

--- a/draft-js-plugins-editor/src/Editor/index.js
+++ b/draft-js-plugins-editor/src/Editor/index.js
@@ -94,24 +94,17 @@ class PluginEditor extends Component {
 
     if (methodName === 'blockRendererFn') {
       let block = { props: {} };
-      let decorators = [];
       for (const plugin of plugins) {
         if (typeof plugin[methodName] !== 'function') continue;
         const result = plugin[methodName](...newArgs);
         if (result !== undefined && result !== null) {
-          const { decorators: pluginDecorators, props: pluginProps, ...pluginRest } = result; // eslint-disable-line no-use-before-define
+          const { props: pluginProps, ...pluginRest } = result; // eslint-disable-line no-use-before-define
           const { props, ...rest } = block; // eslint-disable-line no-use-before-define
-          if (pluginDecorators) decorators = [...decorators, ...pluginDecorators];
           block = { ...rest, ...pluginRest, props: { ...props, ...pluginProps } };
         }
       }
 
-      if (block.component) {
-        decorators.forEach(decorator => { block.component = decorator(block.component); });
-        return block;
-      }
-
-      return false;
+      return block.component ? block : false;
     } else if (methodName === 'blockStyleFn') {
       let styles;
       for (const plugin of plugins) {

--- a/draft-js-plugins-editor/src/Editor/index.js
+++ b/draft-js-plugins-editor/src/Editor/index.js
@@ -47,7 +47,7 @@ class PluginEditor extends Component {
       );
     }
 
-    this.state = {};
+    this.state = {}; // TODO for Nik: ask ben why this is relevent
   }
 
   componentWillMount() {
@@ -74,14 +74,21 @@ class PluginEditor extends Component {
     }
   };
 
+  getPlugins = () => this.props.plugins.slice(0);
+  getProps = () => ({ ...this.props });
+
+  // TODO further down in render we use readOnly={this.props.readOnly || this.state.readOnly}. Ask Ben why readOnly is here just from the props? Why would plugins use this instead of just taking it from getProps?
+  getReadOnly = () => this.props.readOnly;
+  setReadOnly = (readOnly) => readOnly !== this.state.readOnly ? this.setState({ readOnly }) : undefined; // eslint-disable-line no-confusing-arrow
+
   getEditorState = () => this.props.editorState;
   getPluginMethods = () => ({
-    getPlugins: () => this.props.plugins.slice(0),
-    getProps: () => ({ ...this.props }),
+    getPlugins: this.getPlugins,
+    getProps: this.getProps,
     setEditorState: this.onChange,
     getEditorState: this.getEditorState,
-    getReadOnly: () => this.props.readOnly,
-    setReadOnly: readOnly => readOnly !== this.state.readOnly ? this.setState({ readOnly }) : undefined, // eslint-disable-line no-confusing-arrow
+    getReadOnly: this.getReadOnly,
+    setReadOnly: this.setReadOnly,
   });
 
   createEventHooks = (methodName, plugins) => (...args) => {


### PR DESCRIPTION
Hey, 
Here are some changes/additions I've created while working on the wysiwyg plugins.

I've removed the block decorator feature, as these will unmount/remount blocks on rerender.

I'm passing all plugin editor properties and methods to plugin methods. I know this has been discussed earlier, I now think this makes sense. Also I'm storing all plugins in this.plugins, which makes them available to plugin methods (for example to check if a certain plugin is available while initializing a plugin).

Also, I've created setReadOnly/getReadOnly to change readOnly through the state. This is crucial for nested editors, as while a nested editor is active the outer editor needs to be set to readOnly=true.
