### PR TITLE
Add babel polyfill to support older browser

### DIFF
--- a/docs/webpack.config.dev.js
+++ b/docs/webpack.config.dev.js
@@ -20,6 +20,7 @@ module.exports = Object.assign(webpackBaseConfig, {
   entry: {
     app: [
       `webpack-hot-middleware/client?path=${HMR_HOST}`,
+      'babel-polyfill',
       './client/index.js',
     ],
   },

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "babel-loader": "^6.2.5",
     "babel-plugin-react-transform": "^2.0.2",
     "babel-plugin-webpack-loaders": "^0.7.1",
+    "babel-polyfill": "^6.13.0",
     "babel-preset-es2015": "^6.14.0",
     "babel-preset-react": "^6.11.1",
     "babel-preset-react-hmre": "^1.1.1",


### PR DESCRIPTION
I added babel polyfill to the demo/website so it supports IE10:
![screen shot 2016-09-27 at 10 53 16](https://cloud.githubusercontent.com/assets/527559/18868671/f90df58c-84a0-11e6-851a-d238ab5d908e.png)

Fix #459