### PR TITLE
Fix Build for Mention Suggestions

### DIFF
--- a/draft-js-mention-plugin/src/MentionSuggestions/index.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/index.js
@@ -27,10 +27,6 @@ export default class MentionSuggestions extends Component {
     },
   };
 
-  static defaultProps = {
-    entryComponent: defaultEntryComponent,
-  };
-
   state = {
     isActive: false,
     focusedOptionIndex: 0,
@@ -313,7 +309,7 @@ export default class MentionSuggestions extends Component {
               id={`mention-option-${this.key}-${index}`}
               theme={theme}
               searchValue={this.lastSearchValue}
-              entryComponent={entryComponent}
+              entryComponent={entryComponent || defaultEntryComponent}
             />
           )).toJS()
         }


### PR DESCRIPTION
I noticed that using the Mentions plugin from npm, the build version disregards the `entryComponent` prop. Seems to be related to `defaultProps` & the webpack build.

in this PR i removed the `defaultProps` and set entryComponent to be `props.entryComponent || defaultEntryComponent`

thanks