### PR TITLE
Add feature to inline toolbar that allows for children to override the content.

### DIFF
--- a/docs/client/components/pages/InlineToolbar/CustomInlineToolbarEditor/editorStyles.css
+++ b/docs/client/components/pages/InlineToolbar/CustomInlineToolbarEditor/editorStyles.css
@@ -12,3 +12,23 @@
 .editor :global(.public-DraftEditor-content) {
   min-height: 140px;
 }
+
+.headlineButtonWrapper {
+  display: inline-block;
+}
+
+.headlineButton {
+  background: #fbfbfb;
+  color: #888;
+  font-size: 18px;
+  border: 0;
+  padding-top: 5px;
+  vertical-align: bottom;
+  height: 34px;
+  width: 36px;
+}
+
+.headlineButton:hover,
+.headlineButton:focus {
+  background: #f3f3f3;
+}

--- a/docs/client/components/pages/InlineToolbar/CustomInlineToolbarEditor/index.js
+++ b/docs/client/components/pages/InlineToolbar/CustomInlineToolbarEditor/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-multi-comp */
 import React, { Component } from 'react';
 // eslint-disable-next-line import/no-unresolved
 import Editor, { createEditorStateWithText } from 'draft-js-plugins-editor';
@@ -18,6 +19,51 @@ import {
 } from 'draft-js-buttons'; // eslint-disable-line import/no-unresolved
 import editorStyles from './editorStyles.css';
 
