### PR TITLE
Fixed Inline toolbar positioning with offsetParent fixes #531

### DIFF
--- a/docs/client/components/pages/InlineToolbar/CustomInlineToolbarEditor/editorStyles.css
+++ b/docs/client/components/pages/InlineToolbar/CustomInlineToolbarEditor/editorStyles.css
@@ -1,4 +1,5 @@
 .editor {
+  position: relative;
   box-sizing: border-box;
   border: 1px solid #ddd;
   cursor: text;

--- a/docs/client/components/pages/InlineToolbar/SimpleInlineToolbarEditor/editorStyles.css
+++ b/docs/client/components/pages/InlineToolbar/SimpleInlineToolbarEditor/editorStyles.css
@@ -1,4 +1,5 @@
 .editor {
+  position: relative;
   box-sizing: border-box;
   border: 1px solid #ddd;
   cursor: text;

--- a/docs/client/components/pages/InlineToolbar/ThemedInlineToolbarEditor/editorStyles.css
+++ b/docs/client/components/pages/InlineToolbar/ThemedInlineToolbarEditor/editorStyles.css
@@ -1,4 +1,5 @@
 .editor {
+  position: relative;
   box-sizing: border-box;
   border: 1px solid #ddd;
   cursor: text;

--- a/docs/client/components/pages/InlineToolbar/editorStyles.css
+++ b/docs/client/components/pages/InlineToolbar/editorStyles.css
@@ -1,0 +1,3 @@
+.editor {
+  position: relative;
+}

--- a/docs/client/components/pages/InlineToolbar/gettingStarted.js
+++ b/docs/client/components/pages/InlineToolbar/gettingStarted.js
@@ -2,19 +2,24 @@
 import Editor from 'draft-js-plugins-editor'; // eslint-disable-line import/no-unresolved
 import createInlineToolbarPlugin from 'draft-js-inline-toolbar-plugin'; // eslint-disable-line import/no-unresolved
 import React from 'react';
+import editorStyles from './editorStyles.css';
 
 // Creates an Instance. At this step, a configuration object can be passed in
 // as an argument.
 const inlineToolbarPlugin = createInlineToolbarPlugin();
+const { InlineToolbar } = inlineToolbarPlugin;
 
 // The Editor accepts an array of plugins. In this case, only the inlineToolbarPlugin
 // is passed in, although it is possible to pass in multiple plugins.
 const MyEditor = ({ editorState, onChange }) => (
-  <Editor
-    editorState={editorState}
-    onChange={onChange}
-    plugins={[inlineToolbarPlugin]}
-  />
+  <div className={editorStyles.editor}>
+    <Editor
+      editorState={editorState}
+      onChange={onChange}
+      plugins={[inlineToolbarPlugin]}
+    />
+    <InlineToolbar />
+  </div>
 );
 
 export default MyEditor;

--- a/docs/client/components/pages/InlineToolbar/index.js
+++ b/docs/client/components/pages/InlineToolbar/index.js
@@ -1,5 +1,7 @@
 import React, { Component } from 'react';
 // eslint-disable-next-line import/no-unresolved
+import editorStylesCode from '!!../../../loaders/prism-loader?language=css!./editorStyles.css';
+// eslint-disable-next-line import/no-unresolved
 import simpleExampleCode from '!!../../../loaders/prism-loader?language=javascript!./SimpleInlineToolbarEditor';
 // eslint-disable-next-line import/no-unresolved
 import simpleExampleEditorStylesCode from '!!../../../loaders/prism-loader?language=css!./SimpleInlineToolbarEditor/editorStyles.css';
@@ -45,6 +47,11 @@ export default class App extends Component {
           <Code code="npm install draft-js-plugins-editor@beta --save" />
           <Code code="npm install draft-js-inline-toolbar-plugin@beta --save" />
           <Code code={gettingStarted} name="gettingStarted.js" />
+          <p>
+            Make sure that you position your editor:
+          </p>
+          <Code code={editorStylesCode} name="editorStyles.css" />
+
           <Heading level={3}>Importing the default styles</Heading>
           <p>
             The plugin ships with a default styling available at this location in the installed package:

--- a/docs/client/components/pages/SideToolbar/CustomSideToolbarEditor/editorStyles.css
+++ b/docs/client/components/pages/SideToolbar/CustomSideToolbarEditor/editorStyles.css
@@ -1,4 +1,5 @@
 .editor {
+  position: relative;
   box-sizing: border-box;
   border: 1px solid #ddd;
   cursor: text;

--- a/docs/client/components/pages/SideToolbar/SimpleSideToolbarEditor/editorStyles.css
+++ b/docs/client/components/pages/SideToolbar/SimpleSideToolbarEditor/editorStyles.css
@@ -1,4 +1,5 @@
 .editor {
+  position: relative;
   box-sizing: border-box;
   border: 1px solid #ddd;
   cursor: text;

--- a/docs/client/components/pages/SideToolbar/editorStyles.css
+++ b/docs/client/components/pages/SideToolbar/editorStyles.css
@@ -1,0 +1,3 @@
+.editor {
+  position: relative;
+}

--- a/docs/client/components/pages/SideToolbar/gettingStarted.js
+++ b/docs/client/components/pages/SideToolbar/gettingStarted.js
@@ -2,19 +2,23 @@
 import Editor from 'draft-js-plugins-editor'; // eslint-disable-line import/no-unresolved
 import createSideToolbarPlugin from 'draft-js-side-toolbar-plugin'; // eslint-disable-line import/no-unresolved
 import React from 'react';
-
+import editorStyles from './editorStyles.css';
 // Creates an Instance. At this step, a configuration object can be passed in
 // as an argument.
 const sideToolbarPlugin = createSideToolbarPlugin();
+const { SideToolbar } = sideToolbarPlugin;
 
 // The Editor accepts an array of plugins. In this case, only the sideToolbarPlugin
 // is passed in, although it is possible to pass in multiple plugins.
 const MyEditor = ({ editorState, onChange }) => (
-  <Editor
-    editorState={editorState}
-    onChange={onChange}
-    plugins={[sideToolbarPlugin]}
-  />
+  <div className={editorStyles.editor}>
+    <Editor
+      editorState={editorState}
+      onChange={onChange}
+      plugins={[sideToolbarPlugin]}
+    />
+    <SideToolbar />
+  </div>
 );
 
 export default MyEditor;

--- a/docs/client/components/pages/SideToolbar/index.js
+++ b/docs/client/components/pages/SideToolbar/index.js
@@ -1,5 +1,7 @@
 import React, { Component } from 'react';
 // eslint-disable-next-line import/no-unresolved
+import editorStylesCode from '!!../../../loaders/prism-loader?language=css!./editorStyles.css';
+// eslint-disable-next-line import/no-unresolved
 import simpleExampleCode from '!!../../../loaders/prism-loader?language=javascript!./SimpleSideToolbarEditor';
 // eslint-disable-next-line import/no-unresolved
 import simpleExampleEditorStylesCode from '!!../../../loaders/prism-loader?language=css!./SimpleSideToolbarEditor/editorStyles.css';
@@ -40,6 +42,11 @@ export default class App extends Component {
           <Code code="npm install draft-js-plugins-editor@beta --save" />
           <Code code="npm install draft-js-side-toolbar-plugin@beta --save" />
           <Code code={gettingStarted} name="gettingStarted.js" />
+          <p>
+            Make sure that you position your editor:
+          </p>
+          <Code code={editorStylesCode} name="editorStyles.css" />
+
           <Heading level={3}>Importing the default styles</Heading>
           <p>
             The plugin ships with a default styling available at this location in the installed package:

--- a/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
+++ b/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
@@ -23,24 +23,37 @@ export default class Toolbar extends React.Component {
     // when focusing editor with already present selection
     setTimeout(() => {
       const selectionRect = isVisible ? getVisibleSelectionRect(window) : undefined;
-      const position = selectionRect ? {
-        top: (selectionRect.top + window.scrollY) - toolbarHeight,
-        left: selectionRect.left + window.scrollX + (selectionRect.width / 2),
-        transform: 'translate(-50%) scale(1)',
-        transition: 'transform 0.15s cubic-bezier(.3,1.2,.2,1)',
-      } : {
-        transform: 'translate(-50%) scale(0)',
-      };
+
+      let position;
+      if (selectionRect) {
+        const rect = this.el.offsetParent.getBoundingClientRect();
+        position = {
+          top: (selectionRect.top - rect.top) - toolbarHeight,
+          left: (selectionRect.left - rect.left) + (selectionRect.width / 2),
+          transform: 'translate(-50%) scale(1)',
+          transition: 'transform 0.15s cubic-bezier(.3,1.2,.2,1)'
+        };
+      } else {
+        position = {
+          transform: 'translate(-50%) scale(0)'
+        };
+      }
+
       this.setState({
         position,
       });
     }, 0);
   }
 
+  setEl = (el) => {
+    this.el = el;
+  };
+
   render() {
     const { theme, store } = this.props;
     return (
       <div
+        ref={this.setEl}
         className={theme.toolbarStyles.toolbar}
         style={this.state.position}
       >

--- a/draft-js-inline-toolbar-plugin/src/toolbarStyles.css
+++ b/draft-js-inline-toolbar-plugin/src/toolbarStyles.css
@@ -8,6 +8,7 @@
   box-shadow: 0px 1px 3px 0px rgba(220,220,220,1);
   z-index: 2;
   box-sizing: border-box;
+  white-space: nowrap;
 }
 
 .toolbar:after, .toolbar:before {

--- a/draft-js-side-toolbar-plugin/src/components/Toolbar/index.js
+++ b/draft-js-side-toolbar-plugin/src/components/Toolbar/index.js
@@ -34,24 +34,31 @@ export default class Toolbar extends React.Component {
     const offsetKey = DraftOffsetKey.encode(currentBlock.getKey(), 0, 0);
     // Note: need to wait on tick to make sure the DOM node has been create by Draft.js
     setTimeout(() => {
-      const node = document.querySelectorAll(`[data-offset-key="${offsetKey}"]`)[0];
-      const top = node.getBoundingClientRect().top;
-      const editor = this.props.store.getItem('getEditorRef')().refs.editor;
-      this.setState({
-        position: {
-          top: (top + window.scrollY),
-          left: editor.getBoundingClientRect().left - 80,
-          transform: 'scale(1)',
-          transition: 'transform 0.15s cubic-bezier(.3,1.2,.2,1)',
-        },
-      });
+      const node = document.querySelector(`[data-offset-key="${offsetKey}"]`);
+      if (node) {
+        const blockTop = node.getBoundingClientRect().top;
+        const offsetParentTop = this.el.offsetParent.getBoundingClientRect().top;
+        this.setState({
+          position: {
+            top: blockTop - offsetParentTop,
+            left: -80,
+            transform: 'scale(1)',
+            transition: 'transform 0.15s cubic-bezier(.3,1.2,.2,1)',
+          },
+        });
+      }
     }, 0);
   }
+
+  setEl = (el) => {
+    this.el = el;
+  };
 
   render() {
     const { theme, store } = this.props;
     return (
       <div
+        ref={this.setEl}
         className={theme.toolbarStyles.wrapper}
         style={this.state.position}
       >


### PR DESCRIPTION
Fixed Inline toolbar positioning with `offsetParent` and `getBoundingClientRect` and updated the documentation.


I just realized there are a couple of PRs for this bug fix (namely  #629) . Sorry not trying to step on toes had this one in development but hadn't gotten around to making a formal PR.