### PR TITLE
Fixes Inline toolbar overflow on left and wrap on right

### DIFF
--- a/docs/client/components/pages/InlineToolbar/ThemedInlineToolbarEditor/toolbarStyles.css
+++ b/docs/client/components/pages/InlineToolbar/ThemedInlineToolbarEditor/toolbarStyles.css
@@ -8,6 +8,7 @@
   box-shadow: 0px 1px 3px 0px rgba(220,220,220,1);
   z-index: 2;
   box-sizing: border-box;
+  display: flex;
 }
 
 .toolbar:after, .toolbar:before {

--- a/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
+++ b/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
@@ -62,7 +62,7 @@ export default class Toolbar extends React.Component {
 
       const position = {
         top: (selectionRect.top - relativeRect.top) - toolbarHeight,
-        left: (selectionRect.left - relativeRect.left) + (selectionRect.width / 2),
+        left: this.calculateToolbarLeft(selectionRect, relativeRect)
       };
       this.setState({ position });
     });
@@ -87,9 +87,43 @@ export default class Toolbar extends React.Component {
     return style;
   }
 
+  calculateToolbarLeft(selectionRect, relativeRect) {
+    const toolbarWidth = this.toolbar.offsetWidth + 4;
+    const defualtToolbarLeft = (selectionRect.left - relativeRect.left) + (selectionRect.width / 2);
+    const outOfWindowPixlesLeft = defualtToolbarLeft - (toolbarWidth / 2);
+    const outOfWindowPixlesRight = relativeRect.width - (defualtToolbarLeft + (toolbarWidth / 2));
+
+    if (outOfWindowPixlesLeft < 0) {
+      this.adjustToolbarPointer(outOfWindowPixlesLeft + (toolbarWidth / 2));
+      return defualtToolbarLeft + Math.abs(outOfWindowPixlesLeft);
+    } else if (outOfWindowPixlesRight < 0) {
+      this.adjustToolbarPointer((toolbarWidth / 2) - outOfWindowPixlesRight);
+      return defualtToolbarLeft + outOfWindowPixlesRight;
+    }
+
+    this.adjustToolbarPointer(toolbarWidth / 2);
+    return defualtToolbarLeft;
+  }
+
   handleToolbarRef = (node) => {
     this.toolbar = node;
   };
+
+  adjustToolbarPointer(leftAttribute) {
+    const { theme } = this.props;
+    const toolbarPointerNode = document.querySelector('.toolbar-pointer');
+    const wordPointerStyle = document.createElement('style');
+
+    if (toolbarPointerNode) {
+      toolbarPointerNode.remove();
+    }
+
+    wordPointerStyle.className = 'toolbar-pointer';
+
+    document.head.appendChild(wordPointerStyle);
+    wordPointerStyle.sheet.insertRule(`.${theme.toolbarStyles.toolbar}::after { left: ${leftAttribute}px}`, 0);
+    wordPointerStyle.sheet.insertRule(`.${theme.toolbarStyles.toolbar}::before { left: ${leftAttribute}px}`, 0);
+  }
 
   render() {
     const { theme, store, structure } = this.props;

--- a/draft-js-inline-toolbar-plugin/src/toolbarStyles.css
+++ b/draft-js-inline-toolbar-plugin/src/toolbarStyles.css
@@ -8,6 +8,7 @@
   box-shadow: 0px 1px 3px 0px rgba(220,220,220,1);
   z-index: 2;
   box-sizing: border-box;
+  display: flex;
 }
 
 .toolbar:after, .toolbar:before {


### PR DESCRIPTION
<!--
Please check out Contributing Guidelines. By following this template you help us to review your code.
https://github.com/draft-js-plugins/draft-js-plugins/blob/master/CONTRIBUTING.md
-->

## Fixed Issue

<img width="806" alt="screen shot 2017-08-15 at 12 36 11 pm" src="https://user-images.githubusercontent.com/12012163/29332855-5a395cbc-81b6-11e7-8e30-344ce280bf37.png">

When a user selects text that is on the far left the toolbox overflows off the left side of the window.

<img width="704" alt="screen shot 2017-08-15 at 12 37 28 pm" src="https://user-images.githubusercontent.com/12012163/29332898-861d743a-81b6-11e7-8a7c-4bf7bda4528d.png">
When a user selects text that is on the right of the toolbox buttons wrap and stack.
