### PR TITLE
[draft-js-mention-plugin] add MentionSuggestions#isActive()

### DIFF
--- a/draft-js-mention-plugin/src/MentionSuggestions/__test__/index.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/__test__/index.js
@@ -71,11 +71,11 @@ describe('MentionSuggestions Component', () => {
     );
 
     suggestions.instance().openDropdown();
-    expect(suggestions.state().isActive).to.equal(true);
+    expect(suggestions.instance().isActive()).to.equal(true);
 
     suggestions.setProps({
       suggestions: fromJS([]),
     });
-    expect(suggestions.state().isActive).to.equal(false);
+    expect(suggestions.instance().isActive()).to.equal(false);
   });
 });

--- a/draft-js-mention-plugin/src/MentionSuggestions/index.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/index.js
@@ -233,6 +233,10 @@ export default class MentionSuggestions extends Component {
     this.props.store.setEditorState(this.props.store.getEditorState());
   };
 
+  isActive() {
+    return this.state.isActive;
+  }
+
   commitSelection = () => {
     this.onMentionSelect(this.props.suggestions.get(this.state.focusedOptionIndex));
     return true;


### PR DESCRIPTION
This is useful if one should know the MentionSuggestions is open or not.

For example, when MentionSuggestions is active, any other keyboard events (i.e. ↑↓) should be handled only by MentionSuggestions.