### PR TITLE
Allow passing extra data with addImage call

### DIFF
--- a/draft-js-image-plugin/src/modifiers/addImage.js
+++ b/draft-js-image-plugin/src/modifiers/addImage.js
@@ -3,10 +3,10 @@ import {
   AtomicBlockUtils,
 } from 'draft-js';
 
-export default (editorState, url) => {
+export default (editorState, url, extraData) => {
   const urlType = 'image';
   const contentState = editorState.getCurrentContent();
-  const contentStateWithEntity = contentState.createEntity(urlType, 'IMMUTABLE', { src: url });
+  const contentStateWithEntity = contentState.createEntity(urlType, 'IMMUTABLE', { ...extraData, src: url });
   const entityKey = contentStateWithEntity.getLastCreatedEntityKey();
   const newEditorState = AtomicBlockUtils.insertAtomicBlock(
     editorState,


### PR DESCRIPTION
We need to keep a reference to the actual file object around in our app, which is currently impossible as we have to use `URL.createObjectURL` to get a URL suitable to be passed as a `src`.

This patch allows us to keep that reference in `entity.data` like so:

```JS
onChange(addImage(state, URL.createObjectURL(file), { file: file }));
```

Without this we can't upload the images to a remote server (in our case S3) since we can't do that with just the URL. By allowing extra data to be passed through to the entity this becomes possible.
