### PR TITLE
Fix EmojiSuggestions unknown props on `<div>` for `on*` callbacks

### DIFF
--- a/draft-js-emoji-plugin/src/EmojiSuggestions/index.js
+++ b/draft-js-emoji-plugin/src/EmojiSuggestions/index.js
@@ -265,9 +265,12 @@ export default class EmojiSuggestions extends Component {
       imageType,
       ariaProps, // eslint-disable-line no-unused-vars
       callbacks, // eslint-disable-line no-unused-vars
-      store, // eslint-disable-line no-unused-vars
+      onClose, // eslint-disable-line no-unused-vars
+      onOpen, // eslint-disable-line no-unused-vars
+      onSearchChange, // eslint-disable-line no-unused-vars
       positionSuggestions, // eslint-disable-line no-unused-vars
       shortNames, // eslint-disable-line no-unused-vars
+      store, // eslint-disable-line no-unused-vars
       ...restProps,
     } = this.props;
     return (


### PR DESCRIPTION
Fixes the following runtime warning:

![screen shot 2017-02-08 at 6 16 41 pm](https://cloud.githubusercontent.com/assets/309732/22794008/9d8f02c6-eebf-11e6-84eb-344aada9347e.png)

Steps to reproduce:
1. Use `EmojiSuggestions` with an `onOpen`, `onSearch`, or `onSearchChange`
2. Upon opening emoji suggestions for first time, see the above warning in javascript console.
