### PR TITLE
Unsubscribe from store - inlineToolbar plugin

### DIFF
--- a/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
+++ b/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
@@ -15,6 +15,10 @@ export default class Toolbar extends React.Component {
     this.props.store.subscribeToItem('isVisible', this.onVisibilityChanged);
   }
 
+  componentWillUnmount() {
+    this.props.store.unsubscribeFromItem('isVisible', this.onVisibilityChanged);
+  }
+
   onVisibilityChanged = (isVisible) => {
     const selectionRect = isVisible ? getVisibleSelectionRect(window) : undefined;
     const position = selectionRect ? {

--- a/draft-js-inline-toolbar-plugin/src/utils/__test__/createStore.js
+++ b/draft-js-inline-toolbar-plugin/src/utils/__test__/createStore.js
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { stub } from 'sinon';
 import createStore from '../createStore';
 
 describe('createStore', () => {
@@ -20,5 +21,14 @@ describe('createStore', () => {
       done();
     });
     store.updateItem('name', 'Ada');
+  });
+
+  it('should be possible to unsubscribe from an update', () => {
+    const store = createStore();
+    const onNameChanged = stub();
+    store.subscribeToItem('name', onNameChanged);
+    store.unsubscribeFromItem('name', onNameChanged);
+    store.updateItem('name', 'Ada');
+    expect(onNameChanged).to.not.have.been.called();
   });
 });

--- a/draft-js-inline-toolbar-plugin/src/utils/createStore.js
+++ b/draft-js-inline-toolbar-plugin/src/utils/createStore.js
@@ -7,6 +7,10 @@ const createStore = (initialState) => {
     listeners[key].push(callback);
   };
 
+  const unsubscribeFromItem = (key, callback) => {
+    listeners[key] = listeners[key].filter((l) => l !== callback);
+  };
+
   const updateItem = (key, item) => {
     state = {
       ...state,
@@ -21,6 +25,7 @@ const createStore = (initialState) => {
 
   return {
     subscribeToItem,
+    unsubscribeFromItem,
     updateItem,
     getItem,
   };


### PR DESCRIPTION
Adds functionality for unsubscribing from listeners to items in store for inlineToolbar plugin.

Fixes #519 