### PR TITLE
adding mentionTrigger 

### DIFF
--- a/draft-js-mention-plugin/src/MentionSuggestions/index.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/index.js
@@ -7,7 +7,6 @@ import { genKey } from 'draft-js';
 import getSearchText from '../utils/getSearchText';
 
 export default class MentionSuggestions extends Component {
-
   static propTypes = {
     entityMutability: PropTypes.oneOf([
       'SEGMENTED',
@@ -192,6 +191,7 @@ export default class MentionSuggestions extends Component {
     const newEditorState = addMention(
       this.props.store.getEditorState(),
       mention,
+      this.props.mentionTrigger,
       this.props.entityMutability,
     );
     this.props.store.setEditorState(newEditorState);

--- a/draft-js-mention-plugin/src/index.js
+++ b/draft-js-mention-plugin/src/index.js
@@ -13,8 +13,11 @@ import defaultPositionSuggestions from './utils/positionSuggestions';
 
 const createMentionPlugin = (config = {}) => {
   const defaultTheme = {
+    // CSS class for mention text
     mention: mentionStyles.mention,
+    // CSS class for suggestions component
     mentionSuggestions: mentionSuggestionsStyles.mentionSuggestions,
+    // CSS classes for an entry in the suggestions component
     mentionSuggestionsEntry: mentionSuggestionsEntryStyles.mentionSuggestionsEntry,
     mentionSuggestionsEntryFocused: mentionSuggestionsEntryStyles.mentionSuggestionsEntryFocused,
     mentionSuggestionsEntryText: mentionSuggestionsEntryStyles.mentionSuggestionsEntryText,

--- a/draft-js-mention-plugin/src/index.js
+++ b/draft-js-mention-plugin/src/index.js
@@ -14,9 +14,7 @@ import defaultPositionSuggestions from './utils/positionSuggestions';
 const createMentionPlugin = (config = {}) => {
   const defaultTheme = {
     mention: mentionStyles.mention,
-
     mentionSuggestions: mentionSuggestionsStyles.mentionSuggestions,
-
     mentionSuggestionsEntry: mentionSuggestionsEntryStyles.mentionSuggestionsEntry,
     mentionSuggestionsEntryFocused: mentionSuggestionsEntryStyles.mentionSuggestionsEntryFocused,
     mentionSuggestionsEntryText: mentionSuggestionsEntryStyles.mentionSuggestionsEntryText,
@@ -92,12 +90,13 @@ const createMentionPlugin = (config = {}) => {
     store,
     entityMutability: config.entityMutability ? config.entityMutability : 'SEGMENTED',
     positionSuggestions,
+    mentionTrigger,
   };
   return {
     MentionSuggestions: decorateComponentWithProps(MentionSuggestions, mentionSearchProps),
     decorators: [
       {
-        strategy: mentionStrategy,
+        strategy: mentionStrategy(mentionTrigger),
         component: decorateComponentWithProps(Mention, { theme, mentionPrefix }),
       },
       {

--- a/draft-js-mention-plugin/src/index.js
+++ b/draft-js-mention-plugin/src/index.js
@@ -83,6 +83,7 @@ const createMentionPlugin = (config = {}) => {
     mentionPrefix = '',
     theme = defaultTheme,
     positionSuggestions = defaultPositionSuggestions,
+    mentionTrigger = '@'
   } = config;
   const mentionSearchProps = {
     ariaProps,
@@ -100,7 +101,7 @@ const createMentionPlugin = (config = {}) => {
         component: decorateComponentWithProps(Mention, { theme, mentionPrefix }),
       },
       {
-        strategy: mentionSuggestionsStrategy,
+        strategy: mentionSuggestionsStrategy(mentionTrigger),
         component: decorateComponentWithProps(MentionSuggestionsPortal, { store }),
       },
     ],

--- a/draft-js-mention-plugin/src/index.js
+++ b/draft-js-mention-plugin/src/index.js
@@ -81,7 +81,7 @@ const createMentionPlugin = (config = {}) => {
     mentionPrefix = '',
     theme = defaultTheme,
     positionSuggestions = defaultPositionSuggestions,
-    mentionTrigger = '@'
+    mentionTrigger = '@',
   } = config;
   const mentionSearchProps = {
     ariaProps,

--- a/draft-js-mention-plugin/src/mentionStrategy.js
+++ b/draft-js-mention-plugin/src/mentionStrategy.js
@@ -1,12 +1,20 @@
 import { Entity } from 'draft-js';
 
-const findMention = (character) => {
-  const entityKey = character.getEntity();
-  return (entityKey !== null && Entity.get(entityKey).getType() === 'mention');
-};
+const findMention = (trigger) => {
+  trigger = trigger || '@';
 
-const findMentionEntities = (contentBlock, callback) => {
-  contentBlock.findEntityRanges(findMention, callback);
+  return (character) => {
+    const entityKey = character.getEntity();
+    return (entityKey !== null && Entity.get(entityKey).getType() === 'mention-' + trigger);
+  }
+}
+
+const findMentionEntities = (trigger) => {
+  trigger = trigger || '@';
+
+  return (contentBlock, callback) => {
+    contentBlock.findEntityRanges(findMention(trigger), callback)
+  }
 };
 
 export default findMentionEntities;

--- a/draft-js-mention-plugin/src/mentionStrategy.js
+++ b/draft-js-mention-plugin/src/mentionStrategy.js
@@ -1,16 +1,12 @@
 import { Entity } from 'draft-js';
 
-const findMention = (trigger) => {
-  return (character) => {
-    const entityKey = character.getEntity();
-    return (entityKey !== null && Entity.get(entityKey).getType() === `mention-${trigger}`);
-  };
+const findMention = (trigger) => (character) => {
+  const entityKey = character.getEntity();
+  return (entityKey !== null && Entity.get(entityKey).getType() === `mention-${trigger}`);
 };
 
-const findMentionEntities = (trigger) => {
-  return (contentBlock, callback) => {
-    contentBlock.findEntityRanges(findMention(trigger), callback);
-  };
+const findMentionEntities = (trigger) => (contentBlock, callback) => {
+  contentBlock.findEntityRanges(findMention(trigger), callback);
 };
 
 export default findMentionEntities;

--- a/draft-js-mention-plugin/src/mentionStrategy.js
+++ b/draft-js-mention-plugin/src/mentionStrategy.js
@@ -1,20 +1,16 @@
 import { Entity } from 'draft-js';
 
 const findMention = (trigger) => {
-  trigger = trigger || '@';
-
   return (character) => {
     const entityKey = character.getEntity();
-    return (entityKey !== null && Entity.get(entityKey).getType() === 'mention-' + trigger);
-  }
-}
+    return (entityKey !== null && Entity.get(entityKey).getType() === `mention-${trigger}`);
+  };
+};
 
 const findMentionEntities = (trigger) => {
-  trigger = trigger || '@';
-
   return (contentBlock, callback) => {
-    contentBlock.findEntityRanges(findMention(trigger), callback)
-  }
+    contentBlock.findEntityRanges(findMention(trigger), callback);
+  };
 };
 
 export default findMentionEntities;

--- a/draft-js-mention-plugin/src/mentionSuggestionsStrategy.js
+++ b/draft-js-mention-plugin/src/mentionSuggestionsStrategy.js
@@ -1,9 +1,14 @@
 /* @flow */
 
 import findWithRegex from 'find-with-regex';
+import _ from 'lodash';
 
-const MENTION_REGEX = /(\s|^)@[\w]*/g;
+export default (trigger) => {
+  if (trigger.length === 0) {
+    trigger = '@';
+  }
 
-export default (contentBlock: Object, callback: Function) => {
-  findWithRegex(MENTION_REGEX, contentBlock, callback);
-};
+  return (contentBlock: Object, callback: Function) => {
+    findWithRegex(new RegExp('(\\s|^)' + _.escapeRegExp(trigger) + '[\\w]*', 'g'), contentBlock, callback);
+  };
+}

--- a/draft-js-mention-plugin/src/mentionSuggestionsStrategy.js
+++ b/draft-js-mention-plugin/src/mentionSuggestionsStrategy.js
@@ -3,8 +3,6 @@
 import findWithRegex from 'find-with-regex';
 import _ from 'lodash';
 
-export default (trigger) => {
-  return (contentBlock: Object, callback: Function) => {
-    findWithRegex(new RegExp(`(\\s|^)${_.escapeRegExp(trigger)}[\\w]*`, 'g'), contentBlock, callback);
-  };
+export default (trigger: String) => (contentBlock: Object, callback: Function) => {
+  findWithRegex(new RegExp(`(\\s|^)${_.escapeRegExp(trigger)}[\\w]*`, 'g'), contentBlock, callback);
 };

--- a/draft-js-mention-plugin/src/mentionSuggestionsStrategy.js
+++ b/draft-js-mention-plugin/src/mentionSuggestionsStrategy.js
@@ -4,9 +4,7 @@ import findWithRegex from 'find-with-regex';
 import _ from 'lodash';
 
 export default (trigger) => {
-  if (trigger.length === 0) {
-    trigger = '@';
-  }
+  trigger = trigger || '@';
 
   return (contentBlock: Object, callback: Function) => {
     findWithRegex(new RegExp('(\\s|^)' + _.escapeRegExp(trigger) + '[\\w]*', 'g'), contentBlock, callback);

--- a/draft-js-mention-plugin/src/mentionSuggestionsStrategy.js
+++ b/draft-js-mention-plugin/src/mentionSuggestionsStrategy.js
@@ -4,9 +4,7 @@ import findWithRegex from 'find-with-regex';
 import _ from 'lodash';
 
 export default (trigger) => {
-  trigger = trigger || '@';
-
   return (contentBlock: Object, callback: Function) => {
-    findWithRegex(new RegExp('(\\s|^)' + _.escapeRegExp(trigger) + '[\\w]*', 'g'), contentBlock, callback);
+    findWithRegex(new RegExp(`(\\s|^)${_.escapeRegExp(trigger)}[\\w]*`, 'g'), contentBlock, callback);
   };
-}
+};

--- a/draft-js-mention-plugin/src/modifiers/addMention.js
+++ b/draft-js-mention-plugin/src/modifiers/addMention.js
@@ -2,7 +2,7 @@ import { Modifier, EditorState, Entity } from 'draft-js';
 import getSearchText from '../utils/getSearchText';
 
 const addMention = (editorState, mention, mentionTrigger, entityMutability) => {
-  const entityKey = Entity.create('mention-' + mentionTrigger, entityMutability, { mention });
+  const entityKey = Entity.create(`mention-${mentionTrigger}`, entityMutability, { mention });
 
   const currentSelectionState = editorState.getSelection();
   const { begin, end } = getSearchText(editorState, currentSelectionState);

--- a/draft-js-mention-plugin/src/modifiers/addMention.js
+++ b/draft-js-mention-plugin/src/modifiers/addMention.js
@@ -1,8 +1,8 @@
 import { Modifier, EditorState, Entity } from 'draft-js';
 import getSearchText from '../utils/getSearchText';
 
-const addMention = (editorState, mention, entityMutability) => {
-  const entityKey = Entity.create('mention', entityMutability, { mention });
+const addMention = (editorState, mention, mentionTrigger, entityMutability) => {
+  const entityKey = Entity.create('mention-' + mentionTrigger, entityMutability, { mention });
 
   const currentSelectionState = editorState.getSelection();
   const { begin, end } = getSearchText(editorState, currentSelectionState);


### PR DESCRIPTION
Addresses https://github.com/draft-js-plugins/draft-js-plugins/issues/253#issuecomment-227144837.

Adds `mentionTrigger` to `config` with default value of `@`.
Adds and searches for mention entities with key of `'mention' + mentionTrigger`
`mentionStrategy` and `mentionSuggestionsStrategy` takes the trigger as a parameter.

Feedback welcome