### PR TITLE
onMentionFocus wasn't properly setting state using `setState`

### DIFF
--- a/draft-js-mention-plugin/src/MentionSuggestions/index.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/index.js
@@ -237,7 +237,9 @@ export default class MentionSuggestions extends Component {
   onMentionFocus = (index) => {
     const descendant = `mention-option-${this.key}-${index}`;
     this.props.ariaProps.ariaActiveDescendantID = descendant;
-    this.state.focusedOptionIndex = index;
+    this.setState({
+      focusedOptionIndex: index,
+    });
 
     // to force a re-render of the outer component to change the aria props
     this.props.store.setEditorState(this.props.store.getEditorState());


### PR DESCRIPTION
## Implementation
Using the latest versions of React and DraftJs when using the up/down arrow keys it wasn't properly selecting the appropriate items