+
+class HeadlinesPicker extends Component {
+  componentDidMount() {
+    setTimeout(() => { window.addEventListener('click', this.onWindowClick); });
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('click', this.onWindowClick);
+  }
+
+  onWindowClick = () =>
+    // Call `onOverrideContent` again with `undefined`
+    // so the toolbar can show its regular content again.
+    this.props.onOverrideContent(undefined);
+
+  render() {
+    const buttons = [HeadlineOneButton, HeadlineTwoButton, HeadlineThreeButton];
+    return (
+      <div>
+        {buttons.map((Button, i) => // eslint-disable-next-line
+          <Button key={i} {...this.props} />
+        )}
+      </div>
+    );
+  }
+}
+
+class HeadlinesButton extends Component {
+  onClick = () =>
+    // A button can call `onOverrideContent` to replace the content
+    // of the toolbar. This can be useful for displaying sub
+    // menus or requesting additional information from the user.
+    this.props.onOverrideContent(HeadlinesPicker);
+
+  render() {
+    return (
+      <div className={editorStyles.headlineButtonWrapper}>
+        <button onClick={this.onClick} className={editorStyles.headlineButton}>
+          H
+        </button>
+      </div>
+    );
+  }
+}
+
 const inlineToolbarPlugin = createInlineToolbarPlugin({
   structure: [
     BoldButton,
@@ -25,13 +71,11 @@ const inlineToolbarPlugin = createInlineToolbarPlugin({
     UnderlineButton,
     CodeButton,
     Separator,
-    HeadlineOneButton,
-    HeadlineTwoButton,
-    HeadlineThreeButton,
+    HeadlinesButton,
     UnorderedListButton,
     OrderedListButton,
     BlockquoteButton,
-    CodeBlockButton,
+    CodeBlockButton
   ]
 });
 const { InlineToolbar } = inlineToolbarPlugin;

--- a/draft-js-inline-toolbar-plugin/src/components/Toolbar/__test__/Toolbar.js
+++ b/draft-js-inline-toolbar-plugin/src/components/Toolbar/__test__/Toolbar.js
@@ -1,0 +1,57 @@
+import React, { Component } from 'react';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
+import Toolbar from '../index';
+
+describe('Toolbar', () => {
+  it('allows children to override the content', (done) => {
+    const structure = [class Child extends Component {
+      componentDidMount() {
+        setTimeout(() => {
+          this.props.onOverrideContent(() => {
+            setTimeout(() => {
+              this.props.onOverrideContent(undefined);
+            });
+            return <span className="overridden" />;
+          });
+        });
+      }
+      render() {
+        return <span className="initial" />;
+      }
+    }];
+
+    const theme = { toolbarStyles: {} };
+
+    const store = {
+      subscribeToItem() {},
+      unsubscribeFromItem() {},
+      getItem: (name) => ({
+        getEditorState: () => ({
+          getSelection: () => ({ isCollapsed: () => true })
+        })
+      }[name])
+    };
+
+    const wrapper = mount(
+      <Toolbar
+        store={store}
+        theme={theme}
+        structure={structure}
+      />
+    );
+
+    expect(wrapper.find('.initial').length).to.equal(1);
+
+    setTimeout(() => {
+      expect(wrapper.find('.initial').length).to.equal(0);
+      expect(wrapper.find('.overridden').length).to.equal(1);
+
+      setTimeout(() => {
+        expect(wrapper.find('.initial').length).to.equal(1);
+        expect(wrapper.find('.overridden').length).to.equal(0);
+        done();
+      });
+    });
+  });
+});

--- a/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
+++ b/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
@@ -47,45 +47,23 @@ export default class Toolbar extends React.Component {
   onOverrideContent = (overrideContent) =>
     this.setState({ overrideContent });
 
-  onVisibilityChanged = (isVisible) => {
+  onSelectionChanged = () => {
     // need to wait a tick for window.getSelection() to be accurate
     // when focusing editor with already present selection
     setTimeout(() => {
-      let position;
-      if (isVisible) {
-        const relativeParent = getRelativeParent(this.toolbar.parentElement);
-        const relativeRect = relativeParent ? relativeParent.getBoundingClientRect() : document.body.getBoundingClientRect();
-        const selectionRect = getVisibleSelectionRect(window);
-        position = {
-          top: (selectionRect.top - relativeRect.top) - toolbarHeight,
-          left: (selectionRect.left - relativeRect.left) + (selectionRect.width / 2),
-          transform: 'translate(-50%) scale(1)',
-          transition: 'transform 0.15s cubic-bezier(.3,1.2,.2,1)',
-        };
-      } else {
-        position = { transform: 'translate(-50%) scale(0)' };
-      }
+      if (!this.toolbar) return;
+      const relativeParent = getRelativeParent(this.toolbar.parentElement);
+      const relativeRect = (relativeParent || document.body).getBoundingClientRect();
+      const selectionRect = getVisibleSelectionRect(window);
+
+      if (!selectionRect) return;
+
+      const position = {
+        top: (selectionRect.top - relativeRect.top) - toolbarHeight,
+        left: (selectionRect.left - relativeRect.left) + (selectionRect.width / 2),
+      };
       this.setState({ position });
-    }, 0);
-
-    // Revert back to the regular structure when the toolbar gets hidden
-    if (!isVisible && this.state.overrideContent) {
-      this.setState({ overrideContent: undefined });
-    }
-  }
-
-  onSelectionChanged = () => {
-    const relativeParent = getRelativeParent(this.toolbar.parentElement);
-    const relativeRect = (relativeParent || document.body).getBoundingClientRect();
-    const selectionRect = getVisibleSelectionRect(window);
-
-    if (!selectionRect) return;
-
-    const position = {
-      top: (selectionRect.top - relativeRect.top) - toolbarHeight,
-      left: (selectionRect.left - relativeRect.left) + (selectionRect.width / 2),
-    };
-    this.setState({ position });
+    });
   };
 
   getStyle() {

--- a/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
+++ b/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
@@ -74,7 +74,7 @@ export default class Toolbar extends React.Component {
     }
   }
 
-  onSelectionChanged = (selection) => {
+  onSelectionChanged = () => {
     const relativeParent = getRelativeParent(this.toolbar.parentElement);
     const relativeRect = (relativeParent || document.body).getBoundingClientRect();
     const selectionRect = getVisibleSelectionRect(window);

--- a/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
+++ b/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
@@ -22,15 +22,30 @@ export default class Toolbar extends React.Component {
 
   state = {
     isVisible: false,
+    position: undefined,
+
+    /**
+     * If this is set, the toolbar will render this instead of the regular
+     * structure and will also be shown when the editor loses focus. It's
+     * the responsibility of the callee to call this function again with
+     * `undefined` to show the regular structure again or hide the toolbar
+     * if the editor doesn't have focus anymore.
+     *
+     * @type {Component}
+     */
+    overrideContent: undefined
   }
 
   componentWillMount() {
-    this.props.store.subscribeToItem('isVisible', this.onVisibilityChanged);
+    this.props.store.subscribeToItem('selection', this.onSelectionChanged);
   }
 
   componentWillUnmount() {
-    this.props.store.unsubscribeFromItem('isVisible', this.onVisibilityChanged);
+    this.props.store.unsubscribeFromItem('selection', this.onSelectionChanged);
   }
+
+  onOverrideContent = (overrideContent) =>
+    this.setState({ overrideContent });
 
   onVisibilityChanged = (isVisible) => {
     // need to wait a tick for window.getSelection() to be accurate
@@ -52,24 +67,68 @@ export default class Toolbar extends React.Component {
       }
       this.setState({ position });
     }, 0);
+
+    // Revert back to the regular structure when the toolbar gets hidden
+    if (!isVisible && this.state.overrideContent) {
+      this.setState({ overrideContent: undefined });
+    }
   }
 
+  onSelectionChanged = (selection) => {
+    const relativeParent = getRelativeParent(this.toolbar.parentElement);
+    const relativeRect = (relativeParent || document.body).getBoundingClientRect();
+    const selectionRect = getVisibleSelectionRect(window);
+
+    if (!selectionRect) return;
+
+    const position = {
+      top: (selectionRect.top - relativeRect.top) - toolbarHeight,
+      left: (selectionRect.left - relativeRect.left) + (selectionRect.width / 2),
+    };
+    this.setState({ position });
+  };
+
+  getStyle() {
+    const { store } = this.props;
+    const { overrideContent, position } = this.state;
+    const selection = store.getItem('getEditorState')().getSelection();
+    const isVisible = !selection.isCollapsed() || overrideContent;
+    const style = { ...position };
+
+    if (isVisible) {
+      style.transform = 'translate(-50%) scale(1)';
+      style.transition = 'transform 0.15s cubic-bezier(.3,1.2,.2,1)';
+    } else {
+      style.transform = 'translate(-50%) scale(0)';
+    }
+
+    return style;
+  }
+
+  handleToolbarRef = (node) => {
+    this.toolbar = node;
+  };
+
   render() {
-    const { theme, store } = this.props;
+    const { theme, store, structure } = this.props;
+    const { overrideContent: OverrideContent } = this.state;
+    const childrenProps = {
+      theme: theme.buttonStyles,
+      getEditorState: store.getItem('getEditorState'),
+      setEditorState: store.getItem('setEditorState'),
+      onOverrideContent: this.onOverrideContent
+    };
+
     return (
       <div
         className={theme.toolbarStyles.toolbar}
-        style={this.state.position}
-        ref={(toolbar) => { this.toolbar = toolbar; }}
+        style={this.getStyle()}
+        ref={this.handleToolbarRef}
       >
-        {this.props.structure.map((Component, index) => (
-          <Component
-            key={index}
-            theme={theme.buttonStyles}
-            getEditorState={store.getItem('getEditorState')}
-            setEditorState={store.getItem('setEditorState')}
-          />
-        ))}
+        {OverrideContent
+          ? <OverrideContent {...childrenProps} />
+          : structure.map((Component, index) =>
+            <Component key={index} {...childrenProps} />)}
       </div>
     );
   }

--- a/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
+++ b/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
@@ -26,11 +26,7 @@ export default class Toolbar extends React.Component {
 
     /**
      * If this is set, the toolbar will render this instead of the regular
-     * structure and will also be shown when the editor loses focus. It's
-     * the responsibility of the callee to call this function again with
-     * `undefined` to show the regular structure again or hide the toolbar
-     * if the editor doesn't have focus anymore.
-     *
+     * structure and will also be shown when the editor loses focus.
      * @type {Component}
      */
     overrideContent: undefined
@@ -44,6 +40,12 @@ export default class Toolbar extends React.Component {
     this.props.store.unsubscribeFromItem('selection', this.onSelectionChanged);
   }
 
+  /**
+   * This can be called by a child in order to render custom content instead
+   * of the regular structure. It's the responsibility of the callee to call
+   * this function again with `undefined` in order to reset `overrideContent`.
+   * @param {Component} overrideContent
+   */
   onOverrideContent = (overrideContent) =>
     this.setState({ overrideContent });
 

--- a/draft-js-inline-toolbar-plugin/src/index.js
+++ b/draft-js-inline-toolbar-plugin/src/index.js
@@ -41,12 +41,7 @@ export default (config = {}) => {
     },
     // Re-Render the text-toolbar on selection change
     onChange: (editorState) => {
-      const selection = editorState.getSelection();
-      if (selection.getHasFocus() && !selection.isCollapsed()) {
-        store.updateItem('isVisible', true);
-      } else {
-        store.updateItem('isVisible', false);
-      }
+      store.updateItem('selection', editorState.getSelection());
       return editorState;
     },
     InlineToolbar: decorateComponentWithProps(Toolbar, toolbarProps),


### PR DESCRIPTION
<!--
Please check out Contributing Guidelines. By following this template you help us to review your code.
https://github.com/draft-js-plugins/draft-js-plugins/blob/master/CONTRIBUTING.md
-->

## Implementation

This allows buttons of the inline toolbar to render dynamic content into the toolbar. An example is the ability to add links directly from the toolbar (see demo).

This could be a first step for a robust plugin to add links. Currently we have #610, but that touches quite a few files and got released in a [separate repository](https://github.com/vacenz/last-draft-js-plugins) anyway. This PR is inspired by the implementation of the toolbar plugin over there, but is agnostic to what kind of content can be rendered in the toolbar.

<!--
Briefly describe the feature or fix
-->

## Demo

![draft](https://cloud.githubusercontent.com/assets/4038316/25861864/4f61447a-34e6-11e7-9018-10c1be9cc42f.gif)

<!--
Please add a recorded gif and ideally code example how to test the feature or reproduce the bug.
-->

In this case, I've got a `AddLinksButton` component in the `structure` for the toolbar. When the button is clicked, it calls `this.props.onOverrideContent(AddLinkForm);` to render the form. The form can use the same method for reverting back to the normal state.

## Use-case

<!--
In case this is a new feature, property or function that is exposed please describe why you need it.
-->

I needed this to implement adding links directly from the toolbar.

## Allow editors for maintainers

- [x] Enable "Allow edits from maintainers" for this PR

## TODO
- [x] Add a test
- [x] Add docs
