### PR TITLE
Max out zIndex on portal.js

### DIFF
--- a/draft-js-toolbar-plugin/src/utils/portal.js
+++ b/draft-js-toolbar-plugin/src/utils/portal.js
@@ -81,7 +81,7 @@ class Tooltip extends Component {
     // Style
     const style = {
       transition: animations ? 'all .3s ease-in-out, visibility .3s ease-in-out' : '',
-      zIndex: 100,
+      zIndex: 9999,
       position: 'absolute',
       left,
       top,


### PR DESCRIPTION
With only 100, the toolbar sometimes stays under other fixed elements like modal window dimmers and such.