### PR TITLE
Fix the positioning of the alignment plugin to work the same way as the inline-toolbar works

### DIFF
--- a/draft-js-alignment-plugin/src/AlignmentTool/index.js
+++ b/draft-js-alignment-plugin/src/AlignmentTool/index.js
@@ -12,6 +12,19 @@ import buttonStyles from '../buttonStyles.css';
 // TODO make toolbarHeight to be determined or a parameter
 const toolbarHeight = 44;
 
+const getRelativeParent = (element) => {
+  if (!element) {
+    return null;
+  }
+
+  const position = window.getComputedStyle(element).getPropertyValue('position');
+  if (position !== 'static') {
+    return element;
+  }
+
+  return getRelativeParent(element.parentElement);
+};
+
 export default class AlignmentTool extends React.Component {
 
   state = {
@@ -30,20 +43,29 @@ export default class AlignmentTool extends React.Component {
   }
 
   onVisibilityChanged = (visibleBlock) => {
-    const boundingRect = this.props.store.getItem('boundingRect');
-    const position = visibleBlock ? {
-      top: (boundingRect.top + window.scrollY) - toolbarHeight,
-      left: boundingRect.left + window.scrollX + (boundingRect.width / 2),
-      transform: 'translate(-50%) scale(1)',
-      transition: 'transform 0.15s cubic-bezier(.3,1.2,.2,1)',
-    } : {
-      transform: 'translate(-50%) scale(0)',
-    };
-    const alignment = this.props.store.getItem('alignment') || 'default';
-    this.setState({
-      alignment,
-      position,
-    });
+
+    setTimeout(() => {
+      let position;
+      const boundingRect = this.props.store.getItem('boundingRect');
+      if (visibleBlock) {
+        const relativeParent = getRelativeParent(this.toolbar.parentElement);
+        const relativeRect = relativeParent ? relativeParent.getBoundingClientRect() : document.body.getBoundingClientRect();
+        position = {
+          top: (boundingRect.top - relativeRect.top) - toolbarHeight,
+          left: (boundingRect.left - relativeRect.left) + (boundingRect.width / 2),
+          transform: 'translate(-50%) scale(1)',
+          transition: 'transform 0.15s cubic-bezier(.3,1.2,.2,1)',
+        };
+      } else {
+        position = { transform: 'translate(-50%) scale(0)' };
+      }
+      const alignment = this.props.store.getItem('alignment') || 'default';
+      this.setState({
+        alignment,
+        position,
+      });
+    } ,0);
+
   }
 
   onAlignmentChange = (alignment) => {
@@ -63,6 +85,7 @@ export default class AlignmentTool extends React.Component {
       <div
         className={styles.alignmentTool}
         style={this.state.position}
+        ref={(toolbar) => { this.toolbar = toolbar; }}
       >
         {defaultButtons.map((Button, index) => (
           <Button


### PR DESCRIPTION
We fixed the positioning of the inline toolbar a while ago to work well with relative parents, but the alignment plugin toolbar still had the same problem. So I changed the positioning logic of the alignment plugin to work the same way. 