### PR TITLE
Support popoverComponent on MentionSuggestions

### DIFF
--- a/docs/client/components/pages/Mention/index.js
+++ b/docs/client/components/pages/Mention/index.js
@@ -187,6 +187,13 @@ export default class App extends Component {
               <span className={styles.paramName}>onAddMention</span>
               <span>A callback which is triggered whenever the mention is about to be added. The first argument of this callback will contain the mention entry.</span>
             </div>
+            <div className={styles.param}>
+              <span className={styles.paramName}>popoverComponent</span>
+              <span>Component to be used as the template for the popover (the parent of entryComponent).  Defaults to a div.</span>
+            </div>
+            <div className={styles.param}>
+              <span>Additional properties are passed to the <InlineCode code="popoverComponent" /></span>
+            </div>
           </div>
           <Heading level={3}>Additional Exports</Heading>
           <div>

--- a/draft-js-mention-plugin/src/MentionSuggestions/__test__/index.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/__test__/index.js
@@ -39,37 +39,37 @@ const mentions = fromJS([
   },
 ]);
 
-describe('MentionSuggestions Component', () => {
-  it('Closes when suggestions is empty', () => {
-    const callbacks = {
+
+function defaultProps() {
+  return {
+    suggestions: mentions,
+    callbacks: {
       onDownArrow: sinon.spy(),
       onUpArrow: sinon.spy(),
       onTab: sinon.spy(),
       onEscape: sinon.spy(),
       handleReturn: sinon.spy()
-    };
-    const store = {
+    },
+    store: {
       getAllSearches: sinon.spy(() => ({ has: () => false })),
       getPortalClientRect: sinon.spy(),
       isEscaped: sinon.spy(),
       resetEscapedSearch: sinon.spy(),
       escapeSearch: sinon.spy(),
-    };
-    const ariaProps = {};
-    const onSearchChange = sinon.spy();
-    const onAddMention = sinon.spy();
-    const positionSuggestions = sinon.stub().returns({});
+    },
+    ariaProps: {},
+    onSearchChange: sinon.spy(),
+    onAddMention: sinon.spy(),
+    positionSuggestions: sinon.stub().returns({}),
+    theme: {},
+  };
+}
+
+describe('MentionSuggestions Component', () => {
+  it('Closes when suggestions is empty', () => {
+    const props = defaultProps();
     const suggestions = mount(
-      <MentionSuggestions
-        ariaProps={ariaProps}
-        onSearchChange={onSearchChange}
-        positionSuggestions={positionSuggestions}
-        suggestions={mentions}
-        callbacks={callbacks}
-        store={store}
-        theme={{}}
-        onAddMention={onAddMention}
-      />
+      <MentionSuggestions {...props} />
     );
 
     suggestions.instance().openDropdown();
@@ -79,5 +79,48 @@ describe('MentionSuggestions Component', () => {
       suggestions: fromJS([]),
     });
     expect(suggestions.state().isActive).to.equal(false);
+  });
+
+  it('The popoverComponent prop changes the popover component', () => {
+    const PopoverComponent = ({ children, ...props }) => (
+      <div data-test-test {...props}>{children}</div>
+    );
+
+    const props = defaultProps();
+    props.popoverComponent = <PopoverComponent />;
+    const suggestions = mount(
+      <MentionSuggestions {...props} />
+    );
+
+    suggestions.instance().openDropdown();
+    expect(suggestions.find('[data-test-test]')).to.have.length(1);
+  });
+
+  it('The popoverComponent recieves the children', () => {
+    let called = false;
+    const PopoverComponent = ({ children, ...props }) => {
+      called = true;
+      expect(React.Children.count(children)).to.equal(mentions.length);
+      return <div {...props}>{children}</div>;
+    };
+
+    const props = defaultProps();
+    props.popoverComponent = <PopoverComponent />;
+    const suggestions = mount(
+      <MentionSuggestions {...props} />
+    );
+
+    suggestions.instance().openDropdown();
+    expect(called).to.equal(true);
+  });
+
+  it('The popoverComponent prop uses div by default', () => {
+    const props = defaultProps();
+    const suggestions = mount(
+      <MentionSuggestions {...props} data-findme />
+    );
+
+    suggestions.instance().openDropdown();
+    expect(suggestions.find('div[data-findme]')).to.have.length(1);
   });
 });

--- a/draft-js-mention-plugin/src/MentionSuggestions/index.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/index.js
@@ -302,6 +302,7 @@ export default class MentionSuggestions extends Component {
 
     const {
       entryComponent,
+      popoverComponent = <div />,
       onClose, // eslint-disable-line no-unused-vars
       onOpen, // eslint-disable-line no-unused-vars
       onAddMention, // eslint-disable-line no-unused-vars, no-shadow
@@ -317,31 +318,29 @@ export default class MentionSuggestions extends Component {
       mentionPrefix, // eslint-disable-line no-unused-vars
       ...elementProps } = this.props;
 
-    return (
-      <div
-        {...elementProps}
-        className={theme.mentionSuggestions}
-        role="listbox"
-        id={`mentions-list-${this.key}`}
-        ref={(element) => { this.popover = element; }}
-      >
-        {
-          this.props.suggestions.map((mention, index) => (
-            <Entry
-              key={mention.has('id') ? mention.get('id') : mention.get('name')}
-              onMentionSelect={this.onMentionSelect}
-              onMentionFocus={this.onMentionFocus}
-              isFocused={this.state.focusedOptionIndex === index}
-              mention={mention}
-              index={index}
-              id={`mention-option-${this.key}-${index}`}
-              theme={theme}
-              searchValue={this.lastSearchValue}
-              entryComponent={entryComponent || defaultEntryComponent}
-            />
-          )).toJS()
-        }
-      </div>
+    return React.cloneElement(
+      popoverComponent,
+      {
+        ...elementProps,
+        className: theme.mentionSuggestions,
+        role: 'listbox',
+        id: `mentions-list-${this.key}`,
+        ref: (element) => { this.popover = element; },
+      },
+      this.props.suggestions.map((mention, index) => (
+        <Entry
+          key={mention.has('id') ? mention.get('id') : mention.get('name')}
+          onMentionSelect={this.onMentionSelect}
+          onMentionFocus={this.onMentionFocus}
+          isFocused={this.state.focusedOptionIndex === index}
+          mention={mention}
+          index={index}
+          id={`mention-option-${this.key}-${index}`}
+          theme={theme}
+          searchValue={this.lastSearchValue}
+          entryComponent={entryComponent || defaultEntryComponent}
+        />
+      )).toJS()
     );
   }
 }


### PR DESCRIPTION
This allows you to override the `<div />` used to render the mention
suggestions in.  A use case is to replace the `<div />` with MaterialUI's
`<Paper />` for design coherency.