### PR TITLE
Add reloadDecorators function to pick up new decorator props manually

### DIFF
--- a/draft-js-plugins-editor/src/Editor/index.js
+++ b/draft-js-plugins-editor/src/Editor/index.js
@@ -85,6 +85,28 @@ class PluginEditor extends Component {
     }
   };
 
+  getPlugins = () => this.props.plugins.slice(0);
+  getProps = () => ({ ...this.props });
+
+  // TODO further down in render we use readOnly={this.props.readOnly || this.state.readOnly}. Ask Ben why readOnly is here just from the props? Why would plugins use this instead of just taking it from getProps?
+  getReadOnly = () => this.props.readOnly;
+  setReadOnly = (readOnly) => {
+    if (readOnly !== this.state.readOnly) this.setState({ readOnly });
+  };
+
+  getEditorRef = () => this.editor;
+
+  getEditorState = () => this.props.editorState;
+  getPluginMethods = () => ({
+    getPlugins: this.getPlugins,
+    getProps: this.getProps,
+    setEditorState: this.onChange,
+    getEditorState: this.getEditorState,
+    getReadOnly: this.getReadOnly,
+    setReadOnly: this.setReadOnly,
+    getEditorRef: this.getEditorRef,
+  });
+
   loadDecorators = () => {
     const decorators = this.resolveDecorators();
     const compositeDecorator = createCompositeDecorator(
@@ -109,28 +131,6 @@ class PluginEditor extends Component {
     const editorState = this.loadDecorators();
     this.onChange(editorState);
   };
-
-  getPlugins = () => this.props.plugins.slice(0);
-  getProps = () => ({ ...this.props });
-
-  // TODO further down in render we use readOnly={this.props.readOnly || this.state.readOnly}. Ask Ben why readOnly is here just from the props? Why would plugins use this instead of just taking it from getProps?
-  getReadOnly = () => this.props.readOnly;
-  setReadOnly = (readOnly) => {
-    if (readOnly !== this.state.readOnly) this.setState({ readOnly });
-  };
-
-  getEditorRef = () => this.editor;
-
-  getEditorState = () => this.props.editorState;
-  getPluginMethods = () => ({
-    getPlugins: this.getPlugins,
-    getProps: this.getProps,
-    setEditorState: this.onChange,
-    getEditorState: this.getEditorState,
-    getReadOnly: this.getReadOnly,
-    setReadOnly: this.setReadOnly,
-    getEditorRef: this.getEditorRef,
-  });
 
   createEventHooks = (methodName, plugins) => (...args) => {
     const newArgs = [].slice.apply(args);

--- a/draft-js-plugins-editor/src/Editor/index.js
+++ b/draft-js-plugins-editor/src/Editor/index.js
@@ -55,23 +55,7 @@ class PluginEditor extends Component {
   }
 
   componentWillMount() {
-    const decorators = this.resolveDecorators();
-    const compositeDecorator = createCompositeDecorator(
-      decorators.filter((decorator) => !this.decoratorIsCustom(decorator)),
-      this.getEditorState,
-      this.onChange);
-
-    const customDecorators = decorators
-      .filter((decorator) => this.decoratorIsCustom(decorator));
-
-    const multiDecorator = new MultiDecorator(
-      [
-        ...customDecorators,
-        compositeDecorator,
-      ]
-    );
-
-    const editorState = EditorState.set(this.props.editorState, { decorator: multiDecorator });
+    const editorState = this.loadDecorators();
     this.onChange(moveSelectionToEnd(editorState));
   }
 
@@ -99,6 +83,31 @@ class PluginEditor extends Component {
     if (this.props.onChange) {
       this.props.onChange(newEditorState, this.getPluginMethods());
     }
+  };
+
+  loadDecorators = () => {
+    const decorators = this.resolveDecorators();
+    const compositeDecorator = createCompositeDecorator(
+      decorators.filter((decorator) => !this.decoratorIsCustom(decorator)),
+      this.getEditorState,
+      this.onChange);
+
+    const customDecorators = decorators
+      .filter((decorator) => this.decoratorIsCustom(decorator));
+
+    const multiDecorator = new MultiDecorator(
+      [
+        ...customDecorators,
+        compositeDecorator,
+      ]
+    );
+
+    return EditorState.set(this.props.editorState, { decorator: multiDecorator });
+  };
+
+  reloadDecorators = () => {
+    const editorState = this.loadDecorators();
+    this.onChange(editorState);
   };
 
   getPlugins = () => this.props.plugins.slice(0);


### PR DESCRIPTION
There is a use case for loading different plugins and decorators after the PluginEditor mounts for the first time.

Accepting new `plugins` props from a `componentWillReceiveProps` hook is a difficult problem to solve. This is because because the `plugins` prop is just a plain JavaScript object and performing deep equality checks isn't possible every time a component will receive props.

We *could* do a strict equality check, but this would be a breaking change as to be consistent we would have to enforce that all consumers of draft-js-plugins-editor use immutable data structures. This is less than ideal.

For now, I'm proposing that we let the consumer of the editor decide when to manually reload decorators. I believe there is a use case for reloading plugins in general, but I want to run this general concept by @nikgraf to see his thoughts before continuing to develop further.

