### PR TITLE
Check that store.getEditorState exists in UndoButton and RedoButton

### DIFF
--- a/draft-js-undo-plugin/src/RedoButton/index.js
+++ b/draft-js-undo-plugin/src/RedoButton/index.js
@@ -19,7 +19,11 @@ class RedoButton extends Component {
     const combinedClassName = unionClassNames(theme.redo, className);
     return (
       <button
-        disabled={!this.props.store || this.props.store.getEditorState().getRedoStack().isEmpty()}
+        disabled={
+          !this.props.store ||
+          !this.props.store.getEditorState ||
+          this.props.store.getEditorState().getRedoStack().isEmpty()
+        }
         onClick={this.onClick}
         className={combinedClassName}
       >

--- a/draft-js-undo-plugin/src/UndoButton/index.js
+++ b/draft-js-undo-plugin/src/UndoButton/index.js
@@ -19,7 +19,11 @@ class UndoButton extends Component {
     const combinedClassName = unionClassNames(theme.undo, className);
     return (
       <button
-        disabled={!this.props.store || this.props.store.getEditorState().getUndoStack().isEmpty()}
+        disabled={
+          !this.props.store ||
+          !this.props.store.getEditorState ||
+          this.props.store.getEditorState().getUndoStack().isEmpty()
+        }
         onClick={this.onClick}
         className={combinedClassName}
       >


### PR DESCRIPTION
This fixes #718. 

Checks that `this.props.store.getEditorState` actually exists in `UndoButton` and `RedoButton`.
Now `UndoButton` and `RedoButton` can be placed above the editor as they're no longer dependent on `store.getEditorState` existing on first render.