### PR TITLE
[Docs] [inline-toolbar] Fix css import typo

### DIFF
--- a/docs/client/components/pages/InlineToolbar/webpackImport.js
+++ b/docs/client/components/pages/InlineToolbar/webpackImport.js
@@ -1,1 +1,1 @@
-import 'draft-js-inlineToolbar-plugin/lib/plugin.css'; // eslint-disable-line import/no-unresolved
+import 'draft-js-inline-toolbar-plugin/lib/plugin.css'; // eslint-disable-line import/no-unresolved


### PR DESCRIPTION
Fixes a typo in the documentation to properly import the css for the inline toolbar.