### PR TITLE
Fix deprecation warning: stop treating Immutable.List like an Array

### DIFF
--- a/draft-js-plugins-editor/src/Editor/index.js
+++ b/draft-js-plugins-editor/src/Editor/index.js
@@ -66,11 +66,7 @@ class PluginEditor extends Component {
       .filter((decorator) => this.decoratorIsCustom(decorator));
 
     const multiDecorator = new MultiDecorator(
-      [
-        ...customDecorators,
-        compositeDecorator,
-      ]
-    );
+      customDecorators.push(compositeDecorator));
 
     const editorState = EditorState.set(this.props.editorState, { decorator: multiDecorator });
     this.onChange(moveSelectionToEnd(editorState));


### PR DESCRIPTION
Hi there,
I'm getting the following warning logged to the console when using `draft-js-plugins-editor@2.0.0-rc2`.
```
VM110896:4655 iterable.length has been deprecated, use iterable.size or iterable.count(). This warning will become a silent error in a future version. Error
    at List.get (eval at <anonymous> (https://localhost:3000/ng/embed.js:1386:1), <anonymous>:4650:21)
    at List.slice (<anonymous>)
    at Function.Array.from (https://testhorse.dev-ben.seamlessdocs.com/_js/mootools-compat-1.4.5.js:136:105)
    at _toConsumableArray (eval at <anonymous> (https://localhost:3000/ng/embed.js:15309:1), <anonymous>:49:182)
    at PluginEditor.componentWillMount (eval at <anonymous> (https://localhost:3000/ng/embed.js:15309:1), <anonymous>:104:67)
    at eval (eval at <anonymous> (https://localhost:3000/ng/embed.js:11297:1), <anonymous>:348:23)
    at measureLifeCyclePerf (eval at <anonymous> (https://localhost:3000/ng/embed.js:11297:1), <anonymous>:75:12)
    at ReactCompositeComponentWrapper.performInitialMount (eval at <anonymous> (https://localhost:3000/ng/embed.js:11297:1), <anonymous>:347:9)
    at ReactCompositeComponentWrapper.mountComponent (eval at <anonymous> (https://localhost:3000/ng/embed.js:11297:1), <anonymous>:258:21)
    at Object.mountComponent (eval at <anonymous> (https://localhost:3000/ng/embed.js:2080:1), <anonymous>:46:35)
```
This warning is emitted by Immutable.js when something calls `.length` on a `List`. After some digging, I found that the root cause was that a `List` (`customDecorators`), was getting spread using the ellipses syntax, which when compiled to es5 involves a `.length` check. This is easily fixed by switching to the `List` api.

## Implementation
Instead of spreading the `List`, use `List.prototype.push`.