### PR TITLE
fix mentions positionSuggestions to work with non-static parents

### DIFF
--- a/draft-js-mention-plugin/src/MentionSuggestions/index.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/index.js
@@ -49,6 +49,7 @@ export default class MentionSuggestions extends Component {
         decoratorRect,
         prevProps,
         prevState,
+        popover: this.refs.popover,
         props: this.props,
         state: this.state,
       });


### PR DESCRIPTION
This PR fixes mentions' `positionSuggestions` function to work with non-static parents, related to #283 #206 #289.

Note: it introduces a "regression" on screens smaller than 480px. There's used to have a condition that would align the popover to the left in such circumstances. The "universal" implementation would be more complex as it'd need to look for the relative parent's position in the viewport plus some other stuff. I wasn't sure if it's something that should be part of the default implementation. It's probably going to be a requirement for us though, so I'll add it anyway.