### PR TITLE
[emoji-plugin] Make emoji highlightable

### DIFF
--- a/draft-js-emoji-plugin/src/emojiStyles.css
+++ b/draft-js-emoji-plugin/src/emojiStyles.css
@@ -28,5 +28,5 @@
   Hide the original Emoji icon no matter what system it is. color: transparent
   would have been nice to avoid the extra span, but it doesn't work on iOS.
   */
-  opacity: 0;
+  color: transparent;
 }

--- a/draft-js-emoji-plugin/src/emojiStyles.css
+++ b/draft-js-emoji-plugin/src/emojiStyles.css
@@ -21,6 +21,7 @@
   */
   max-height: 1em;
   line-height: inherit;
+  margin: -.2ex 0em .2ex;
 }
 
 .emojiCharacter {


### PR DESCRIPTION
Currently if you highlight the emojione emoji's, the highlight bar disappears. With these changes however you get a nice continuous highlight so you can actually see what you are selecting.