### PR TITLE
Add a way to provide a custom component for the suggestions' entry

### DIFF
--- a/docs/client/components/pages/Mention/CustomMentionEditor/index.js
+++ b/docs/client/components/pages/Mention/CustomMentionEditor/index.js
@@ -34,6 +34,34 @@ const mentionPlugin = createMentionPlugin({
 const { MentionSuggestions } = mentionPlugin;
 const plugins = [mentionPlugin];
 
+const Entry = (props) => {
+  const { mention, theme, ...parentProps } = props;
+
+  return (
+    <div {...parentProps}>
+      <div className={theme.mentionSuggestionsEntryContainer}>
+        <div className={theme.mentionSuggestionsEntryContainerLeft}>
+          <img
+            src={mention.get('avatar')}
+            className={theme.mentionSuggestionsEntryAvatar}
+            role="presentation"
+          />
+        </div>
+
+        <div className={theme.mentionSuggestionsEntryContainerRight}>
+          <div className={theme.mentionSuggestionsEntryText}>
+            {mention.get('name')}
+          </div>
+
+          <div className={theme.mentionSuggestionsEntryTitle}>
+            {mention.get('title')}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
 export default class CustomMentionEditor extends Component {
 
   state = {
@@ -69,6 +97,7 @@ export default class CustomMentionEditor extends Component {
         <MentionSuggestions
           onSearchChange={this.onSearchChange}
           suggestions={this.state.suggestions}
+          entryComponent={Entry}
         />
       </div>
     );

--- a/docs/client/components/pages/Mention/CustomMentionEditor/mentions.js
+++ b/docs/client/components/pages/Mention/CustomMentionEditor/mentions.js
@@ -3,26 +3,32 @@ import { fromJS } from 'immutable';
 const mentions = fromJS([
   {
     name: 'matthew',
+    title: 'Senior Software Engineer',
     avatar: 'https://pbs.twimg.com/profile_images/517863945/mattsailing_400x400.jpg',
   },
   {
     name: 'julian',
+    title: 'United Kingdom',
     avatar: 'https://pbs.twimg.com/profile_images/477132877763579904/m5bFc8LF_400x400.png',
   },
   {
     name: 'jyoti',
+    title: 'New Delhi, India',
     avatar: 'https://pbs.twimg.com/profile_images/705714058939359233/IaJoIa78_400x400.jpg',
   },
   {
     name: 'max',
+    title: 'Travels around the world, brews coffee, skis mountains and makes stuff on the web.',
     avatar: 'https://pbs.twimg.com/profile_images/681114454029942784/PwhopfmU_400x400.jpg',
   },
   {
     name: 'nik',
+    title: 'Passionate about Software Architecture, UX, Skiing & Triathlons',
     avatar: 'https://pbs.twimg.com/profile_images/535634005769457664/Ppl32NaN_400x400.jpeg',
   },
   {
     name: 'pascal',
+    title: 'HeathIT hacker and researcher',
     avatar: 'https://pbs.twimg.com/profile_images/688487813025640448/E6O6I011_400x400.png',
   },
 ]);

--- a/docs/client/components/pages/Mention/CustomMentionEditor/mentionsStyles.css
+++ b/docs/client/components/pages/Mention/CustomMentionEditor/mentionsStyles.css
@@ -18,6 +18,22 @@
   margin: -16px;
 }
 
+.mentionSuggestionsEntryContainer {
+  display: table;
+  width: 100%;
+}
+
+.mentionSuggestionsEntryContainerLeft,
+.mentionSuggestionsEntryContainerRight {
+  display: table-cell;
+  vertical-align: middle;
+}
+
+.mentionSuggestionsEntryContainerRight {
+  width: 100%;
+  padding-left: 8px;
+}
+
 .mentionSuggestionsEntry {
   padding: 7px 10px 3px 10px;
   transition: background-color 0.4s cubic-bezier(.27,1.27,.48,.56);
@@ -32,17 +48,24 @@
   background-color: #e6f3ff;
 }
 
-.mentionSuggestionsEntryText {
-  display: inline-block;
-  margin-left: 8px;
+.mentionSuggestionsEntryText,
+.mentionSuggestionsEntryTitle {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
+.mentionSuggestionsEntryText {
+}
+
+.mentionSuggestionsEntryTitle {
+  font-size: 80%;
+  color: #a7a7a7;
+}
+
 .mentionSuggestionsEntryAvatar {
-  display: inline-block;
-  width: 24px;
-  height: 24px;
-  border-radius: 12px;
+  display: block;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
 }

--- a/docs/client/components/pages/Mention/index.js
+++ b/docs/client/components/pages/Mention/index.js
@@ -149,6 +149,10 @@ export default class App extends Component {
               <span className={styles.paramName}>onClose</span>
               <span>A callback which is triggered whenever the suggestions popover closes.</span>
             </div>
+            <div className={styles.param}>
+              <span className={styles.paramName}>entryComponent</span>
+              <span>Component to be used as the template for each of the suggestions' entry.</span>
+            </div>
           </div>
           <Heading level={3}>Additional Exports</Heading>
           <div>

--- a/draft-js-mention-plugin/src/MentionSuggestions/Entry/defaultEntryComponent.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/Entry/defaultEntryComponent.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import Avatar from './Avatar';
+
+const defaultEntryComponent = (props) => {
+  const { mention, theme, ...parentProps } = props;
+
+  return (
+    <div {...parentProps}>
+      <Avatar mention={mention} theme={theme} />
+      <span className={theme.mentionSuggestionsEntryText}>{mention.get('name')}</span>
+    </div>
+  );
+};
+
+export default defaultEntryComponent;

--- a/draft-js-mention-plugin/src/MentionSuggestions/Entry/index.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/Entry/index.js
@@ -1,9 +1,13 @@
 import React, {
   Component,
+  PropTypes,
 } from 'react';
-import Avatar from './Avatar';
 
 export default class Entry extends Component {
+
+  static propTypes = {
+    entryComponent: PropTypes.func.isRequired,
+  };
 
   constructor(props) {
     super(props);
@@ -35,17 +39,17 @@ export default class Entry extends Component {
   render() {
     const { theme = {} } = this.props;
     const className = this.props.isFocused ? theme.mentionSuggestionsEntryFocused : theme.mentionSuggestionsEntry;
+    const EntryComponent = this.props.entryComponent;
     return (
-      <div
+      <EntryComponent
         className={className}
         onMouseDown={this.onMouseDown}
         onMouseUp={this.onMouseUp}
         onMouseEnter={this.onMouseEnter}
         role="option"
-      >
-        <Avatar mention={this.props.mention} theme={theme} />
-        <span className={theme.mentionSuggestionsEntryText}>{this.props.mention.get('name')}</span>
-      </div>
+        theme={theme}
+        mention={this.props.mention}
+      />
     );
   }
 }

--- a/draft-js-mention-plugin/src/MentionSuggestions/index.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/index.js
@@ -5,6 +5,7 @@ import addMention from '../modifiers/addMention';
 import decodeOffsetKey from '../utils/decodeOffsetKey';
 import { genKey } from 'draft-js';
 import getSearchText from '../utils/getSearchText';
+import defaultEntryComponent from './Entry/defaultEntryComponent';
 
 export default class MentionSuggestions extends Component {
 
@@ -14,6 +15,11 @@ export default class MentionSuggestions extends Component {
       'IMMUTABLE',
       'MUTABLE',
     ]),
+    entryComponent: PropTypes.func,
+  };
+
+  static defaultProps = {
+    entryComponent: defaultEntryComponent,
   };
 
   state = {
@@ -265,9 +271,11 @@ export default class MentionSuggestions extends Component {
     }
 
     const { theme = {} } = this.props;
+    const { entryComponent, ...props } = this.props;
+
     return (
       <div
-        {...this.props}
+        {...props}
         className={theme.mentionSuggestions}
         role="listbox"
         id={`mentions-list-${this.key}`}
@@ -284,6 +292,7 @@ export default class MentionSuggestions extends Component {
               index={index}
               id={`mention-option-${this.key}-${index}`}
               theme={theme}
+              entryComponent={entryComponent}
             />
           )).toJS()
         }


### PR DESCRIPTION
This PR adds a `entryComponent` option to `MentionSuggestions` that provides a way to have a custom template for each suggestions' entry. You can have a look at what it looks like from the documentation (I've updated the custom mention editor example to include an usage example).

![screenshot](http://i.imgur.com/RdxI6KH.png)