### PR TITLE
Fix emoji background styles.

### DIFF
--- a/draft-js-emoji-plugin/src/emojiStyles.css
+++ b/draft-js-emoji-plugin/src/emojiStyles.css
@@ -1,13 +1,15 @@
 .emoji {
+  background-position: center;
   /* make sure the background the image is only shown once */
   background-repeat: no-repeat;
+  background-size: contain;
   /* move it a bit further down to align it nicer with the text */
   vertical-align: middle;
 
   /*
   We need to limit the emoji width because it can be multiple characters
   long if it is a 32bit unicode. Since the proper width depends on the font and
-  it's relationship between 0 and other characters it's not ideal. 1.85ch is not
+  it's relationship between 0 and other characters it's not ideal. 1.95ch is not
   the best value, but hopefully a good enough approximation for most fonts.
   */
   display: inline-block;


### PR DESCRIPTION
I'm seeing mispositioned emojis in my projects and in the [draft-js-plugins](https://www.draft-js-plugins.com/) example editor as of an hour ago.

Notice the oversized, askew *(nerd)* and *(tada)* emojis.
![](https://s3.amazonaws.com/f.cl.ly/items/3A1T1i0Z2e473O2R1X2K/Screen%20Shot%202016-06-01%20at%208.10.24%20PM.png?v=680fcc50)

I can repro in chrome and firefox - safari isn't polyfilled, errs out, and just renders the unicode character - and some slack peeps were able to repro as well.

I couldn't find any glaring, recent change that would have caused this but haven't had much time to look 😋 

My solution here is just to *center* and *contain* the emoji background images.

I'll follow up with `changelog` changes if this is indeed valid and useful :)