### PR TITLE
Add `background-size` to emoji

### DIFF
--- a/draft-js-emoji-plugin/src/emojiStyles.css
+++ b/draft-js-emoji-plugin/src/emojiStyles.css
@@ -19,6 +19,11 @@
   */
   max-height: 1em;
   line-height: inherit;
+  
+  /*
+  For making the emoji in the right size
+  */
+  background-size: 100%;
 }
 
 .emojiCharacter {


### PR DESCRIPTION
some emojis get cut in the editor..

![image](https://cloud.githubusercontent.com/assets/2054772/15771537/295c4e1a-2974-11e6-8c3c-2d62197db625.png)

this is fixed with `background-size: 100%`:

![image](https://cloud.githubusercontent.com/assets/2054772/15771567/5016d9a8-2974-11e6-9b41-096da5c6d2b8.png)

this should fix #293 