### PR TITLE
Fix initialization of blockRenderMap to address problem with Maps ins…

### DIFF
--- a/draft-js-plugins-editor/src/Editor/index.js
+++ b/draft-js-plugins-editor/src/Editor/index.js
@@ -272,7 +272,12 @@ class PluginEditor extends Component {
   resolveblockRenderMap = () => {
     let blockRenderMap = this.props.plugins
       .filter((plug) => plug.blockRenderMap !== undefined)
-      .reduce((maps, plug) => maps.merge(plug.blockRenderMap), Map({}));
+      .reduce((maps, plug) => {
+        Object.keys(plug.blockRenderMap).forEach((key) => {
+          maps = maps.set(key, plug.blockRenderMap[key]);
+        });
+        return maps;
+      }, Map({}));
     if (this.props.defaultBlockRenderMap) {
       blockRenderMap = DefaultDraftBlockRenderMap.merge(blockRenderMap);
     }


### PR DESCRIPTION
…ide of blockRenderMap.

<!--
Please check out Contributing Guidelines. By following this template you help us to review your code.
https://github.com/draft-js-plugins/draft-js-plugins/blob/master/CONTRIBUTING.md
-->

## Implementation

The problem with a plain maps.merge is that immutable will completely wrap the item into a Map object. Then when the draft-js editor gets the blockRender item from the blockRenderMap it will receive a Map object rather than the expected plain javascript object.

## Demo

This is hard to demo since nothing shows when it's broken and the custom renderMap item works when it's fixed. Basically it will look for Map.wrapper to have a value inside of draft-js to determine whether it needs to do custom rendering and it just doesn't.

## Use-case

Creating a plugin with a blockRenderMap will work after this patch. Before the renderMap was being ignored.

## Allow editors for maintainers

- [ ] Enable "Allow edits from maintainers" for this PR
