### PR TITLE
Add groups to MentionSuggestion popup

### DIFF
--- a/docs/client/components/pages/Mention/SimpleMentionEditor/index.js
+++ b/docs/client/components/pages/Mention/SimpleMentionEditor/index.js
@@ -44,6 +44,10 @@ export default class SimpleMentionEditor extends Component {
         <MentionSuggestions
           onSearchChange={ this.onSearchChange }
           suggestions={ this.state.suggestions }
+          groupTitles={{
+            engineering: 'Engineering',
+            marketing: 'Marketing',
+          }}
         />
       </div>
     );

--- a/docs/client/components/pages/Mention/SimpleMentionEditor/mentions.js
+++ b/docs/client/components/pages/Mention/SimpleMentionEditor/mentions.js
@@ -5,16 +5,25 @@ const mentions = fromJS([
     name: 'Matthew Russell',
     link: 'https://twitter.com/mrussell247',
     avatar: 'https://pbs.twimg.com/profile_images/517863945/mattsailing_400x400.jpg',
+    type: 'engineering',
   },
   {
     name: 'Julian Krispel-Samsel',
     link: 'https://twitter.com/juliandoesstuff',
     avatar: 'https://pbs.twimg.com/profile_images/477132877763579904/m5bFc8LF_400x400.png',
+    type: 'engineering',
   },
   {
     name: 'Jyoti Puri',
     link: 'https://twitter.com/jyopur',
     avatar: 'https://pbs.twimg.com/profile_images/705714058939359233/IaJoIa78_400x400.jpg',
+    type: 'engineering',
+  },
+  {
+    name: 'Nik Graf',
+    link: 'https://twitter.com/nikgraf',
+    avatar: 'https://pbs.twimg.com/profile_images/535634005769457664/Ppl32NaN_400x400.jpeg',
+    type: 'marketing',
   },
   {
     name: 'Max Stoiber',
@@ -22,14 +31,10 @@ const mentions = fromJS([
     avatar: 'https://pbs.twimg.com/profile_images/681114454029942784/PwhopfmU_400x400.jpg',
   },
   {
-    name: 'Nik Graf',
-    link: 'https://twitter.com/nikgraf',
-    avatar: 'https://pbs.twimg.com/profile_images/535634005769457664/Ppl32NaN_400x400.jpeg',
-  },
-  {
     name: 'Pascal Brandt',
     link: 'https://twitter.com/psbrandt',
     avatar: 'https://pbs.twimg.com/profile_images/688487813025640448/E6O6I011_400x400.png',
+    type: 'marketing',
   },
 ]);
 

--- a/draft-js-mention-plugin/src/MentionSuggestions/index.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/index.js
@@ -5,6 +5,7 @@ import addMention from '../modifiers/addMention';
 import decodeOffsetKey from '../utils/decodeOffsetKey';
 import { genKey } from 'draft-js';
 import getSearchText from '../utils/getSearchText';
+import Immutable from 'immutable';
 
 export default class MentionSuggestions extends Component {
 
@@ -261,6 +262,19 @@ export default class MentionSuggestions extends Component {
     }
 
     const { theme = {} } = this.props;
+    const groups = this.props.suggestions.reduce((data, value) => {
+      const type = value.get('type') || 'other';
+      let items = data.get(type);
+      if (!items) {
+        items = Immutable.OrderedSet();
+      }
+      items = items.add(value);
+      return data.set(type, items);
+    }, Immutable.OrderedMap());
+
+    const groupTitles = Object.assign({ other: 'Other' }, this.props.groupTitles);
+    let mentionIndex = 0;
+    let groupIndex = 0;
     return (
       <div
         {...this.props}
@@ -269,20 +283,29 @@ export default class MentionSuggestions extends Component {
         id={ `mentions-list-${this.key}` }
         ref="popover"
       >
-        {
-          this.props.suggestions.map((mention, index) => (
-            <Entry
-              key={ mention.get('name') }
-              onMentionSelect={ this.onMentionSelect }
-              onMentionFocus={ this.onMentionFocus }
-              isFocused={ this.state.focusedOptionIndex === index }
-              mention={ mention }
-              index={ index }
-              id={ `mention-option-${this.key}-${index}` }
-              theme={ theme }
-            />
-          )).toJS()
-        }
+      {
+        groups.map((group, key) => (
+          <div key={key}>
+            {groups.size > 1 &&
+              <div className={ theme.mentionSuggestionsHeading + (groupIndex++ === 0 ? ' first' : '') }>
+                {groupTitles[key] || key}
+              </div>}
+            {group.map(mention => {
+              const index = mentionIndex++;
+              return (<Entry
+                key={ mention.get('name') }
+                onMentionSelect={ this.onMentionSelect }
+                onMentionFocus={ this.onMentionFocus }
+                isFocused={ this.state.focusedOptionIndex === index }
+                mention={ mention }
+                index={ index }
+                id={ `mention-option-${this.key}-${index}` }
+                theme={ theme }
+              />);
+            }).toJS()}
+          </div>
+        )).toArray()
+      }
       </div>
     );
   }

--- a/draft-js-mention-plugin/src/index.js
+++ b/draft-js-mention-plugin/src/index.js
@@ -16,6 +16,7 @@ const createMentionPlugin = (config = {}) => {
     mention: mentionStyles.mention,
 
     mentionSuggestions: mentionSuggestionsStyles.mentionSuggestions,
+    mentionSuggestionsHeading: mentionSuggestionsStyles.mentionSuggestionsHeading,
 
     mentionSuggestionsEntry: mentionSuggestionsEntryStyles.mentionSuggestionsEntry,
     mentionSuggestionsEntryFocused: mentionSuggestionsEntryStyles.mentionSuggestionsEntryFocused,

--- a/draft-js-mention-plugin/src/mentionSuggestionsStyles.css
+++ b/draft-js-mention-plugin/src/mentionSuggestionsStyles.css
@@ -16,3 +16,13 @@
   box-sizing: border-box;
   transform: scale(0);
 }
+
+.mentionSuggestionsHeading:global(.first) {
+  margin-top: -8px;
+}
+.mentionSuggestionsHeading {
+  padding: 5px 10px;
+  background: #fafafa;
+  border-top: 1px solid #efefef;
+  border-bottom: 1px solid #efefef;
+}


### PR DESCRIPTION
Ive added the ability to add a 'type' field to the suggestions. 
- Types are split into groups in the popup
- groups are not shown when there is only one
- items without a type fall into an 'other' group

I tried to keep it simple by not creating a Group component and working directly in the MentionSuggestions. I could look to refactoring it into 'Groups' if you like. 

It might be nice to have the 'other' group always show up last

It should hopefully work as before when no 'types' are set 

All style, refactoring changes welcome, It's a pretty quick pass
