### PR TITLE
Fix the Undo/Redo Button initialize issue

### DIFF
--- a/draft-js-undo-plugin/src/RedoButton/index.js
+++ b/draft-js-undo-plugin/src/RedoButton/index.js
@@ -19,7 +19,7 @@ class RedoButton extends Component {
     const combinedClassName = unionClassNames(theme.redo, className);
     return (
       <button
-        disabled={this.props.store.getEditorState().getRedoStack().isEmpty()}
+        disabled={!this.props.store || this.props.store.getEditorState().getRedoStack().isEmpty()}
         onClick={this.onClick}
         className={combinedClassName}
       >

--- a/draft-js-undo-plugin/src/UndoButton/index.js
+++ b/draft-js-undo-plugin/src/UndoButton/index.js
@@ -19,7 +19,7 @@ class UndoButton extends Component {
     const combinedClassName = unionClassNames(theme.undo, className);
     return (
       <button
-        disabled={this.props.store.getEditorState().getUndoStack().isEmpty()}
+        disabled={!this.props.store || this.props.store.getEditorState().getUndoStack().isEmpty()}
         onClick={this.onClick}
         className={combinedClassName}
       >


### PR DESCRIPTION
UNdo/Redo Button is disabled when => store is not initialized, or redo stack is empty.

<!--
Please check out Contributing Guidelines. By following this template you help us to review your code.
https://github.com/draft-js-plugins/draft-js-plugins/blob/master/CONTRIBUTING.md
-->

## Implementation

Added an existence check of store to the Undo/Redo button
<!--
Briefly describe the feature or fix
-->

## Demo

https://github.com/draft-js-plugins/draft-js-plugins/issues/718

<!--
Please add a recorded gif and ideally code example how to test the feature or reproduce the bug.
-->

## Use-case

<!--
In case this is a new feature, property or function that is exposed please describe why you need it.
-->

## Allow editors for maintainers

- [ ] Enable "Allow edits from maintainers" for this PR
