### PR TITLE
feat(mention-suggestions): Adds a property `triggerOnEmpty`

### DIFF
--- a/docs/client/components/pages/Mention/index.js
+++ b/docs/client/components/pages/Mention/index.js
@@ -152,6 +152,10 @@ export default class App extends Component {
             <span>Allows you to provide a custom character to change when the search is triggered. By default it is set to `@`. By default typing `@` will trigger the search for mentions. Note: the implementation does not support a multi-character mentionTrigger.</span>
           </div>
           <div className={styles.param}>
+            <span className={styles.paramName}>triggerOnEmpty</span>
+            <span>If provided, the search will be triggered even if the search value is empty. This can be useful if you want to fetch remote data whenever the user hits `@`. By default, this is set to `false`.</span>
+          </div>
+          <div className={styles.param}>
             <span className={styles.paramName}>mentionRegExp</span>
             <span>Allows you to overwrite the regular expression for initiating the dropdown. By default this supports any alphanumeric character as well as Chinese, Japanese & Korean characters. We are happy to accept pull requests to extend the default mentionRegExp as well.</span>
           </div>

--- a/draft-js-mention-plugin/src/MentionSuggestions/index.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/index.js
@@ -16,7 +16,7 @@ export default class MentionSuggestions extends Component {
       'MUTABLE',
     ]),
     entryComponent: PropTypes.func,
-    triggerOnEmpty: PropTypes.bool,
+    triggerOnEmpty: PropTypes.bool, // comment, so that travis hopefully works, please remove this comment after success
     onAddMention: PropTypes.func,
     suggestions: (props, propName, componentName) => {
       if (!List.isList(props[propName])) {
@@ -173,6 +173,7 @@ export default class MentionSuggestions extends Component {
     const searchValue = word.substring(1, word.length);
     if (this.lastSearchValue !== searchValue || this.props.triggerOnEmpty) {
       this.lastSearchValue = searchValue;
+      console.log(searchValue, searchValue.length);
       this.props.onSearchChange({ value: searchValue });
     }
   };

--- a/draft-js-mention-plugin/src/MentionSuggestions/index.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/index.js
@@ -16,6 +16,7 @@ export default class MentionSuggestions extends Component {
       'MUTABLE',
     ]),
     entryComponent: PropTypes.func,
+    triggerOnEmpty: PropTypes.bool,
     onAddMention: PropTypes.func,
     suggestions: (props, propName, componentName) => {
       if (!List.isList(props[propName])) {
@@ -170,7 +171,7 @@ export default class MentionSuggestions extends Component {
   onSearchChange = (editorState, selection) => {
     const { word } = getSearchText(editorState, selection);
     const searchValue = word.substring(1, word.length);
-    if (this.lastSearchValue !== searchValue) {
+    if (this.lastSearchValue !== searchValue || this.props.triggerOnEmpty) {
       this.lastSearchValue = searchValue;
       this.props.onSearchChange({ value: searchValue });
     }
@@ -297,6 +298,7 @@ export default class MentionSuggestions extends Component {
 
     const {
       entryComponent,
+      triggerOnEmpty,
       onClose, // eslint-disable-line no-unused-vars
       onOpen, // eslint-disable-line no-unused-vars
       onAddMention, // eslint-disable-line no-unused-vars, no-shadow

--- a/draft-js-mention-plugin/src/MentionSuggestions/index.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/index.js
@@ -173,7 +173,6 @@ export default class MentionSuggestions extends Component {
     const searchValue = word.substring(1, word.length);
     if (this.lastSearchValue !== searchValue || this.props.triggerOnEmpty) {
       this.lastSearchValue = searchValue;
-      console.log(searchValue, searchValue.length);
       this.props.onSearchChange({ value: searchValue });
     }
   };
@@ -299,7 +298,7 @@ export default class MentionSuggestions extends Component {
 
     const {
       entryComponent,
-      triggerOnEmpty,
+      triggerOnEmpty, // eslint-disable-line no-unused-vars
       onClose, // eslint-disable-line no-unused-vars
       onOpen, // eslint-disable-line no-unused-vars
       onAddMention, // eslint-disable-line no-unused-vars, no-shadow

--- a/draft-js-mention-plugin/src/index.js
+++ b/draft-js-mention-plugin/src/index.js
@@ -95,6 +95,7 @@ const createMentionPlugin = (config = {}) => {
     theme,
     store,
     entityMutability: config.entityMutability ? config.entityMutability : 'SEGMENTED',
+    triggerOnEmpty: config.triggerOnEmpty ? config.triggerOnEmpty : false,
     positionSuggestions,
     mentionTrigger,
     mentionPrefix,


### PR DESCRIPTION
This prop allows onSearchChange to be triggered, even if the search value is empty. Useful for dynamic remote data fetching.

Out of the documentation entry:

> If provided, the search will be triggered even if the search value is empty. This can be useful if you want to fetch remote data whenever the user hits `@`. By default, this is set to `false`.