### PR TITLE
Add sass-loader to emoji-plugin webpack config

### DIFF
--- a/docs/webpack.config.base.js
+++ b/docs/webpack.config.base.js
@@ -81,7 +81,7 @@ module.exports = {
           path.join(__dirname, 'client/components'),
         ],
       }, {
-        test: /\.(scss|sass)/,
+        test: /\.(scss|sass)$/,
         loader: ExtractTextPlugin.extract({
           fallback: 'style-loader',
           use: 'css-loader?modules&importLoaders=1&localIdentName=[local]___[hash:base64:5]!postcss-loader!sass-loader',

--- a/draft-js-emoji-plugin/webpack.config.js
+++ b/draft-js-emoji-plugin/webpack.config.js
@@ -14,6 +14,13 @@ module.exports = {
         test: /\.css$/,
         loader: ExtractTextPlugin.extract({ fallback: 'style-loader', use: 'css-loader?modules&importLoaders=1&localIdentName=draftJsEmojiPlugin__[local]__[hash:base64:5]!postcss-loader' }),
       },
+      {
+        test: /\.(scss|sass)$/,
+        loader: ExtractTextPlugin.extract({
+          fallback: 'style-loader',
+          use: 'css-loader?modules&importLoaders=1&localIdentName=draftJsEmojiPlugin__[local]__[hash:base64:5]!postcss-loader!sass-loader',
+        }),
+      }
     ],
   },
 


### PR DESCRIPTION
Fix issue https://github.com/draft-js-plugins/draft-js-plugins/issues/748
Add `sass-loader` to `draft-js-emoji-plugin/webpack.config.js`