### PR TITLE
Add native art display possibility for emojis.

### DIFF
--- a/docs/client/components/pages/Emoji/index.js
+++ b/docs/client/components/pages/Emoji/index.js
@@ -70,6 +70,9 @@ export default class App extends Component {
             a background image. This creates consistency across all platforms while maintaining
             natural copy/pasting functionality.
           </p>
+          <p>
+            If useNativeArt parameter is used, emoji unicode characters are displayed. This enables displaying platform specific art for emojis.
+          </p>
           <Heading level={3}>Usage</Heading>
           <p>
             To use simply type <code>:</code> which will show an autocomplete with matching emojis.
@@ -295,6 +298,10 @@ export default class App extends Component {
           <div className={styles.paramBig}>
             <span className={styles.paramName}>toneSelectOpenDelay</span>
             <span>Time delay before opening tone select. (Default value is 500&nbsp;ms)</span>
+          </div>
+          <div className={styles.paramBig}>
+            <span className={styles.paramName}>useNativeArt</span>
+            <span>If set to <InlineCode code={'true'} />, uses host system art for emojis instead of EmojiOne art. Default value is <InlineCode code={'false'} />.</span>
           </div>
           <Heading level={3}>EmojiSuggestions</Heading>
           <div>

--- a/draft-js-emoji-plugin/src/components/Emoji/index.js
+++ b/draft-js-emoji-plugin/src/components/Emoji/index.js
@@ -1,22 +1,40 @@
 import React from 'react';
 import unionClassNames from 'union-class-names';
 import emojione from 'emojione';
+import emojiList from '../../utils/emojiList';
+import convertShortNameToUnicode from '../../utils/convertShortNameToUnicode';
 
-const Emoji = ({ theme = {}, cacheBustParam, imagePath, imageType, className, decoratedText, ...props }) => {
+const Emoji = ({ theme = {}, cacheBustParam, imagePath, imageType, className, decoratedText, useNativeArt, ...props }) => {
   const shortName = emojione.toShort(decoratedText);
-  // short name to image url code steal from emojione source code
-  const shortNameForImage = emojione.emojioneList[shortName].unicode[emojione.emojioneList[shortName].unicode.length - 1];
-  const backgroundImage = `url(${imagePath}${shortNameForImage}.${imageType}${cacheBustParam})`;
-  const combinedClassName = unionClassNames(theme.emoji, className);
-  return (
-    <span
-      className={combinedClassName}
-      title={emojione.toShort(decoratedText)}
-      style={{ backgroundImage }}
-    >
-      {props.children}
-    </span>
-  );
+
+  let emojiDisplay = null;
+  if (useNativeArt === true) {
+    const unicode = emojiList.list[shortName][0];
+    emojiDisplay = (
+      <span
+        title={emojione.toShort(decoratedText)}
+      >
+        {convertShortNameToUnicode(unicode)}
+      </span>
+    );
+  } else {
+    // short name to image url code steal from emojione source code
+    const shortNameForImage = emojione.emojioneList[shortName].unicode[emojione.emojioneList[shortName].unicode.length - 1];
+    const backgroundImage = `url(${imagePath}${shortNameForImage}.${imageType}${cacheBustParam})`;
+    const combinedClassName = unionClassNames(theme.emoji, className);
+
+    emojiDisplay = (
+      <span
+        className={combinedClassName}
+        title={emojione.toShort(decoratedText)}
+        style={{ backgroundImage }}
+      >
+        {props.children}
+      </span>
+    );
+  }
+
+  return emojiDisplay;
 };
 
 export default Emoji;

--- a/draft-js-emoji-plugin/src/components/EmojiSelect/Popover/Entry/index.js
+++ b/draft-js-emoji-plugin/src/components/EmojiSelect/Popover/Entry/index.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import emojione from 'emojione';
+import emojiList from '../../../../utils/emojiList';
+import convertShortNameToUnicode from '../../../../utils/convertShortNameToUnicode';
 
 export default class Entry extends Component {
   static propTypes = {
@@ -13,6 +15,7 @@ export default class Entry extends Component {
     checkMouseDown: PropTypes.func.isRequired,
     onEmojiSelect: PropTypes.func.isRequired,
     onEmojiMouseDown: PropTypes.func,
+    useNativeArt: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -54,11 +57,26 @@ export default class Entry extends Component {
   mouseDown = this.props.mouseDown;
 
   render() {
-    const { cacheBustParam, imagePath, imageType, theme = {}, emoji } = this.props;
-    // short name to image url code steal from emojione source code
-    const shortNameForImage = emojione.emojioneList[emoji].unicode[emojione.emojioneList[emoji].unicode.length - 1];
-    const fullImagePath = `${imagePath}${shortNameForImage}.${imageType}${cacheBustParam}`;
+    const { cacheBustParam, imagePath, imageType, theme = {}, emoji, useNativeArt } = this.props;
     const { isFocused } = this.state;
+
+    let emojiDisplay = null;
+    if (useNativeArt === true) {
+      const unicode = emojiList.list[emoji][0];
+      emojiDisplay = convertShortNameToUnicode(unicode);
+    } else {
+      // short name to image url code steal from emojione source code
+      const shortNameForImage = emojione.emojioneList[emoji].unicode[emojione.emojioneList[emoji].unicode.length - 1];
+      const fullImagePath = `${imagePath}${shortNameForImage}.${imageType}${cacheBustParam}`;
+      emojiDisplay = (
+        <img
+          src={fullImagePath}
+          className={theme.emojiSelectPopoverEntryIcon}
+          draggable={false}
+          role="presentation"
+        />
+      );
+    }
 
     return (
       <button
@@ -71,12 +89,7 @@ export default class Entry extends Component {
         onMouseUp={this.onMouseUp}
         ref={(element) => { this.button = element; }}
       >
-        <img
-          src={fullImagePath}
-          className={theme.emojiSelectPopoverEntryIcon}
-          draggable={false}
-          role="presentation"
-        />
+        {emojiDisplay}
       </button>
     );
   }

--- a/draft-js-emoji-plugin/src/components/EmojiSelect/Popover/Groups/Group/index.js
+++ b/draft-js-emoji-plugin/src/components/EmojiSelect/Popover/Groups/Group/index.js
@@ -13,6 +13,7 @@ export default class Group extends Component {
     checkMouseDown: PropTypes.func.isRequired,
     onEmojiSelect: PropTypes.func.isRequired,
     onEmojiMouseDown: PropTypes.func.isRequired,
+    useNativeArt: PropTypes.bool,
   };
 
   shouldComponentUpdate = () => false;
@@ -27,6 +28,7 @@ export default class Group extends Component {
       checkMouseDown,
       onEmojiSelect,
       onEmojiMouseDown,
+      useNativeArt,
     } = this.props;
 
     const categoryEmojis = emojis[category];
@@ -46,6 +48,7 @@ export default class Group extends Component {
           checkMouseDown={checkMouseDown}
           onEmojiSelect={onEmojiSelect}
           onEmojiMouseDown={onEmojiMouseDown}
+          useNativeArt={useNativeArt}
         />
       </li>
     ));

--- a/draft-js-emoji-plugin/src/components/EmojiSelect/Popover/Groups/index.js
+++ b/draft-js-emoji-plugin/src/components/EmojiSelect/Popover/Groups/index.js
@@ -15,6 +15,7 @@ export default class Groups extends Component {
     onEmojiSelect: PropTypes.func.isRequired,
     onEmojiMouseDown: PropTypes.func.isRequired,
     onGroupScroll: PropTypes.func.isRequired,
+    useNativeArt: PropTypes.bool,
   };
 
   componentDidMount() {
@@ -86,6 +87,7 @@ export default class Groups extends Component {
       checkMouseDown,
       onEmojiSelect,
       onEmojiMouseDown,
+      useNativeArt,
     } = this.props;
 
     return (
@@ -121,6 +123,7 @@ export default class Groups extends Component {
               ref={(element) => {
                 group.instance = element; // eslint-disable-line no-param-reassign
               }}
+              useNativeArt={useNativeArt}
             />
           ))}
         </Scrollbars>

--- a/draft-js-emoji-plugin/src/components/EmojiSelect/Popover/index.js
+++ b/draft-js-emoji-plugin/src/components/EmojiSelect/Popover/index.js
@@ -16,6 +16,7 @@ export default class Popover extends Component {
     emojis: PropTypes.object.isRequired,
     toneSelectOpenDelay: PropTypes.number.isRequired,
     isOpen: PropTypes.bool,
+    useNativeArt: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -167,6 +168,7 @@ export default class Popover extends Component {
       groups = [],
       emojis,
       isOpen = false,
+      useNativeArt,
     } = this.props;
     const className = isOpen ?
       theme.emojiSelectPopover :
@@ -195,6 +197,7 @@ export default class Popover extends Component {
           onEmojiMouseDown={this.onEmojiMouseDown}
           onGroupScroll={this.onGroupScroll}
           ref={(element) => { this.groups = element; }}
+          useNativeArt={useNativeArt}
         />
         <Nav
           theme={theme}

--- a/draft-js-emoji-plugin/src/components/EmojiSelect/index.js
+++ b/draft-js-emoji-plugin/src/components/EmojiSelect/index.js
@@ -27,6 +27,7 @@ export default class EmojiSelect extends Component {
       PropTypes.string,
     ]),
     toneSelectOpenDelay: PropTypes.number,
+    useNativeArt: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -87,6 +88,7 @@ export default class EmojiSelect extends Component {
       selectGroups,
       selectButtonContent,
       toneSelectOpenDelay,
+      useNativeArt,
     } = this.props;
     const buttonClassName = this.state.isOpen ?
       theme.emojiSelectButtonPressed :
@@ -110,6 +112,7 @@ export default class EmojiSelect extends Component {
           emojis={emojis}
           toneSelectOpenDelay={toneSelectOpenDelay}
           isOpen={this.state.isOpen}
+          useNativeArt={useNativeArt}
         />
       </div>
     );

--- a/draft-js-emoji-plugin/src/components/EmojiSuggestions/Entry/index.js
+++ b/draft-js-emoji-plugin/src/components/EmojiSuggestions/Entry/index.js
@@ -3,6 +3,8 @@ import React, {
   Component,
 } from 'react';
 import emojione from 'emojione';
+import emojiList from '../../../utils/emojiList';
+import convertShortNameToUnicode from '../../../utils/convertShortNameToUnicode';
 
 export default class Entry extends Component {
 
@@ -34,11 +36,26 @@ export default class Entry extends Component {
   };
 
   render() {
-    const { theme = {}, imagePath, imageType, cacheBustParam } = this.props;
+    const { theme = {}, imagePath, imageType, cacheBustParam, useNativeArt } = this.props;
     const className = this.props.isFocused ? theme.emojiSuggestionsEntryFocused : theme.emojiSuggestionsEntry;
-    // short name to image url code steal from emojione source code
-    const shortNameForImage = emojione.emojioneList[this.props.emoji].unicode[emojione.emojioneList[this.props.emoji].unicode.length - 1];
-    const fullImagePath = `${imagePath}${shortNameForImage}.${imageType}${cacheBustParam}`;
+
+    let emojiDisplay = null;
+    if (useNativeArt === true) {
+      const unicode = emojiList.list[this.props.emoji][0];
+      emojiDisplay = convertShortNameToUnicode(unicode);
+    } else {
+      // short name to image url code steal from emojione source code
+      const shortNameForImage = emojione.emojioneList[this.props.emoji].unicode[emojione.emojioneList[this.props.emoji].unicode.length - 1];
+      const fullImagePath = `${imagePath}${shortNameForImage}.${imageType}${cacheBustParam}`;
+      emojiDisplay = (
+        <img
+          src={fullImagePath}
+          className={theme.emojiSuggestionsEntryIcon}
+          role="presentation"
+        />
+      );
+    }
+
     return (
       <div
         className={className}
@@ -47,11 +64,7 @@ export default class Entry extends Component {
         onMouseEnter={this.onMouseEnter}
         role="option"
       >
-        <img
-          src={fullImagePath}
-          className={theme.emojiSuggestionsEntryIcon}
-          role="presentation"
-        />
+        {emojiDisplay}
         <span className={theme.emojiSuggestionsEntryText}>
           {this.props.emoji}
         </span>

--- a/draft-js-emoji-plugin/src/components/EmojiSuggestions/index.js
+++ b/draft-js-emoji-plugin/src/components/EmojiSuggestions/index.js
@@ -272,6 +272,7 @@ export default class EmojiSuggestions extends Component {
       positionSuggestions, // eslint-disable-line no-unused-vars
       shortNames, // eslint-disable-line no-unused-vars
       store, // eslint-disable-line no-unused-vars
+      useNativeArt,
       ...restProps,
     } = this.props;
     return (
@@ -298,6 +299,7 @@ export default class EmojiSuggestions extends Component {
               imagePath={imagePath}
               imageType={imageType}
               cacheBustParam={cacheBustParam}
+              useNativeArt={useNativeArt}
             />
           )).toJS()
         }

--- a/draft-js-emoji-plugin/src/index.js
+++ b/draft-js-emoji-plugin/src/index.js
@@ -132,6 +132,7 @@ export default (config = {}) => {
     selectGroups,
     selectButtonContent,
     toneSelectOpenDelay,
+    useNativeArt,
   } = config;
 
   const cacheBustParam = allowImageCache ? '' : defaultCacheBustParam;
@@ -148,6 +149,7 @@ export default (config = {}) => {
     store,
     positionSuggestions,
     shortNames: List(keys(emojiList.list)),
+    useNativeArt,
   };
   const selectProps = {
     cacheBustParam,
@@ -158,6 +160,7 @@ export default (config = {}) => {
     selectGroups,
     selectButtonContent,
     toneSelectOpenDelay,
+    useNativeArt,
   };
   return {
     EmojiSuggestions: decorateComponentWithProps(EmojiSuggestions, suggestionsProps),
@@ -165,7 +168,7 @@ export default (config = {}) => {
     decorators: [
       {
         strategy: emojiStrategy,
-        component: decorateComponentWithProps(Emoji, { theme, imagePath, imageType, cacheBustParam }),
+        component: decorateComponentWithProps(Emoji, { theme, imagePath, imageType, cacheBustParam, useNativeArt }),
       },
       {
         strategy: emojiSuggestionsStrategy,


### PR DESCRIPTION
## Implementation
This allows displaying the native emoji art instead of EmojiOne art for emoji plugin.
#756 

## Demo
You can change between native and EmojiOne art by passing useNativeArt for emoji plugin when initializing.
```javascript
import React, { Component } from 'react';
import Editor, { createEditorStateWithText } from 'draft-js-plugins-editor'; // eslint-disable-line import/no-unresolved
import createEmojiPlugin from 'draft-js-emoji-plugin'; // eslint-disable-line import/no-unresolved
import editorStyles from './editorStyles.css';

const emojiPlugin = createEmojiPlugin({
  useNativeArt: true
});
const { EmojiSuggestions, EmojiSelect } = emojiPlugin;
const plugins = [emojiPlugin];
const text = `Cool, we can have all sorts of Emojis here. 🙌
🌿☃️🎉🙈 aaaand maybe a few more here 🐲☀️🗻 Quite fun!`;

export default class SimpleEmojiEditor extends Component {

  state = {
    editorState: createEditorStateWithText(text),
  };

  onChange = (editorState) => {
    this.setState({
      editorState,
    });
  };

  focus = () => {
    this.editor.focus();
  };

  render() {
    return (
      <div>
        <div className={editorStyles.editor} onClick={this.focus}>
          <Editor
            editorState={this.state.editorState}
            onChange={this.onChange}
            plugins={plugins}
            ref={(element) => { this.editor = element; }}
          />
          <EmojiSuggestions />
        </div>
        <div className={editorStyles.options}>
          <EmojiSelect />
        </div>
      </div>
    );
  }
}
```
![emoji_art](https://cloud.githubusercontent.com/assets/3472062/26654549/eb411b10-465f-11e7-94a7-d464eb0b6f10.jpg)


## Use-case
Some cases the native art is better fit than EmojiOne so it is good to have the option to choose which one to use.

## Allow editors for maintainers

- [x] Enable "Allow edits from maintainers" for this PR
