### PR TITLE
Update polyfill list for IE11 in FAQ

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -133,6 +133,7 @@ import 'core-js/es6/weak-map';
 import 'core-js/fn/object/assign';
 import 'core-js/fn/symbol';
 import 'core-js/fn/array/from';
+import 'core-js/fn/array/fill';
 import 'core-js/fn/string/starts-with';
 import 'core-js/fn/string/ends-with';
 ```


### PR DESCRIPTION
## Description

Add `Array.fill` polyfill to the list of polyfills required for IE11
You can see the usage of it [here](https://github.com/draft-js-plugins/draft-js-plugins/blob/a571b3d10b1022199a56e42723f23ff2cb477a9c/draft-js-plugins-editor/src/Editor/MultiDecorator.js#L17).

## Allow editors for maintainers

- [x] Enable "Allow edits from maintainers" for this PR
