### PR TITLE
Limit the amount of suggestions in mentions

### DIFF
--- a/draft-js-mention-plugin/src/utils/defaultSuggestionsFilter.js
+++ b/draft-js-mention-plugin/src/utils/defaultSuggestionsFilter.js
@@ -1,10 +1,10 @@
 // Get the first 5 suggestions that match
-const defaultSuggestionsFilter = (searchValue, suggestions) => {
+const defaultSuggestionsFilter = (searchValue, suggestions, limit = 5) => {
   const value = searchValue.toLowerCase();
   const filteredSuggestions = suggestions.filter((suggestion) => (
     !value || suggestion.get('name').toLowerCase().indexOf(value) > -1
   ));
-  const size = filteredSuggestions.size < 5 ? filteredSuggestions.size : 5;
+  const size = filteredSuggestions.size < limit ? filteredSuggestions.size : limit;
   return filteredSuggestions.setSize(size);
 };
 


### PR DESCRIPTION
## Implementation
Adjust for issue #773, limit the amount of suggestions in mentions

## Demo
```
  onSearchChange = ({ value }) => {
    this.setState({
      suggestions: defaultSuggestionsFilter(value, mentions, 3),
    });
  };
```

## Use-case
For cases where we need more or less than 5 listed suggestions
