### PR TITLE
Handles boolean return values in handle hooks (Closes #806)

### DIFF
--- a/draft-js-plugins-editor/src/Editor/__test__/index.js
+++ b/draft-js-plugins-editor/src/Editor/__test__/index.js
@@ -189,6 +189,54 @@ describe('Editor', () => {
       expect(plugin.handleDrop).has.been.calledWith('command', expectedSecondArgument);
     });
 
+    it('allows handle-hooks functions with boolean return values', () => {
+      const plugins = [
+        {
+          handleKeyCommand: sinon.stub().returns(true),
+          handlePastedText: sinon.stub().returns(true),
+          handleReturn: sinon.stub().returns(true),
+          handleDrop: sinon.stub().returns(true),
+        },
+      ];
+      const result = shallow(
+        <PluginEditor
+          editorState={editorState}
+          onChange={changeSpy}
+          plugins={plugins}
+        />
+      );
+
+      const draftEditor = result.node;
+      expect(draftEditor.props.handleDrop('command')).to.equal('handled');
+      expect(draftEditor.props.handleKeyCommand('command')).to.equal('handled');
+      expect(draftEditor.props.handlePastedText('command')).to.equal('handled');
+      expect(draftEditor.props.handleReturn('command')).to.equal('handled');
+    });
+
+    it("allows handle-hooks functions with 'handled'|'not-handled' return values", () => {
+      const plugins = [
+        {
+          handleKeyCommand: sinon.stub().returns('handled'),
+          handlePastedText: sinon.stub().returns('handled'),
+          handleReturn: sinon.stub().returns('handled'),
+          handleDrop: sinon.stub().returns('handled'),
+        },
+      ];
+      const result = shallow(
+        <PluginEditor
+          editorState={editorState}
+          onChange={changeSpy}
+          plugins={plugins}
+        />
+      );
+
+      const draftEditor = result.node;
+      expect(draftEditor.props.handleDrop('command')).to.equal('handled');
+      expect(draftEditor.props.handleKeyCommand('command')).to.equal('handled');
+      expect(draftEditor.props.handlePastedText('command')).to.equal('handled');
+      expect(draftEditor.props.handleReturn('command')).to.equal('handled');
+    });
+
     it('calls willUnmount', () => {
       const plugins = [
         {

--- a/draft-js-plugins-editor/src/Editor/index.js
+++ b/draft-js-plugins-editor/src/Editor/index.js
@@ -134,10 +134,13 @@ class PluginEditor extends Component {
     const newArgs = [].slice.apply(args);
     newArgs.push(this.getPluginMethods());
 
-    return plugins.some((plugin) =>
-      typeof plugin[methodName] === 'function'
-        && plugin[methodName](...newArgs) === 'handled'
-    ) ? 'handled' : 'not-handled';
+    return plugins.some((plugin) => {
+      if (typeof plugin[methodName] === 'function') {
+        const value = plugin[methodName](...newArgs);
+        return value === 'handled' || value === true;
+      }
+      return false;
+    }) ? 'handled' : 'not-handled';
   };
 
   createFnHooks = (methodName, plugins) => (...args) => {


### PR DESCRIPTION
## Implementation

Fixes the issue outlined here https://github.com/draft-js-plugins/draft-js-plugins/issues/806.

[Cancelable Handlers](https://draftjs.org/docs/api-reference-editor.html#cancelable-handlers-optional) should be able to return `'handled'` or `true` based on the `draft-js` source [here](https://github.com/facebook/draft-js/blob/master/src/component/utils/isEventHandled.js), but `draft-js-plugins-editor` is only checking for `'handled'`.

## Demo

From @ramrami who had a handler for trimming pasted text:
```javascript
 handlePastedText(text, html) {
    console.log("handlePastedText executed");
    const {editorState} = this.state;
    const newState = Modifier.replaceText(editorState.getCurrentContent(), editorState.getSelection(), text.trim());
    this.onChange(EditorState.push(editorState, newState, 'insert-fragment'));

    return true;
  }
```

### draft-js editor
![draft-js-editor](https://user-images.githubusercontent.com/9569590/28675635-5d5819a4-72e0-11e7-8d5c-618c7d0ab123.gif)

### draft-js-plugins-editor (note: text is not trimmed on paste)
![draft-js-editor](https://user-images.githubusercontent.com/9569590/28675737-99cad58e-72e0-11e7-9521-ad222d51812e.gif)

## Use-case
It is expected behavior in the draft-js editor component to accept return values for cancelable handlers as either `'handled'` or `true`

## Allow editors for maintainers

- [x] Enable "Allow edits from maintainers" for this PR
