### PR TITLE
Add type="button" to emoji select to prevent submitting when placed inside a form.

### DIFF
--- a/draft-js-emoji-plugin/src/components/EmojiSelect/index.js
+++ b/draft-js-emoji-plugin/src/components/EmojiSelect/index.js
@@ -97,6 +97,7 @@ export default class EmojiSelect extends Component {
         <button
           className={buttonClassName}
           onMouseUp={this.onButtonMouseUp}
+          type="button"
         >
           {selectButtonContent}
         </button>


### PR DESCRIPTION
Fix for issue #781 

By default buttons inside nested forms when clicked submit the form. Adding type="button" fixes the issue.