### PR TITLE
Fix positioning of side toolbar in IE11.

### DIFF
--- a/draft-js-side-toolbar-plugin/src/components/Toolbar/index.js
+++ b/draft-js-side-toolbar-plugin/src/components/Toolbar/index.js
@@ -38,9 +38,10 @@ export default class Toolbar extends React.Component {
       const node = document.querySelectorAll(`[data-offset-key="${offsetKey}"]`)[0];
       const top = node.getBoundingClientRect().top;
       const editor = this.props.store.getItem('getEditorRef')().refs.editor;
+      const scrollY = window.scrollY == null ? window.pageYOffset : window.scrollY;
       this.setState({
         position: {
-          top: (top + window.scrollY),
+          top: (top + scrollY),
           left: editor.getBoundingClientRect().left - 80,
           transform: 'scale(1)',
           transition: 'transform 0.15s cubic-bezier(.3,1.2,.2,1)',


### PR DESCRIPTION
<!--
Please check out Contributing Guidelines. By following this template you help us to review your code.
https://github.com/draft-js-plugins/draft-js-plugins/blob/master/CONTRIBUTING.md
-->

The positioning of the side toolbar was broken in IE11, as `window.scrollY` isn't available there. This fixes the issue.