### PR TITLE
Adds a check to set mouseDown property after component updates

### DIFF
--- a/draft-js-mention-plugin/src/MentionSuggestions/Entry/index.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/Entry/index.js
@@ -15,7 +15,7 @@ export default class Entry extends Component {
   }
 
   componentDidUpdate() {
-    this.mouseDown = this.mouseDown || false;
+    this.mouseDown = this.mouseDown || false;
   }
 
   onMouseUp = () => {

--- a/draft-js-mention-plugin/src/MentionSuggestions/Entry/index.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/Entry/index.js
@@ -15,7 +15,7 @@ export default class Entry extends Component {
   }
 
   componentDidUpdate() {
-    this.mouseDown = false;
+    this.mouseDown = this.mouseDown || false;
   }
 
   onMouseUp = () => {


### PR DESCRIPTION
I could not get the plugin to work properly when clicking on an item. After reviewing the code I found the mouseDown property was always set to false even though my "mouse was down". With this check, clicking on an item works as expected.