### PR TITLE
[mentions]: prevent selection commit on Tab/Enter if dropdown is not rendered

### DIFF
--- a/draft-js-mention-plugin/src/MentionSuggestions/__test__/index.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/__test__/index.js
@@ -100,7 +100,7 @@ describe('MentionSuggestions Component', () => {
     let called = false;
     const PopoverComponent = ({ children, ...props }) => {
       called = true;
-      expect(React.Children.count(children)).to.equal(mentions.length);
+      expect(React.Children.count(children)).to.equal(mentions.size);
       return <div {...props}>{children}</div>;
     };
 

--- a/draft-js-mention-plugin/src/MentionSuggestions/index.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/index.js
@@ -246,6 +246,10 @@ export default class MentionSuggestions extends Component {
   };
 
   commitSelection = () => {
+    if (!this.props.store.getIsOpened()) {
+      return 'not-handled';
+    }
+
     this.onMentionSelect(this.props.suggestions.get(this.state.focusedOptionIndex));
     return 'handled';
   };

--- a/draft-js-mention-plugin/src/MentionSuggestionsPortal/index.js
+++ b/draft-js-mention-plugin/src/MentionSuggestionsPortal/index.js
@@ -18,6 +18,7 @@ export default class MentionSuggestionsPortal extends Component {
   // was still in the DOM, so it wasn't re-registering the offsetkey.
   componentDidMount() {
     this.props.store.register(this.props.offsetKey);
+    this.props.store.setIsOpened(true);
     this.updatePortalClientRect(this.props);
 
     // trigger a re-render so the MentionSuggestions becomes active
@@ -30,6 +31,7 @@ export default class MentionSuggestionsPortal extends Component {
 
   componentWillUnmount() {
     this.props.store.unregister(this.props.offsetKey);
+    this.props.store.setIsOpened(false);
   }
 
   updatePortalClientRect(props) {

--- a/draft-js-mention-plugin/src/index.js
+++ b/draft-js-mention-plugin/src/index.js
@@ -46,6 +46,7 @@ export default (config = {}) => {
   let searches = Map();
   let escapedSearch;
   let clientRectFunctions = Map();
+  let isOpened;
 
   const store = {
     getEditorState: undefined,
@@ -73,6 +74,9 @@ export default (config = {}) => {
       searches = searches.delete(offsetKey);
       clientRectFunctions = clientRectFunctions.delete(offsetKey);
     },
+
+    getIsOpened: () => isOpened,
+    setIsOpened: (nextIsOpened) => { isOpened = nextIsOpened; },
   };
 
   // Styles are overwritten instead of merged as merging causes a lot of confusion.


### PR DESCRIPTION
I tried out mentions plugin and noticed that it inserts selected item on `Enter` or `Tab` when there's no trigger in sight and dropdown is not rendered. After reading the code, this is the first solution I came up with. Also, I was thinking about using `null` value for `focusedOptionIndex` when dropdown is not visible, but it's a bit implicit and I've already implemented the current fix, so I'd get feedback from maintainers first.

There's a chance that both directions are suck :) due to lack of my familiarity with this code base (and with draft js in general, yet). So I'll be happy to implement it in the right way after feedback from maintainers.