### PR TITLE
Fix inline toolbar positioning to work with a relative parent fixes #531

### DIFF
--- a/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
+++ b/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
@@ -59,7 +59,7 @@ export default class Toolbar extends React.Component {
       <div
         className={theme.toolbarStyles.toolbar}
         style={this.state.position}
-        ref={toolbar => this.toolbar = toolbar}
+        ref={(toolbar) => { this.toolbar = toolbar; }}
       >
         {this.props.structure.map((Component, index) => (
           <Component


### PR DESCRIPTION
The inline toolbar plugin is currently positioned absolutely but the offset assumes there are no containers between the toolbar and the document body with a position other than `static`

This PR re-uses the `getRelativeParent` function from the mention and emoji plugins to correct the positioning of the toolbar to fix #531

Whilst the alternative fix in PR #617 is much better than it is at the moment, using `position: fixed` means that if the user scrolls whilst something is selected the toolbar follows them down the page.

I think/hope this PR creates a nicer experience.