### PR TITLE
fix inline toolbar left and right alignment issue

### DIFF
--- a/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
+++ b/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
@@ -61,14 +61,14 @@ export default class Toolbar extends React.Component {
 
       if (!selectionRect) return;
 
-      let toolbarwidth = this.toolbar.clientWidth;
+      const toolbarwidth = this.toolbar.clientWidth;
 
-      let left = (selectionRect.left - relativeRect.left) + (selectionRect.width / 2) - (toolbarwidth/2);
+      let left = (selectionRect.left - relativeRect.left) + (selectionRect.width / 2) - (toolbarwidth / 2);
 
-      if(left < padding) {
+      if (left < padding) {
         left = padding;
-      } else if(left > (document.documentElement.clientWidth - toolbarwidth + padding)) {
-        left = document.documentElement.clientWidth - toolbarwidth - padding
+      } else if (left > (document.documentElement.clientWidth - toolbarwidth + padding)) {
+        left = document.documentElement.clientWidth - toolbarwidth - padding;
       }
 
       const position = {
@@ -88,11 +88,9 @@ export default class Toolbar extends React.Component {
 
     if (isVisible) {
       style.visibility = 'visible';
-      //style.transform = 'translate(-50%) scale(1)';
       style.transform = 'scale(1)';
       style.transition = 'transform 0.15s cubic-bezier(.3,1.2,.2,1)';
     } else {
-      //z style.transform = 'translate(-50%) scale(0)';
       style.transform = 'scale(0)';
       style.visibility = 'hidden';
     }

--- a/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
+++ b/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
@@ -4,6 +4,7 @@ import { getVisibleSelectionRect } from 'draft-js';
 
 // TODO make toolbarHeight to be determined or a parameter
 const toolbarHeight = 44;
+const padding = 5;
 
 const getRelativeParent = (element) => {
   if (!element) {
@@ -57,12 +58,23 @@ export default class Toolbar extends React.Component {
       const relativeParent = getRelativeParent(this.toolbar.parentElement);
       const relativeRect = (relativeParent || document.body).getBoundingClientRect();
       const selectionRect = getVisibleSelectionRect(window);
+      const selection = window.getSelection();
 
       if (!selectionRect) return;
 
+      let toolbarwidth = this.toolbar.clientWidth;
+
+      let left = (selectionRect.left - relativeRect.left) + (selectionRect.width / 2) - (toolbarwidth/2);
+
+      if(left < padding) {
+        left = padding;
+      } else if(left > (document.documentElement.clientWidth - toolbarwidth + padding)) {
+        left = document.documentElement.clientWidth - toolbarwidth - padding
+      }
+
       const position = {
         top: (selectionRect.top - relativeRect.top) - toolbarHeight,
-        left: (selectionRect.left - relativeRect.left) + (selectionRect.width / 2),
+        left: left
       };
       this.setState({ position });
     });
@@ -77,10 +89,12 @@ export default class Toolbar extends React.Component {
 
     if (isVisible) {
       style.visibility = 'visible';
-      style.transform = 'translate(-50%) scale(1)';
+      //style.transform = 'translate(-50%) scale(1)';
+      style.transform = 'scale(1)';
       style.transition = 'transform 0.15s cubic-bezier(.3,1.2,.2,1)';
     } else {
-      style.transform = 'translate(-50%) scale(0)';
+      //z style.transform = 'translate(-50%) scale(0)';
+      style.transform = 'scale(0)';
       style.visibility = 'hidden';
     }
 

--- a/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
+++ b/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
@@ -58,7 +58,6 @@ export default class Toolbar extends React.Component {
       const relativeParent = getRelativeParent(this.toolbar.parentElement);
       const relativeRect = (relativeParent || document.body).getBoundingClientRect();
       const selectionRect = getVisibleSelectionRect(window);
-      const selection = window.getSelection();
 
       if (!selectionRect) return;
 

--- a/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
+++ b/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
@@ -73,7 +73,7 @@ export default class Toolbar extends React.Component {
 
       const position = {
         top: (selectionRect.top - relativeRect.top) - toolbarHeight,
-        left: left
+        left
       };
       this.setState({ position });
     });

--- a/draft-js-inline-toolbar-plugin/src/toolbarStyles.css
+++ b/draft-js-inline-toolbar-plugin/src/toolbarStyles.css
@@ -1,6 +1,7 @@
 .toolbar {
   left: 50%;
-  transform: translate(-50%) scale(0);
+  /*transform: translate(-50%) scale(0);*/
+  transform: scale(0);
   position: absolute;
   border: 1px solid #ddd;
   background: #fff;
@@ -8,6 +9,7 @@
   box-shadow: 0px 1px 3px 0px rgba(220,220,220,1);
   z-index: 2;
   box-sizing: border-box;
+  display: flex;
 }
 
 .toolbar:after, .toolbar:before {


### PR DESCRIPTION
![draftjs-toolbar-ex1](https://user-images.githubusercontent.com/8967726/30281238-7cf6ca42-96d7-11e7-85bb-dec9fbcbc034.png)
![draftjs-toolbar-ex2](https://user-images.githubusercontent.com/8967726/30281239-7d0439b6-96d7-11e7-868d-be62e177b96e.png)



<!--
Please check out Contributing Guidelines. By following this template you help us to review your code.
https://github.com/draft-js-plugins/draft-js-plugins/blob/master/CONTRIBUTING.md
-->

## Implementation

<!--
Briefly describe the feature or fix
-->
The above screenshots show the issue with the toolbar on small window size.
The code fixes the toolbar to stay in the visible viewport. This still doesn't fix the pointer to point correctly to the center of the content selected.

## Demo
![djs-tb-3](https://user-images.githubusercontent.com/8967726/30286222-71b4f744-96e6-11e7-8a4c-0d1ee3becaee.png)
![djs-tb-2](https://user-images.githubusercontent.com/8967726/30286224-71ba2fc0-96e6-11e7-8055-7bf5abcd57a5.png)
![djs-tb-1](https://user-images.githubusercontent.com/8967726/30286223-71b6e252-96e6-11e7-9a22-74953ecb4c59.png)

<!--
Please add a recorded gif and ideally code example how to test the feature or reproduce the bug.
-->

## Use-case

<!--
In case this is a new feature, property or function that is exposed please describe why you need it.
-->

## Allow editors for maintainers

- [x] Enable "Allow edits from maintainers" for this PR
