### PR TITLE
Use propTypes from external package in anchor-plugin

### DIFF
--- a/draft-js-anchor-plugin/src/components/Link/index.js
+++ b/draft-js-anchor-plugin/src/components/Link/index.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 const propTypes = {
   className: PropTypes.string,


### PR DESCRIPTION
So I ended up closing the other PR which had this change, but I pulled down the repo and ran the PropTypes codemod across the project, and this was the only update it found.

I also locally upgraded to React 16 beta, and I found that the anchor plugin was the only thing causing an error, so I'm pretty confident this is the only Component which uses PropTypes from the React package instead of `prop-types`.