### PR TITLE
bugfix position toolbar on focus

### DIFF
--- a/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
+++ b/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
@@ -16,18 +16,22 @@ export default class Toolbar extends React.Component {
   }
 
   onVisibilityChanged = (isVisible) => {
-    const selectionRect = isVisible ? getVisibleSelectionRect(window) : undefined;
-    const position = selectionRect ? {
-      top: (selectionRect.top + window.scrollY) - toolbarHeight,
-      left: selectionRect.left + window.scrollX + (selectionRect.width / 2),
-      transform: 'translate(-50%) scale(1)',
-      transition: 'transform 0.15s cubic-bezier(.3,1.2,.2,1)',
-    } : {
-      transform: 'translate(-50%) scale(0)',
-    };
-    this.setState({
-      position,
-    });
+    // need to wait a tick for window.getSelection() to be accurate
+    // when focusing editor with allready present selection
+    setTimeout(() => {
+      const selectionRect = isVisible ? getVisibleSelectionRect(window) : undefined;
+      const position = selectionRect ? {
+        top: (selectionRect.top + window.scrollY) - toolbarHeight,
+        left: selectionRect.left + window.scrollX + (selectionRect.width / 2),
+        transform: 'translate(-50%) scale(1)',
+        transition: 'transform 0.15s cubic-bezier(.3,1.2,.2,1)',
+      } : {
+        transform: 'translate(-50%) scale(0)',
+      };
+      this.setState({
+        position,
+      });
+    }, 0);
   }
 
   render() {

--- a/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
+++ b/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
@@ -17,7 +17,7 @@ export default class Toolbar extends React.Component {
 
   onVisibilityChanged = (isVisible) => {
     // need to wait a tick for window.getSelection() to be accurate
-    // when focusing editor with allready present selection
+    // when focusing editor with already present selection
     setTimeout(() => {
       const selectionRect = isVisible ? getVisibleSelectionRect(window) : undefined;
       const position = selectionRect ? {


### PR DESCRIPTION
Bug reproduction:

1. select a word
2. click outside editor
3. click in the editor, not in a text

![](http://i.imgur.com/zfwoTN3.gif)