### PR TITLE
feat(Linkify): Allow the Linkify plugin to accept a custom component

### DIFF
--- a/draft-js-linkify-plugin/src/Link/index.js
+++ b/draft-js-linkify-plugin/src/Link/index.js
@@ -9,25 +9,28 @@ linkify.tlds(tlds);
 // The component we render when we encounter a hyperlink in the text
 export default class Link extends Component {
   render() {
-    /* eslint-disable no-use-before-define */
     const {
       decoratedText = '',
       theme = {},
       target = '_self',
       className,
-      ...props,
+      component,
+      ...rest,
       } = this.props;
-    /* eslint-enable */
+
     const combinedClassName = unionClassNames(theme.link, className);
     const links = linkify.match(decoratedText);
     const href = links && links[0] ? links[0].url : '';
-    return (
-      <a
-        {...props}
-        href={href}
-        className={combinedClassName}
-        target={target}
-      />
-    );
+
+    const props = {
+      ...rest,
+      href,
+      target,
+      className: combinedClassName,
+    };
+
+    return component
+      ? React.createElement(component, props)
+      : <a {...props} />;
   }
 }

--- a/draft-js-linkify-plugin/src/index.js
+++ b/draft-js-linkify-plugin/src/index.js
@@ -9,18 +9,23 @@ const defaultTheme = {
 
 const linkPlugin = (config = {}) => {
   // Styles are overwritten instead of merged as merging causes a lot of confusion.
-  //
+
   // Why? Because when merging a developer needs to know all of the underlying
   // styles which needs a deep dive into the code. Merging also makes it prone to
   // errors when upgrading as basically every styling change would become a major
   // breaking change. 1px of an increased padding can break a whole layout.
-  const theme = config.theme ? config.theme : defaultTheme;
-  const target = config.target ? config.target : '_self';
+
+  const {
+    component,
+    theme = defaultTheme,
+    target = '_self',
+  } = config;
+
   return {
     decorators: [
       {
         strategy: linkStrategy,
-        component: decorateComponentWithProps(Link, { theme, target }),
+        component: decorateComponentWithProps(Link, { theme, target, component }),
       },
     ],
   };


### PR DESCRIPTION
This adds a configuration key 'component', which can be used to enhance the default one
with additional properties like event handlers, or inline style.

In other words, this is the #271 for the Linkify plugin.