### PR TITLE
Add a default rel property; limit props to component to valid attributes

### DIFF
--- a/docs/client/components/pages/Linkify/index.js
+++ b/docs/client/components/pages/Linkify/index.js
@@ -106,6 +106,10 @@ export default class App extends Component {
             <span className={styles.paramName}>component</span>
             <span>If provided this component will be rendered instead of the default Anchor tag. It receives the following props: target, href & className</span>
           </div>
+          <div className={styles.param}>
+            <span className={styles.paramName}>rel</span>
+            <span>String value for the rel attribute. (Default value is noreferrer noopener)</span>
+          </div>
         </Container>
         <Container>
           <Heading level={2}>Simple Example</Heading>

--- a/draft-js-linkify-plugin/CHANGELOG.md
+++ b/draft-js-linkify-plugin/CHANGELOG.md
@@ -9,6 +9,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - The plugin now accepts a `component` config and if provided this component will be rendered instead of the default Anchor tag. Thanks to @antoinerey.
 
+### Fix
+
+- The plugin now accepts a `rel` config to prevent the `target="_blank"` vulnerability.
+- Limit the props that can be added to the link to prevent the Unknown Prop Warning
+
 ## 1.0.1 - 2016-04-29
 
 ### Fix

--- a/draft-js-linkify-plugin/src/Link/index.js
+++ b/draft-js-linkify-plugin/src/Link/index.js
@@ -21,7 +21,7 @@ export default class Link extends Component {
       offsetKey, // eslint-disable-line no-unused-vars
       setEditorState, // eslint-disable-line no-unused-vars
       contentState, // eslint-disable-line no-unused-vars
-      ...otherProps
+      rel = 'noreferrer noopener',
     } = this.props;
 
     const combinedClassName = unionClassNames(theme.link, className);
@@ -29,7 +29,7 @@ export default class Link extends Component {
     const href = links && links[0] ? links[0].url : '';
 
     const props = {
-      ...otherProps,
+      rel,
       href,
       target,
       className: combinedClassName,

--- a/draft-js-linkify-plugin/src/index.js
+++ b/draft-js-linkify-plugin/src/index.js
@@ -19,13 +19,14 @@ export default (config = {}) => {
     component,
     theme = defaultTheme,
     target = '_self',
+    rel = 'noreferrer noopener',
   } = config;
 
   return {
     decorators: [
       {
         strategy: linkStrategy,
-        component: decorateComponentWithProps(Link, { theme, target, component }),
+        component: decorateComponentWithProps(Link, { theme, target, rel, component }),
       },
     ],
   };


### PR DESCRIPTION
React was throwing the unknown prop warning, this fix is to address that but limiting the props that can be added to a link.

Also addresses the `target="_blank"` vulnerability.
