### PR TITLE
add mentionUnicodeRegex support in config for mention plugin

### DIFF
--- a/draft-js-mention-plugin/CHANGELOG.md
+++ b/draft-js-mention-plugin/CHANGELOG.md
@@ -13,6 +13,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - The config now accepts a new prop `mentionComponent`. If provided the passed component is used to render a Mention. [#271](https://github.com/draft-js-plugins/draft-js-plugins/pull/271). Thanks to @alexkuz
 - Added support for Chinese words. Thanks to @mzbac
 - Added support for Japanese characters (hiragana & katakana).
+- Added mentionUnicodeRegex in config.
+ ```js
+ createMentionPlugin({
+   mentionUnicodeRegex: '._\-',// mentionUnicodeRegex will go to mentionSuggestionsStrategy's regex. current code example will add '._-' support for mentions
+ });
+ ```
 
 ### Fixed
 

--- a/draft-js-mention-plugin/src/index.js
+++ b/draft-js-mention-plugin/src/index.js
@@ -86,6 +86,7 @@ const createMentionPlugin = (config = {}) => {
     positionSuggestions = defaultPositionSuggestions,
     mentionComponent,
     mentionTrigger = '@',
+    mentionUnicodeRegex = '',
   } = config;
   const mentionSearchProps = {
     ariaProps,
@@ -104,7 +105,7 @@ const createMentionPlugin = (config = {}) => {
         component: decorateComponentWithProps(Mention, { theme, mentionPrefix, mentionComponent }),
       },
       {
-        strategy: mentionSuggestionsStrategy(mentionTrigger),
+        strategy: mentionSuggestionsStrategy(mentionTrigger, mentionUnicodeRegex),
         component: decorateComponentWithProps(MentionSuggestionsPortal, { store }),
       },
     ],

--- a/draft-js-mention-plugin/src/mentionSuggestionsStrategy.js
+++ b/draft-js-mention-plugin/src/mentionSuggestionsStrategy.js
@@ -3,9 +3,9 @@
 import findWithRegex from 'find-with-regex';
 import escapeRegExp from 'lodash.escaperegexp';
 
-export default (trigger: String) => (contentBlock: Object, callback: Function) => {
+export default (trigger: String, mentionUnicodeRegex: String) => (contentBlock: Object, callback: Function) => {
   // common chinese symbols: \u4e00-\u9eff - http://stackoverflow.com/a/1366113/837709
   // hiragana (japanese): \u3040-\u309F - https://gist.github.com/ryanmcgrath/982242#file-japaneseregex-js
   // katakana (japanese): \u30A0-\u30FF - https://gist.github.com/ryanmcgrath/982242#file-japaneseregex-js
-  findWithRegex(new RegExp(`(\\s|^)${escapeRegExp(trigger)}[\\w\u4e00-\u9eff\u3040-\u309F\u30A0-\u30FF]*`, 'g'), contentBlock, callback);
+  findWithRegex(new RegExp(`(\\s|^)${escapeRegExp(trigger)}[\\w\u4e00-\u9eff\u3040-\u309F\u30A0-\u30FF${escapeRegExp(mentionUnicodeRegex)}]*`, 'g'), contentBlock, callback);
 };


### PR DESCRIPTION
it solve the issue for 
https://github.com/draft-js-plugins/draft-js-plugins/issues/406
https://github.com/draft-js-plugins/draft-js-plugins/issues/457

user can specify their own regex to let mention plugin to support any kind of Unicode as they want