### PR TITLE
Let mentions render with plain JS Object

### DIFF
--- a/draft-js-mention-plugin/src/Mention/__test__/index.js
+++ b/draft-js-mention-plugin/src/Mention/__test__/index.js
@@ -21,4 +21,11 @@ describe('Mention', () => {
     const result = render(<Mention entityKey={ entityKey } theme={ Map() } />);
     expect(result).to.have.tagName('span');
   });
+
+  it('can render when mention is an Object', () => {
+    const mention = {};
+    const entityKey = Entity.create('mention', 'SEGMENTED', { mention });
+    const result = render(<Mention entityKey={ entityKey } theme={ Map() } />);
+    expect(result).to.have.tagName('span');
+  });
 });

--- a/draft-js-mention-plugin/src/Mention/index.js
+++ b/draft-js-mention-plugin/src/Mention/index.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import { Entity } from 'draft-js';
+import { fromJS } from 'immutable';
 
 const Mention = (props) => {
   const { entityKey, theme = {} } = props;
-  const { mention } = Entity.get(entityKey).getData();
+  const mention = fromJS(Entity.get(entityKey).getData().mention);
 
   if (mention.has('link')) {
     return (


### PR DESCRIPTION
When you try to use an `editorState` that was converted from a
`RawDraftContentState`, the assumption that a mention is a `Map` does not
hold.

````js
const contentState = convertFromRaw(instanceOfRawDraftContentState);
const editorState = EditorState.createWithContent(contentState);
this.state = {
  editorState: editorState,
}
````

I assume that calling `fromJS` on something that is already a `Map` is a no-op.
Which seems to be the case: https://github.com/facebook/immutable-js/blob/38019326a8d006a45ef48d9c4644e23ea476d298/src/fromJS.js#L28-L36