### PR TITLE
[draft-js-mention-plugin] do open in componentWillReceiveProps() if and only if needed

### DIFF
--- a/draft-js-mention-plugin/src/MentionSuggestions/index.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/index.js
@@ -39,6 +39,11 @@ export default class MentionSuggestions extends Component {
   componentWillReceiveProps(nextProps) {
     if (nextProps.suggestions.size === 0 && this.state.isActive) {
       this.closeDropdown();
+    } else if (this.isOpening) {
+      if (nextProps.suggestions.size > 0) {
+        this.openDropdown();
+      }
+      this.isOpening = false;
     }
   }
 
@@ -149,7 +154,7 @@ export default class MentionSuggestions extends Component {
     // the dropdown should be open. This is useful when a user focuses on another
     // input field and then comes back: the dropdown will again.
     if (!this.state.isActive && !this.props.store.isEscaped(this.activeOffsetKey)) {
-      this.openDropdown();
+      this.isOpening = true;
     }
 
     // makes sure the focused index is reseted every time a new selection opens


### PR DESCRIPTION
With draft-js-mention-plugin 2.0.0-beta5 (and 1.1.2), sometimes I can't use keyboard ↑ and ↓ on mention entities.

This is because once `openDropdown()` is called, keyboard event handlers are set and the events occurring are handled by them. This behavior, I guess, bans users from moving cursors up and down by keyboards.

This PR make `onEditorStateChange()` doesn't immediately call `openDropdown()`. Instead, `componentWillReceiveProps()` do so if `nextProps.suggestions` is not empty.