### PR TITLE
add missing props to render of MentionSuggestions

### DIFF
--- a/draft-js-mention-plugin/src/MentionSuggestions/index.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/index.js
@@ -291,6 +291,8 @@ export default class MentionSuggestions extends Component {
 
     const {
       entryComponent,
+      onClose, // eslint-disable-line no-unused-vars
+      onOpen, // eslint-disable-line no-unused-vars
       onSearchChange, // eslint-disable-line no-unused-vars, no-shadow
       suggestions, // eslint-disable-line no-unused-vars
       ariaProps, // eslint-disable-line no-unused-vars


### PR DESCRIPTION
Without this props in render method of MentionSuggestions component you may have warning:
_`Warning: Unknown props `onOpen`, `onClose` on <div> tag`_

