### PR TITLE
Remove duplicated entries in the changelog

### DIFF
--- a/draft-js-plugins-editor/CHANGELOG.md
+++ b/draft-js-plugins-editor/CHANGELOG.md
@@ -11,8 +11,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - `handlePastedText` now receives the arguments `(text, html, editorState, pluginFunctions)`
 - `handleBeforeInput` now receives the arguments `(chars, editorState, pluginFunctions)`
 - `handleReturn` now receives the arguments `(event, editorState, pluginFunctions)`
-- `handleBeforeInput` now receives the arguments `(chars, editorState, pluginFunctions)`
-- `handleBeforeInput` now receives the arguments `(chars, editorState, pluginFunctions)`
 - `onChange` & and all handlers now also receive: `getPlugins`, `getProps`, `getReadOnly`, `setReadOnly`, `getEditorRef`.
 - `defaultBlockRenderMap` option, by default is set to true. If set to false the defaultBlockRenderMap from Draft.js is not used as base for the generated blockRenderMap.
 - `decorators` option now allows custom implementations the [DraftDecoratorType](https://github.com/facebook/draft-js/blob/master/src/model/decorators/DraftDecoratorType.js) interface to be passed into the array along with the traditional CompositeDecorator objects


### PR DESCRIPTION
## Implementation
Remove the following duplicated entries. This sentence was appeared 3 times.

> `handleBeforeInput` now receives the arguments `(chars, editorState, pluginFunctions)`
