### PR TITLE
Fix incorrect PropType specification in CustomCounter

### DIFF
--- a/draft-js-counter-plugin/src/CustomCounter/index.js
+++ b/draft-js-counter-plugin/src/CustomCounter/index.js
@@ -6,7 +6,7 @@ class CustomCounter extends Component {
   static propTypes = {
     theme: PropTypes.any,
     limit: PropTypes.number,
-    countFunction: PropTypes.function,
+    countFunction: PropTypes.func.isRequired,
   };
 
   getClassNames(count, limit) {


### PR DESCRIPTION
`PropTypes.function` is incorrect. It should be `PropTypes.func`.

Also a `CustomCounter` without a `count` function doesn't really make sense. So I've marked the `countFunction` as being required.