### PR TITLE
draft-js-vide-plugin: added missed .babelrc, without it compile but n…

### DIFF
--- a/draft-js-video-plugin/.babelrc
+++ b/draft-js-video-plugin/.babelrc
@@ -1,0 +1,16 @@
+{
+  "presets": ["react", "es2015", "stage-0"],
+  "env": {
+    "production": {
+      "plugins": [
+        [
+          "babel-plugin-webpack-loaders",
+          {
+            "config": "${WEBPACK_CONFIG}",
+            "verbose": true
+          }
+        ]
+      ]
+    }
+  }
+}


### PR DESCRIPTION
draft-js-vide-plugin: added missed .babelrc, without it compile but not working

<!--
Please check out Contributing Guidelines. By following this template you help us to review your code.
https://github.com/draft-js-plugins/draft-js-plugins/blob/master/CONTRIBUTING.md
-->

## Implementation

<!--
Briefly describe the feature or fix
-->

## Demo

<!--
Please add a recorded gif and ideally code example how to test the feature or reproduce the bug.
-->

## Use-case

<!--
In case this is a new feature, property or function that is exposed please describe why you need it.
-->

## Allow editors for maintainers

- [ ] Enable "Allow edits from maintainers" for this PR
