### PR TITLE
[wysiwyg:toolbar] keep tooltip visible within window

### DIFF
--- a/draft-js-toolbar-plugin/src/utils/portal.js
+++ b/draft-js-toolbar-plugin/src/utils/portal.js
@@ -39,21 +39,19 @@ class Tooltip extends Component {
       const refRect = ref.getBoundingClientRect();
       const scrollY = window.scrollY ? window.scrollY : window.pageYOffset;
       const scrollX = window.scrollX ? window.scrollX : window.pageXOffset;
-      const leftForVerticalCenter = left - (refRect.width / 2) + (width / 2) + scrollX; 
+      const leftForVerticalCenter = left - (refRect.width / 2) + (width / 2) + scrollX;
       // if tooltip overflow to window left(leftForVerticalCenter < 0),
       // some parts of it become invisible,
       // just simply set `state.left = 0` here
-      const actualLeft = typeof forceLeft === 'number' ? forceLeft :
-        leftForVerticalCenter > 0 ? leftForVerticalCenter : 0;
-      const actualTop = top - (position === 'left' ? 0 : refRect.height) + scrollY;
+      const adjustedLeft = leftForVerticalCenter > 0 ? leftForVerticalCenter : 0;
 
       // Skip next componentDidUpdate
       this._skip = true;
 
       // Set state
       this.setState({ // eslint-disable-line react/no-did-mount-set-state
-        top: actualTop,
-        left: actualLeft,
+        top: top - (position === 'left' ? 0 : refRect.height) + scrollY,
+        left: typeof forceLeft === 'number' ? forceLeft : adjustedLeft,
         width,
       });
     }

--- a/draft-js-toolbar-plugin/src/utils/portal.js
+++ b/draft-js-toolbar-plugin/src/utils/portal.js
@@ -39,14 +39,23 @@ class Tooltip extends Component {
       const refRect = ref.getBoundingClientRect();
       const scrollY = window.scrollY ? window.scrollY : window.pageYOffset;
       const scrollX = window.scrollX ? window.scrollX : window.pageXOffset;
+      const leftForVerticalCenter = left - (refRect.width / 2) + (width / 2) + scrollX; 
+      // if tooltip overflow to window left(leftForVerticalCenter < 0),
+      // some parts of it become invisible, just simply set `state.left = 0`
+      // ____________________        _______
+      //|______tooltip_______|      |_______|
+      //  |___selecttion___|     => |___| 
+      const actualLeft = typeof forceLeft === 'number' ? forceLeft :
+        leftForVerticalCenter > 0 ? leftForVerticalCenter : 0;
+      const actualTop = top - (position === 'left' ? 0 : refRect.height) + scrollY;
 
       // Skip next componentDidUpdate
       this._skip = true;
 
       // Set state
       this.setState({ // eslint-disable-line react/no-did-mount-set-state
-        top: top - (position === 'left' ? 0 : refRect.height) + scrollY,
-        left: forceLeft || (left - (refRect.width / 2) + (width / 2) + scrollX),
+        top: actualTop,
+        left: actualLeft,
         width,
       });
     }

--- a/draft-js-toolbar-plugin/src/utils/portal.js
+++ b/draft-js-toolbar-plugin/src/utils/portal.js
@@ -41,10 +41,8 @@ class Tooltip extends Component {
       const scrollX = window.scrollX ? window.scrollX : window.pageXOffset;
       const leftForVerticalCenter = left - (refRect.width / 2) + (width / 2) + scrollX; 
       // if tooltip overflow to window left(leftForVerticalCenter < 0),
-      // some parts of it become invisible, just simply set `state.left = 0`
-      // ____________________        _______
-      //|______tooltip_______|      |_______|
-      //  |___selecttion___|     => |___| 
+      // some parts of it become invisible,
+      // just simply set `state.left = 0` here
       const actualLeft = typeof forceLeft === 'number' ? forceLeft :
         leftForVerticalCenter > 0 ? leftForVerticalCenter : 0;
       const actualTop = top - (position === 'left' ? 0 : refRect.height) + scrollY;


### PR DESCRIPTION
when tooltip get too wide for vertical-align to the target, it would overflow to the left of window, some parts of it become invisible. this patch sets state.left = 0
![qq20160524-2 2x](https://cloud.githubusercontent.com/assets/6291986/15495468/b7587130-21c2-11e6-9528-45a25d4d65fe.png)
