### PR TITLE
MOD: to prevent the user from dragging the sticker

### DIFF
--- a/draft-js-sticker-plugin/src/selectStickerStyles.css
+++ b/draft-js-sticker-plugin/src/selectStickerStyles.css
@@ -18,4 +18,6 @@
 .selectStickerImage {
   height: 80px;
   width: 80px;
+  -webkit-user-drag: none;
+  user-drag: none;
 }


### PR DESCRIPTION
Vendor Prefix included because autoprefixer won't catch that one.

See #374 