### PR TITLE
Allow immutable 3.8.x as well

### DIFF
--- a/draft-js-plugins-editor/package.json
+++ b/draft-js-plugins-editor/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "decorate-component-with-props": "^1.0.2",
     "find-with-regex": "^1.0.2",
-    "immutable": "~3.7.4",
+    "immutable": "^3.7.4",
     "prop-types": "^15.5.8",
     "union-class-names": "^1.0.0"
   },


### PR DESCRIPTION
Please tell if the `~` is intended :)

<!--
Please check out Contributing Guidelines. By following this template you help us to review your code.
https://github.com/draft-js-plugins/draft-js-plugins/blob/master/CONTRIBUTING.md
-->

## Implementation
Allow not just immuatable 3.7.4 but alos 3.8.x etc

## Allow editors for maintainers

- [x] Enable "Allow edits from maintainers" for this PR
