### PR TITLE
Adds optional `leftOffset` arg to toolbar decorator

### DIFF
--- a/draft-js-toolbar-plugin/src/decorators/toolbar.js
+++ b/draft-js-toolbar-plugin/src/decorators/toolbar.js
@@ -10,7 +10,11 @@ const getDisplayName = (WrappedComponent) => {
 let number = 0;
 
 // HoverToolbar decorator will render a toolbar on hovering the WrappedComponent
-export default ({ theme, customRender }) => (WrappedComponent) => class FocusedToolbarDecorator extends Component {
+export default ({
+  theme,
+  leftOffset,
+  customRender,
+}) => (WrappedComponent) => class FocusedToolbarDecorator extends Component {
   // Statics
   static displayName = `FocusedToolbar(${getDisplayName(WrappedComponent)})`;
   static WrappedComponent = WrappedComponent.WrappedComponent || WrappedComponent;
@@ -54,6 +58,7 @@ export default ({ theme, customRender }) => (WrappedComponent) => class FocusedT
       ...this.props,
       actions,
       theme,
+      leftOffset,
       getTargetRectangle: () => this.DOMNode.getBoundingClientRect(),
       uid: this.DOMNode,
     };

--- a/draft-js-toolbar-plugin/src/index.js
+++ b/draft-js-toolbar-plugin/src/index.js
@@ -44,4 +44,7 @@ const toolbarPlugin = (config = {}) => {
 
 export default toolbarPlugin;
 
-export const ToolbarDecorator = (options = {}) => Decorator({ theme: options.theme || styles });
+export const ToolbarDecorator = (options = {}) => Decorator({
+  leftOffset: options.leftOffset,
+  theme: options.theme || styles,
+});

--- a/draft-js-toolbar-plugin/src/utils/portal.js
+++ b/draft-js-toolbar-plugin/src/utils/portal.js
@@ -66,7 +66,7 @@ class Tooltip extends Component {
   }
 
   render() {
-    const { onMouseOver, onMouseLeave, active, animations } = this.props;
+    const { onMouseOver, onMouseLeave, active, animations, leftOffset } = this.props;
 
     // Is server?
     if (typeof window === 'undefined') {
@@ -74,7 +74,7 @@ class Tooltip extends Component {
     }
 
     // Left/Top
-    const left = `${this.state.left}px`;
+    const left = `${this.state.left + leftOffset || 0}px`;
     const top = `${this.state.top + 1}px`;
 
     // Style


### PR DESCRIPTION
- the left absolute positioning calculation in `Tooltip` in `utils/portal.js` seems to work fine for standard text-selection toolbar
- left positioning seems to be off for decorated components in certain cases, however
- this optional arg to the decorator allows a number of pixels to offset the left positioning calculation by, in the case that it's a little bit off
- defaults to 0 to avoid unwanted offsetting
- tests passing locally