### PR TITLE
Fixes race condition with Japanese input

### DIFF
--- a/draft-js-mention-plugin/src/MentionSuggestionsPortal/index.js
+++ b/draft-js-mention-plugin/src/MentionSuggestionsPortal/index.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 
 export default class MentionSuggestionsPortal extends Component {
 
-  componentWillMount() {
+  componentDidMount() {
     this.props.store.register(this.props.offsetKey);
     this.updatePortalClientRect(this.props);
 


### PR DESCRIPTION
When inputting Japanese characters (or any complex alphabet which requires hitting enter to commit the characters), that action was causing a race condition. By changing componentWillMount to componentDidMount, this issue is resolved and the component will unmount unregister and then properly mount and register after. Prior to this change, componentWillMount would not fire after componentWillUnmount even though it was still in the DOM, so it wasn't re-registering the offsetkey.