### PR TITLE
Move searchPortal ref function to constructor

### DIFF
--- a/draft-js-mention-plugin/src/MentionSuggestionsPortal/index.js
+++ b/draft-js-mention-plugin/src/MentionSuggestionsPortal/index.js
@@ -2,6 +2,11 @@ import React, { Component } from 'react';
 
 export default class MentionSuggestionsPortal extends Component {
 
+  constructor(props) {
+    super(props);
+    this.searchPortalRef = (element) => { this.searchPortal = element; };
+  }
+
   // When inputting Japanese characters (or any complex alphabet which requires
   // hitting enter to commit the characters), that action was causing a race
   // condition when we used componentWillMount. By using componentDidMount
@@ -38,7 +43,7 @@ export default class MentionSuggestionsPortal extends Component {
     return (
       <span
         className={this.key}
-        ref={(element) => { this.searchPortal = element; }}
+        ref={this.searchPortalRef}
       >
         {this.props.children}
       </span>


### PR DESCRIPTION
Fixes issue #666.

I'm not entirely sure why this makes a difference. I suspect it's a timing issue in React. Ideally, we shouldn't be accessing refs outside of the React lifecycle functions, so accessing this in a closure like this may cause problems again in the future if React internals change.