### PR TITLE
feat(props): Offer a way to customize the link component props

### DIFF
--- a/draft-js-linkify-plugin/src/index.js
+++ b/draft-js-linkify-plugin/src/index.js
@@ -14,13 +14,17 @@ const linkPlugin = (config = {}) => {
   // styles which needs a deep dive into the code. Merging also makes it prone to
   // errors when upgrading as basically every styling change would become a major
   // breaking change. 1px of an increased padding can break a whole layout.
-  const theme = config.theme ? config.theme : defaultTheme;
-  const target = config.target ? config.target : '_self';
+  const {
+    theme = defaultTheme,
+    target = '_self',
+    linkProps = {},
+  } = config;
+
   return {
     decorators: [
       {
         strategy: linkStrategy,
-        component: decorateComponentWithProps(Link, { theme, target }),
+        component: decorateComponentWithProps(Link, { theme, target, ...linkProps }),
       },
     ],
   };


### PR DESCRIPTION
The linkify plugins configuration now offers a way to specify custom
props to be passed down to the Link component. This way, one can
override the appearance with inline styles, setup event handlers or
whatever.

I kept the target configuration out of the linkProps to keep the current
API working.

Let me know if that's okay for you, and I'll make the same changes to
every plugins.

Closes #269