### PR TITLE
[draft-js-mention-plugin] mentionPrefix as part of draft editor node

### DIFF
--- a/docs/client/components/pages/Mention/index.js
+++ b/docs/client/components/pages/Mention/index.js
@@ -153,7 +153,7 @@ export default class App extends Component {
           </div>
           <div className={styles.param}>
             <span className={styles.paramName}>mentionComponent</span>
-            <span>If provided the passed component is used to render a Mention. It receives the following props: entityKey, mention, className, mentionPrefix & decoratedText</span>
+            <span>If provided the passed component is used to render a Mention. It receives the following props: entityKey, mention, className & decoratedText</span>
           </div>
           <Heading level={3}>MentionSuggestions</Heading>
           <div>

--- a/draft-js-mention-plugin/CHANGELOG.md
+++ b/draft-js-mention-plugin/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed bug where a user typed @xxx (invalid mention) and hit Enter. [#416](https://github.com/draft-js-plugins/draft-js-plugins/pull/416)
 - Fixed bug where press up arrow would not cycle back to the bottom of suggestions
 - Fixed race condition where the SuggestionPortal would unregister and not register again when inputting Japanese, etc.
+- Fixed bug where `mentionPrefix` does not appear in `editorState`
 
 ## 1.1.2 - 2016-06-26
 

--- a/draft-js-mention-plugin/CHANGELOG.md
+++ b/draft-js-mention-plugin/CHANGELOG.md
@@ -21,7 +21,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed bug where a user typed @xxx (invalid mention) and hit Enter. [#416](https://github.com/draft-js-plugins/draft-js-plugins/pull/416)
 - Fixed bug where press up arrow would not cycle back to the bottom of suggestions
 - Fixed race condition where the SuggestionPortal would unregister and not register again when inputting Japanese, etc.
-- Fixed bug where `mentionPrefix` does not appear in `editorState`
+- Fixed bug where `mentionPrefix` does not appear in `editorState`. `mentionPrefix` is no longer passed to `mentionComponent`.
 
 ## 1.1.2 - 2016-06-26
 

--- a/draft-js-mention-plugin/src/Mention/index.js
+++ b/draft-js-mention-plugin/src/Mention/index.js
@@ -3,21 +3,21 @@ import { Entity } from 'draft-js';
 import { fromJS } from 'immutable';
 import unionClassNames from 'union-class-names';
 
-const MentionLink = ({ mention, mentionPrefix, children, className }) =>
+const MentionLink = ({ mention, children, className }) =>
   <a
     href={mention.get('link')}
     className={className}
     spellCheck={false}
   >
-    {mentionPrefix}{children}
+    {children}
   </a>;
 
-const MentionText = ({ mentionPrefix, children, className }) =>
+const MentionText = ({ children, className }) =>
   <span
     className={className}
     spellCheck={false}
   >
-    {mentionPrefix}{children}
+    {children}
   </span>;
 
 const Mention = (props) => {
@@ -25,7 +25,6 @@ const Mention = (props) => {
     entityKey,
     theme = {},
     mentionComponent,
-    mentionPrefix,
     children,
     decoratedText,
     className,
@@ -44,7 +43,6 @@ const Mention = (props) => {
       mention={mention}
       theme={theme}
       className={combinedClassName}
-      mentionPrefix={mentionPrefix}
       decoratedText={decoratedText}
     >
       {children}

--- a/draft-js-mention-plugin/src/MentionSuggestions/index.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/index.js
@@ -19,7 +19,7 @@ export default class MentionSuggestions extends Component {
     suggestions: (props, propName, componentName) => {
       if (!List.isList(props[propName])) {
         return new Error(
-          `Invalid prop \`${propName}\' supplied to \`${componentName}\`. should be an instance of immutable list.`
+          `Invalid prop \`${propName}' supplied to \`${componentName}\`. should be an instance of immutable list.`
         );
       }
       return undefined;

--- a/draft-js-mention-plugin/src/MentionSuggestions/index.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/index.js
@@ -218,6 +218,7 @@ export default class MentionSuggestions extends Component {
     const newEditorState = addMention(
       this.props.store.getEditorState(),
       mention,
+      this.props.mentionPrefix,
       this.props.mentionTrigger,
       this.props.entityMutability,
     );
@@ -299,6 +300,7 @@ export default class MentionSuggestions extends Component {
       entityMutability, // eslint-disable-line no-unused-vars
       positionSuggestions, // eslint-disable-line no-unused-vars
       mentionTrigger, // eslint-disable-line no-unused-vars
+      mentionPrefix, // eslint-disable-line no-unused-vars
       ...elementProps } = this.props;
 
     return (

--- a/draft-js-mention-plugin/src/index.js
+++ b/draft-js-mention-plugin/src/index.js
@@ -102,7 +102,7 @@ const createMentionPlugin = (config = {}) => {
     decorators: [
       {
         strategy: mentionStrategy(mentionTrigger),
-        component: decorateComponentWithProps(Mention, { theme, mentionPrefix, mentionComponent }),
+        component: decorateComponentWithProps(Mention, { theme, mentionComponent }),
       },
       {
         strategy: mentionSuggestionsStrategy(mentionTrigger),

--- a/draft-js-mention-plugin/src/index.js
+++ b/draft-js-mention-plugin/src/index.js
@@ -95,6 +95,7 @@ const createMentionPlugin = (config = {}) => {
     entityMutability: config.entityMutability ? config.entityMutability : 'SEGMENTED',
     positionSuggestions,
     mentionTrigger,
+    mentionPrefix,
   };
   return {
     MentionSuggestions: decorateComponentWithProps(MentionSuggestions, mentionSearchProps),

--- a/draft-js-mention-plugin/src/modifiers/addMention.js
+++ b/draft-js-mention-plugin/src/modifiers/addMention.js
@@ -2,7 +2,7 @@ import { Modifier, EditorState, Entity } from 'draft-js';
 import getSearchText from '../utils/getSearchText';
 import getTypeByTrigger from '../utils/getTypeByTrigger';
 
-const addMention = (editorState, mention, mentionTrigger, entityMutability) => {
+const addMention = (editorState, mention, mentionPrefix, mentionTrigger, entityMutability) => {
   const entityKey = Entity.create(getTypeByTrigger(mentionTrigger), entityMutability, { mention });
 
   const currentSelectionState = editorState.getSelection();
@@ -17,7 +17,7 @@ const addMention = (editorState, mention, mentionTrigger, entityMutability) => {
   let mentionReplacedContent = Modifier.replaceText(
     editorState.getCurrentContent(),
     mentionTextSelection,
-    mention.get('name'),
+    `${mentionPrefix}${mention.get('name')}`,
     null, // no inline style needed
     entityKey
   );


### PR DESCRIPTION
mentionPrefix is not in editorState since it's added as a plain text node, not draft editor node. This creates a problem when the plugin is used with CharCounter. (See example https://drive.google.com/open?id=0B3Ftrnd9yXx-SzQ2YndPR0g4YW8)

I'm not sure if this behavior is intentional. Feedback needed.