### PR TITLE
Fix module not resolving for lodash escapeRegExp, causing linting error

### DIFF
--- a/draft-js-mention-plugin/package.json
+++ b/draft-js-mention-plugin/package.json
@@ -32,11 +32,12 @@
   "license": "MIT",
   "dependencies": {
     "decorate-component-with-props": "^1.0.2",
-    "find-with-regex": "^1.0.2",
-    "union-class-names": "^1.0.0",
     "draft-js": ">=0.7.0",
+    "find-with-regex": "^1.0.2",
     "immutable": ">=3.8.1",
+    "lodash": "^4.14.1",
     "react": ">=15.1.0",
-    "react-dom": ">=15.1.0"
+    "react-dom": ">=15.1.0",
+    "union-class-names": "^1.0.0"
   }
 }

--- a/draft-js-mention-plugin/src/mentionSuggestionsStrategy.js
+++ b/draft-js-mention-plugin/src/mentionSuggestionsStrategy.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import findWithRegex from 'find-with-regex';
-import escapeRegExp from 'lodash/escapeRegExp';
+import escapeRegExp from 'lodash/string/escapeRegExp';
 
 export default (trigger: String) => (contentBlock: Object, callback: Function) => {
   findWithRegex(new RegExp(`(\\s|^)${escapeRegExp(trigger)}[\\w]*`, 'g'), contentBlock, callback);

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "immutable": "^3.8.1",
     "linkify-it": "2.0.0",
     "loader-utils": "^0.2.15",
+    "lodash": "^4.14.1",
     "react": ">=15.1.0",
     "react-dom": ">=15.1.0",
     "tlds": "1.132.0",


### PR DESCRIPTION
It seems that the lodash library is no longer organized such that you can import like this:

```js
import escapeRegExp from 'lodash/escapeRegExp';
```

Many of its functions are now separated into sub-folders for ease of categorization, so now you must do this instead:

```js
import escapeRegExp from 'lodash/string/escapeRegExp';
```