### PR TITLE
Make link clickable

### DIFF
--- a/draft-js-mention-plugin/src/Mention/index.js
+++ b/draft-js-mention-plugin/src/Mention/index.js
@@ -9,6 +9,7 @@ const Mention = (props) => {
   if (mention.has('link')) {
     return (
       <a
+        contentEditable: false,
         href={mention.get('link')}
         className={theme.mention}
         spellCheck={false}

--- a/draft-js-mention-plugin/src/Mention/index.js
+++ b/draft-js-mention-plugin/src/Mention/index.js
@@ -9,7 +9,7 @@ const Mention = (props) => {
   if (mention.has('link')) {
     return (
       <a
-        contentEditable: false,
+        contentEditable = {false}
         href={mention.get('link')}
         className={theme.mention}
         spellCheck={false}

--- a/draft-js-mention-plugin/src/Mention/index.js
+++ b/draft-js-mention-plugin/src/Mention/index.js
@@ -9,7 +9,7 @@ const Mention = (props) => {
   if (mention.has('link')) {
     return (
       <a
-        contentEditable = {false}
+        contentEditable={false}
         href={mention.get('link')}
         className={theme.mention}
         spellCheck={false}


### PR DESCRIPTION
Is there a reason for keeping the mention editable?
With it enabled I couldn't click the link.