### PR TITLE
hide inline toolbar if is not visible using css visibility

### DIFF
--- a/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
+++ b/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
@@ -76,10 +76,12 @@ export default class Toolbar extends React.Component {
     const style = { ...position };
 
     if (isVisible) {
+      style.visibility = 'visible';
       style.transform = 'translate(-50%) scale(1)';
       style.transition = 'transform 0.15s cubic-bezier(.3,1.2,.2,1)';
     } else {
       style.transform = 'translate(-50%) scale(0)';
+      style.visibility = 'hidden';
     }
 
     return style;


### PR DESCRIPTION
 - it takes toolbar buttons out of the tab order, when are hidden

## Implementation
Hide toolbar with visibility property, browser then ignore buttons whenpage is walked throught tab. 

## Demo
same as https://github.com/draft-js-plugins/draft-js-plugins/pull/647

## Allow editors for maintainers

- [ x] Enable "Allow edits from maintainers" for this PR
