### PR TITLE
[draft-js-anchor-plugin] PropTypes from 'prop-types' instead of React

### DIFF
--- a/draft-js-anchor-plugin/src/components/Link/index.js
+++ b/draft-js-anchor-plugin/src/components/Link/index.js
@@ -1,4 +1,4 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
 
 const propTypes = {
   className: PropTypes.string,


### PR DESCRIPTION
Noticed I got a warning in my project. I haven't tested it (I just made the change through the Github UI), but it matches the other component in this plugin.