### PR TITLE
Hide inline toolbar on editor blur

### DIFF
--- a/draft-js-inline-toolbar-plugin/src/components/Toolbar/__test__/Toolbar.js
+++ b/draft-js-inline-toolbar-plugin/src/components/Toolbar/__test__/Toolbar.js
@@ -28,7 +28,7 @@ describe('Toolbar', () => {
       unsubscribeFromItem() {},
       getItem: (name) => ({
         getEditorState: () => ({
-          getSelection: () => ({ isCollapsed: () => true })
+          getSelection: () => ({ isCollapsed: () => true, getHasFocus: () => true })
         })
       }[name])
     };

--- a/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
+++ b/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
@@ -72,7 +72,7 @@ export default class Toolbar extends React.Component {
     const { store } = this.props;
     const { overrideContent, position } = this.state;
     const selection = store.getItem('getEditorState')().getSelection();
-    const isVisible = !selection.isCollapsed() || overrideContent;
+    const isVisible = (!selection.isCollapsed() || overrideContent) && selection.getHasFocus();
     const style = { ...position };
 
     if (isVisible) {


### PR DESCRIPTION
<!--
Please check out Contributing Guidelines. By following this template you help us to review your code.
https://github.com/draft-js-plugins/draft-js-plugins/blob/master/CONTRIBUTING.md
-->

## Implementation

- Fixed inline toolbar not disappearing when editor loses focus (blur) [Video of the bug](https://drive.google.com/file/d/0B4McFs23KX_VdnFsbmc2c0hDX1E/view?usp=sharing)
- Fixed test for inline toolbar

## Demo

[Demo of the fix](https://drive.google.com/file/d/0B4McFs23KX_VdWlNU1N5LVpMTGc/view?usp=sharing)

## Use-case

//

## Allow editors for maintainers

- [x] Enable "Allow edits from maintainers" for this PR
