### PR TITLE
Fix for DND onDropBlock overwriting custom Entity types

### DIFF
--- a/draft-js-dnd-plugin/package.json
+++ b/draft-js-dnd-plugin/package.json
@@ -1,7 +1,8 @@
 {
-  "name": "draft-js-dnd-plugin",
+  "name": "@poltak/draft-js-dnd-plugin",
   "version": "2.0.0-beta5",
   "description": "Dnd Plugin for DraftJS",
+  "private": false,
   "author": {
     "name": "Benjamin Kniffler",
     "email": "benjamin@kniffler.com"

--- a/draft-js-dnd-plugin/package.json
+++ b/draft-js-dnd-plugin/package.json
@@ -1,8 +1,7 @@
 {
-  "name": "@poltak/draft-js-dnd-plugin",
+  "name": "draft-js-dnd-plugin",
   "version": "2.0.0-beta5",
   "description": "Dnd Plugin for DraftJS",
-  "private": false,
   "author": {
     "name": "Benjamin Kniffler",
     "email": "benjamin@kniffler.com"

--- a/draft-js-dnd-plugin/src/modifiers/addBlock.js
+++ b/draft-js-dnd-plugin/src/modifiers/addBlock.js
@@ -1,7 +1,7 @@
 import { List, Repeat } from 'immutable';
 import { Modifier, CharacterMetadata, BlockMapBuilder, EditorState, ContentBlock, Entity, genKey } from 'draft-js';
 
-export default function (editorState, selection, type, data, entityType = undefined, text = ' ') {
+export default function (editorState, selection, type, data, entityType, text = ' ') {
   const currentContentState = editorState.getCurrentContent();
   const currentSelectionState = selection;
 

--- a/draft-js-dnd-plugin/src/modifiers/addBlock.js
+++ b/draft-js-dnd-plugin/src/modifiers/addBlock.js
@@ -1,7 +1,7 @@
 import { List, Repeat } from 'immutable';
 import { Modifier, CharacterMetadata, BlockMapBuilder, EditorState, ContentBlock, Entity, genKey } from 'draft-js';
 
-export default function (editorState, selection, type, data, text = ' ') {
+export default function (editorState, selection, type, data, entityType = undefined, text = ' ') {
   const currentContentState = editorState.getCurrentContent();
   const currentSelectionState = selection;
 
@@ -39,7 +39,8 @@ export default function (editorState, selection, type, data, text = ' ') {
   const newContentStateAfterSplit = Modifier.setBlockType(insertionTargetBlock, insertionTargetSelection, type);
 
   // creating a new ContentBlock including the entity with data
-  const entityKey = Entity.create(type, 'IMMUTABLE', { ...data });
+  // Entity will be created with a specific type, if defined, else will fall back to the ContentBlock type
+  const entityKey = Entity.create(entityType || type, 'IMMUTABLE', { ...data });
   const charData = CharacterMetadata.create({ entity: entityKey });
 
   const fragmentArray = [

--- a/draft-js-dnd-plugin/src/modifiers/onDropBlock.js
+++ b/draft-js-dnd-plugin/src/modifiers/onDropBlock.js
@@ -21,7 +21,8 @@ export default function onDropBlock({ handleDefaultData }) {
 
       // Get content, selection, block
       const block = state.getCurrentContent().getBlockForKey(blockKey);
-      const editorStateAfterInsert = addBlock(state, selection, block.getType(), Entity.get(block.getEntityAt(0)).data);
+      const entity = Entity.get(block.getEntityAt(0));
+      const editorStateAfterInsert = addBlock(state, selection, block.getType(), entity.data, entity.type);
       setEditorState(removeBlock(editorStateAfterInsert, blockKey));
     }
 


### PR DESCRIPTION
- in the case where the Entity associated with the given block is of a custom type, the current onDropBlock function overwrites the Entity type with whatever type the ContentBlock is
- this commit allows optional specification of entity type in the addBlock modifier function, meaning the newly created Entity will be typed correctly as it was before being dragged-n-dropped
- if unspecified in the addBlock modifier function, it will fallback to the old behaviour of creating an Entity with whatever type the ContentBlock was using
- tests and linting passing; no build errors


### Example:
- I have an atomic-typed ContentBlock associated with a Entity of type 'blah'
- dragging and dropping that block somewhere else will recreate the Entity in the new selection but replace the type with 'atomic', as that's what the block is typed as (there is currently no separation of concern between ContentBlock type and Entity type)

