### PR TITLE
Do not openDropdown in componentWillReceiveProps

### DIFF
--- a/draft-js-mention-plugin/src/MentionSuggestions/index.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/index.js
@@ -41,9 +41,6 @@ export default class MentionSuggestions extends Component {
     if (nextProps.suggestions.size === 0 && this.state.isActive) {
       this.closeDropdown();
     }
-    if (nextProps.suggestions.size >= 1 && !this.state.isActive) {
-      this.openDropdown();
-    }
   }
 
   componentDidUpdate = (prevProps, prevState) => {


### PR DESCRIPTION
Hi,

I've removed lines calling `MentionSuggestions#openDropdown` in `componentWillReceiveProps` that caused unintended method binding.

This caused a bug that selects candidate on hitting return key even if the dropdown was closed.

![apr-24-2017 22-26-18](https://cloud.githubusercontent.com/assets/18631/25339280/1be0506e-293d-11e7-8e53-b1a6a7708ab7.gif)
