### PR TITLE
add react-portal to emojis and mentions

### DIFF
--- a/docs/client/components/pages/Emoji/SimpleEmojiEditor/index.js
+++ b/docs/client/components/pages/Emoji/SimpleEmojiEditor/index.js
@@ -27,7 +27,7 @@ export default class SimpleEmojiEditor extends Component {
 
   render() {
     return (
-      <div style={{position: 'relative', overflow: 'hidden'}}>
+      <div style={{ position: 'relative', overflow: 'hidden' }}>
         <div className={editorStyles.editor} onClick={this.focus}>
           <Editor
             editorState={this.state.editorState}

--- a/docs/client/components/pages/Emoji/SimpleEmojiEditor/index.js
+++ b/docs/client/components/pages/Emoji/SimpleEmojiEditor/index.js
@@ -27,7 +27,7 @@ export default class SimpleEmojiEditor extends Component {
 
   render() {
     return (
-      <div>
+      <div style={{position: 'relative', overflow: 'hidden'}}>
         <div className={editorStyles.editor} onClick={this.focus}>
           <Editor
             editorState={this.state.editorState}

--- a/docs/client/components/pages/Mention/SimpleMentionEditor/index.js
+++ b/docs/client/components/pages/Mention/SimpleMentionEditor/index.js
@@ -38,7 +38,7 @@ export default class SimpleMentionEditor extends Component {
 
   render() {
     return (
-      <div className={editorStyles.editor} onClick={this.focus}>
+      <div className={editorStyles.editor} onClick={this.focus} style={{ position: 'relative', overflow: 'hidden' }}>
         <Editor
           editorState={this.state.editorState}
           onChange={this.onChange}

--- a/draft-js-emoji-plugin/package.json
+++ b/draft-js-emoji-plugin/package.json
@@ -35,11 +35,11 @@
     "emojione": "^2.2.7",
     "find-with-regex": "^1.0.2",
     "immutable": "~3.7.4",
-    "prop-types": "^15.5.8",
     "lodash.keys": "^4.2.0",
+    "prop-types": "^15.5.8",
     "react-custom-scrollbars": "^4.1.1",
-    "react-portal": "^3.1.0",
     "react-icons": "^2.2.3",
+    "react-portal": "^3.1.0",
     "to-style": "^1.3.3",
     "union-class-names": "^1.0.0"
   },

--- a/draft-js-emoji-plugin/package.json
+++ b/draft-js-emoji-plugin/package.json
@@ -38,6 +38,7 @@
     "prop-types": "^15.5.8",
     "lodash.keys": "^4.2.0",
     "react-custom-scrollbars": "^4.1.1",
+    "react-portal": "^3.1.0",
     "react-icons": "^2.2.3",
     "to-style": "^1.3.3",
     "union-class-names": "^1.0.0"

--- a/draft-js-emoji-plugin/src/components/EmojiSuggestions/index.js
+++ b/draft-js-emoji-plugin/src/components/EmojiSuggestions/index.js
@@ -4,7 +4,7 @@ import Entry from './Entry';
 import addEmoji, { Mode as AddEmojiMode } from '../../modifiers/addEmoji';
 import getSearchText from '../../utils/getSearchText';
 import decodeOffsetKey from '../../utils/decodeOffsetKey';
-
+import Portal from 'react-portal';
 
 export default class EmojiSuggestions extends Component {
 
@@ -275,33 +275,35 @@ export default class EmojiSuggestions extends Component {
       ...restProps,
     } = this.props;
     return (
-      <div
-        {...restProps}
-        className={theme.emojiSuggestions}
-        role="listbox"
-        id={`emojis-list-${this.key}`}
-        ref={(element) => {
-          this.popover = element;
-        }}
-      >
-        {
-          this.filteredEmojis.map((emoji, index) => (
-            <Entry
-              key={emoji}
-              onEmojiSelect={this.onEmojiSelect}
-              onEmojiFocus={this.onEmojiFocus}
-              isFocused={this.state.focusedOptionIndex === index}
-              emoji={emoji}
-              index={index}
-              id={`emoji-option-${this.key}-${index}`}
-              theme={theme}
-              imagePath={imagePath}
-              imageType={imageType}
-              cacheBustParam={cacheBustParam}
-            />
-          )).toJS()
-        }
-      </div>
+      <Portal isOpened>
+        <div
+          {...restProps}
+          className={theme.emojiSuggestions}
+          role="listbox"
+          id={`emojis-list-${this.key}`}
+          ref={(element) => {
+            this.popover = element;
+          }}
+        >
+          {
+            this.filteredEmojis.map((emoji, index) => (
+              <Entry
+                key={emoji}
+                onEmojiSelect={this.onEmojiSelect}
+                onEmojiFocus={this.onEmojiFocus}
+                isFocused={this.state.focusedOptionIndex === index}
+                emoji={emoji}
+                index={index}
+                id={`emoji-option-${this.key}-${index}`}
+                theme={theme}
+                imagePath={imagePath}
+                imageType={imageType}
+                cacheBustParam={cacheBustParam}
+              />
+            )).toJS()
+          }
+        </div>
+      </Portal>
     );
   }
 }

--- a/draft-js-emoji-plugin/src/components/EmojiSuggestions/index.js
+++ b/draft-js-emoji-plugin/src/components/EmojiSuggestions/index.js
@@ -1,10 +1,10 @@
 import React, { Component } from 'react';
 import { genKey } from 'draft-js';
+import Portal from 'react-portal';
 import Entry from './Entry';
 import addEmoji, { Mode as AddEmojiMode } from '../../modifiers/addEmoji';
 import getSearchText from '../../utils/getSearchText';
 import decodeOffsetKey from '../../utils/decodeOffsetKey';
-import Portal from 'react-portal';
 
 export default class EmojiSuggestions extends Component {
 

--- a/draft-js-mention-plugin/package.json
+++ b/draft-js-mention-plugin/package.json
@@ -34,8 +34,9 @@
     "decorate-component-with-props": "^1.0.2",
     "find-with-regex": "^1.0.2",
     "immutable": "~3.7.4",
-    "prop-types": "^15.5.8",
     "lodash.escaperegexp": "^4.1.2",
+    "prop-types": "^15.5.8",
+    "react-portal": "^3.1.0",
     "union-class-names": "^1.0.0"
   },
   "peerDependencies": {

--- a/draft-js-mention-plugin/src/MentionSuggestions/__test__/index.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/__test__/index.js
@@ -82,6 +82,7 @@ describe('MentionSuggestions Component', () => {
   });
 
   it('The popoverComponent prop changes the popover component', () => {
+    // eslint-disable-next-line no-unused-vars
     const PopoverComponent = ({ children, closePortal, popoverRef, ...props }) => (
       <div data-test-test ref={popoverRef} {...props}>{children}</div>
     );

--- a/draft-js-mention-plugin/src/MentionSuggestions/__test__/index.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/__test__/index.js
@@ -82,21 +82,24 @@ describe('MentionSuggestions Component', () => {
   });
 
   it('The popoverComponent prop changes the popover component', () => {
-    const PopoverComponent = ({ children, ...props }) => (
-      <div data-test-test {...props}>{children}</div>
+    const PopoverComponent = ({ children, closePortal, popoverRef, ...props }) => (
+      <div data-test-test ref={popoverRef} {...props}>{children}</div>
     );
 
     const props = defaultProps();
-    props.popoverComponent = <PopoverComponent />;
+    props.popoverComponent = PopoverComponent;
     const suggestions = mount(
       <MentionSuggestions {...props} />
     );
 
     suggestions.instance().openDropdown();
-    expect(suggestions.find('[data-test-test]')).to.have.length(1);
+    const { popover } = suggestions.instance();
+    // React 16 has native support for portals, so using _currentElement is safe until then
+    const componentProps = popover[Object.keys(popover)[0]]._currentElement.props; // eslint-disable-line
+    expect(componentProps['data-test-test']).to.equal(true);
   });
 
-  it('The popoverComponent recieves the children', () => {
+  it('The popoverComponent receives the children', () => {
     let called = false;
     const PopoverComponent = ({ children, ...props }) => {
       called = true;
@@ -105,7 +108,7 @@ describe('MentionSuggestions Component', () => {
     };
 
     const props = defaultProps();
-    props.popoverComponent = <PopoverComponent />;
+    props.popoverComponent = PopoverComponent;
     const suggestions = mount(
       <MentionSuggestions {...props} />
     );
@@ -121,6 +124,6 @@ describe('MentionSuggestions Component', () => {
     );
 
     suggestions.instance().openDropdown();
-    expect(suggestions.find('div[data-findme]')).to.have.length(1);
+    expect(suggestions.instance().popover.constructor.name).to.equal('HTMLDivElement');
   });
 });

--- a/draft-js-mention-plugin/src/MentionSuggestions/index.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/index.js
@@ -9,6 +9,10 @@ import decodeOffsetKey from '../utils/decodeOffsetKey';
 import getSearchText from '../utils/getSearchText';
 import defaultEntryComponent from './Entry/defaultEntryComponent';
 
+const DefaultPopoverComponent = ({children, closePortal, popoverRef, ...props}) => (
+  <div ref={popoverRef} {...props}>{children}</div>
+);
+
 export default class MentionSuggestions extends Component {
 
   static propTypes = {
@@ -305,7 +309,7 @@ export default class MentionSuggestions extends Component {
 
     const {
       entryComponent,
-      popoverComponent = <div />,
+      popoverComponent: Popover = DefaultPopoverComponent,
       onClose, // eslint-disable-line no-unused-vars
       onOpen, // eslint-disable-line no-unused-vars
       onAddMention, // eslint-disable-line no-unused-vars, no-shadow
@@ -321,36 +325,30 @@ export default class MentionSuggestions extends Component {
       mentionPrefix, // eslint-disable-line no-unused-vars
       ...elementProps
     } = this.props;
-
-    const children = React.cloneElement(
-      popoverComponent,
-      {
-        ...elementProps,
-        className: theme.mentionSuggestions,
-        role: 'listbox',
-        id: `mentions-list-${this.key}`,
-        ref: (element) => {
-          this.popover = element;
-        },
-      },
-      this.props.suggestions.map((mention, index) => (
-        <Entry
-          key={mention.has('id') ? mention.get('id') : mention.get('name')}
-          onMentionSelect={this.onMentionSelect}
-          onMentionFocus={this.onMentionFocus}
-          isFocused={this.state.focusedOptionIndex === index}
-          mention={mention}
-          index={index}
-          id={`mention-option-${this.key}-${index}`}
-          theme={theme}
-          searchValue={this.lastSearchValue}
-          entryComponent={entryComponent || defaultEntryComponent}
-        />
-      )).toJS()
-    );
     return (
       <Portal isOpened>
-        {children}
+        <Popover
+          {...elementProps}
+          className={theme.mentionSuggestions}
+          role="listbox"
+          id={`mentions-list-${this.key}`}
+          popoverRef={(el) => { this.popover = el; }}
+        >
+          {this.props.suggestions.map((mention, index) => (
+            <Entry
+              key={mention.has('id') ? mention.get('id') : mention.get('name')}
+              onMentionSelect={this.onMentionSelect}
+              onMentionFocus={this.onMentionFocus}
+              isFocused={this.state.focusedOptionIndex === index}
+              mention={mention}
+              index={index}
+              id={`mention-option-${this.key}-${index}`}
+              theme={theme}
+              searchValue={this.lastSearchValue}
+              entryComponent={entryComponent || defaultEntryComponent}
+            />
+          )).toJS()}
+        </Popover>
       </Portal>
     );
   }

--- a/draft-js-mention-plugin/src/MentionSuggestions/index.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/index.js
@@ -9,7 +9,8 @@ import decodeOffsetKey from '../utils/decodeOffsetKey';
 import getSearchText from '../utils/getSearchText';
 import defaultEntryComponent from './Entry/defaultEntryComponent';
 
-const DefaultPopoverComponent = ({children, closePortal, popoverRef, ...props}) => (
+// eslint-disable-next-line no-unused-vars
+const DefaultPopoverComponent = ({ children, closePortal, popoverRef, ...props }) => (
   <div ref={popoverRef} {...props}>{children}</div>
 );
 

--- a/draft-js-mention-plugin/src/MentionSuggestions/index.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/index.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { genKey } from 'draft-js';
 import { List } from 'immutable';
+import Portal from 'react-portal';
 import Entry from './Entry';
 import addMention from '../modifiers/addMention';
 import decodeOffsetKey from '../utils/decodeOffsetKey';
@@ -318,16 +319,19 @@ export default class MentionSuggestions extends Component {
       positionSuggestions, // eslint-disable-line no-unused-vars
       mentionTrigger, // eslint-disable-line no-unused-vars
       mentionPrefix, // eslint-disable-line no-unused-vars
-      ...elementProps } = this.props;
+      ...elementProps
+    } = this.props;
 
-    return React.cloneElement(
+    const children = React.cloneElement(
       popoverComponent,
       {
         ...elementProps,
         className: theme.mentionSuggestions,
         role: 'listbox',
         id: `mentions-list-${this.key}`,
-        ref: (element) => { this.popover = element; },
+        ref: (element) => {
+          this.popover = element;
+        },
       },
       this.props.suggestions.map((mention, index) => (
         <Entry
@@ -343,6 +347,11 @@ export default class MentionSuggestions extends Component {
           entryComponent={entryComponent || defaultEntryComponent}
         />
       )).toJS()
+    );
+    return (
+      <Portal isOpened>
+        {children}
+      </Portal>
     );
   }
 }

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "react-custom-scrollbars": "^4.1.1",
     "react-dom": "^15.5.4",
     "react-icons": "^2.2.3",
+    "react-portal": "^3.1.0",
     "tlds": "^1.183.0",
     "to-style": "^1.3.3",
     "union-class-names": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5684,6 +5684,12 @@ react-icons@^2.2.3:
   dependencies:
     react-icon-base "2.0.7"
 
+react-portal@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/react-portal/-/react-portal-3.1.0.tgz#865c44fb72a1da106c649206936559ce891ee899"
+  dependencies:
+    prop-types "^15.5.8"
+
 react-proxy@^1.1.7:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/react-proxy/-/react-proxy-1.1.8.tgz#9dbfd9d927528c3aa9f444e4558c37830ab8c26a"


### PR DESCRIPTION
## Implementation

In #341 you said you were open to a PR, so here's a minimal example of what is possible when we use a portal to break out of the DOM tree. 

## Demo

Nothing fancy to show, it looks the same!

## Use-case

As you can see in the example, even though the parent div is `position: relative` & `overflow: hidden`, the full menu still shows. This is the same strategy that facebook uses. If we don't make this change, then a designer could very easily bork the entire menu by simply changing the styles of a nearby component. A good summary of this issue (albeit with a different conclusion) is here: https://medium.com/@david.gilbertson/modals-in-react-f6c3ff9f4701. Ideally, we can switch over all plugins that produce a modal.

If closing animations, multiple menus, or more complex logic is required, we could switch to a more complex portal component that I made (https://github.com/mattkrick/react-portal-hoc), but as the name implies that is a higher-order component & I figured I'd start simple.


### NOTE BREAKING CHANGE FOR `popoverComponent`
The current implementation of `popoverComponent` accepts a component _instance_. 
This is troubling for a couple reasons:
- The instance _must_ be an `HTMLElement` (span, div, etc.)  
- The instance _must_ handle the props passed into it & any extra props in future versions will cause a breaking change since they may not be suitable for the element
- the instance _must_ handle `ref` appropriately, otherwise the modal won't appear
- The `ref` is may be stale & set to `null`. This makes portals impossible & was the main reason for fixing it

Reading the history of the feature, I see it's for using material-ui. Unfortunately, as it is currently written, this is about the only 3rd party package it is useful with because most others don't expect a `ref`.
The path to upgrade would look something like this:
```
const popoverComponent = ({popoverRef, children, closePortal, ...props}) => <Paper ref={props.popoverRef} {...props}>{children}</Paper>
```

With that small tweak, it'll work for everybody! (portals included)