### PR TITLE
Remote data example doesn't show when just @ is typed

### DIFF
--- a/draft-js-mention-plugin/CHANGELOG.md
+++ b/draft-js-mention-plugin/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Mentions popover showed up when typing before a @ [#323](https://github.com/draft-js-plugins/draft-js-plugins/issues/323) Thanks to @nishp1
+- Remote data example doesn't show when just @ is typed [#351](https://github.com/draft-js-plugins/draft-js-plugins/pull/351) Thanks to @nishp1
 
 ## 1.1.2 - 2016-06-26
 

--- a/draft-js-mention-plugin/src/MentionSuggestions/__test__/index.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/__test__/index.js
@@ -40,21 +40,26 @@ const mentions = fromJS([
 ]);
 
 describe('MentionSuggestions Component', () => {
-  it('Closes when suggestions is empty', () => {
-    const callbacks = {
-      onDownArrow: sinon.spy(),
-      onUpArrow: sinon.spy(),
-      onTab: sinon.spy(),
-      onEscape: sinon.spy(),
-      handleReturn: sinon.spy(),
-    };
-    const store = {
-      getAllSearches: sinon.spy(),
-      getPortalClientRect: sinon.spy(),
-      isEscaped: sinon.spy(),
-      resetEscapedSearch: sinon.spy(),
-      escapeSearch: sinon.spy(),
-    };
+  const mockCallbacks = () => ({
+    onDownArrow: sinon.spy(),
+    onUpArrow: sinon.spy(),
+    onTab: sinon.spy(),
+    onEscape: sinon.spy(),
+    handleReturn: sinon.spy()
+  });
+
+  const mockStore = () => ({
+    getAllSearches: sinon.spy(),
+    getPortalClientRect: sinon.spy(),
+    isEscaped: sinon.spy(),
+    resetEscapedSearch: sinon.spy(),
+    escapeSearch: sinon.spy(),
+    setEditorState: sinon.spy()
+  });
+
+  it('does not closes when suggestions is empty', () => {
+    const callbacks = mockCallbacks();
+    const store = mockStore();
     const ariaProps = {};
     const onSearchChange = sinon.spy();
     const positionSuggestions = sinon.stub().returns({});
@@ -76,6 +81,30 @@ describe('MentionSuggestions Component', () => {
     suggestions.setProps({
       suggestions: fromJS([]),
     });
-    expect(suggestions.state().isActive).to.equal(false);
+    expect(suggestions.state().isActive).to.equal(true);
+  });
+
+  it('closes dropdown on Enter when no mention is selected and does not throw', () => {
+    const callbacks = mockCallbacks();
+    const store = mockStore();
+    const ariaProps = {};
+    const onSearchChange = sinon.spy();
+    const positionSuggestions = sinon.stub().returns({});
+    const suggestions = mount(
+      <MentionSuggestions
+        ariaProps={ariaProps}
+        onSearchChange={onSearchChange}
+        positionSuggestions={positionSuggestions}
+        suggestions={mentions}
+        callbacks={callbacks}
+        store={store}
+        theme={{}}
+      />
+    );
+
+    const closeDropdownSpy = sinon.spy(suggestions.instance(), 'closeDropdown');
+    suggestions.instance().onMentionSelect(null);
+    expect(closeDropdownSpy).to.have.been.calledOnce();
+    expect(store.setEditorState).to.not.have.been.called();
   });
 });

--- a/draft-js-mention-plugin/src/MentionSuggestions/index.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/index.js
@@ -32,12 +32,6 @@ export default class MentionSuggestions extends Component {
     this.props.callbacks.onChange = this.onEditorStateChange;
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.suggestions.size === 0 && this.state.isActive) {
-      this.closeDropdown();
-    }
-  }
-
   componentDidUpdate = (prevProps, prevState) => {
     if (this.refs.popover) {
       // In case the list shrinks there should be still an option focused.
@@ -198,6 +192,10 @@ export default class MentionSuggestions extends Component {
 
   onMentionSelect = (mention) => {
     this.closeDropdown();
+
+    if (!mention) {
+      return;
+    }
     const newEditorState = addMention(
       this.props.store.getEditorState(),
       mention,


### PR DESCRIPTION
onChange when editorState is set, suggestion are not typically loaded and thus are empty, which causes dropdown to close and not show when data actually does arrive from the server.