### PR TITLE
Update mention documentation to assign plugin instance to property

### DIFF
--- a/docs/client/components/pages/Mention/CustomComponentMentionEditor/index.js
+++ b/docs/client/components/pages/Mention/CustomComponentMentionEditor/index.js
@@ -7,6 +7,23 @@ import mentions from './mentions';
 
 export default class CustomMentionEditor extends Component {
 
+  constructor(props) {
+    super(props);
+
+    this.mentionPlugin = createMentionPlugin({
+      mentions,
+      mentionComponent: (mentionProps) => (
+        <span
+          className={mentionProps.className}
+          // eslint-disable-next-line no-alert
+          onClick={() => alert('Clicked on the Mention!')}
+        >
+          {mentionProps.children}
+        </span>
+      ),
+    });
+  }
+
   state = {
     editorState: EditorState.createEmpty(),
     suggestions: mentions,
@@ -27,19 +44,6 @@ export default class CustomMentionEditor extends Component {
   focus = () => {
     this.editor.focus();
   };
-
-  mentionPlugin = createMentionPlugin({
-    mentions,
-    mentionComponent: (mentionProps) => (
-      <span
-        className={mentionProps.className}
-        // eslint-disable-next-line no-alert
-        onClick={() => alert('Clicked on the Mention!')}
-      >
-        {mentionProps.children}
-      </span>
-    ),
-  });
 
   render() {
     const { MentionSuggestions } = this.mentionPlugin;

--- a/docs/client/components/pages/Mention/CustomComponentMentionEditor/index.js
+++ b/docs/client/components/pages/Mention/CustomComponentMentionEditor/index.js
@@ -5,21 +5,6 @@ import createMentionPlugin, { defaultSuggestionsFilter } from 'draft-js-mention-
 import editorStyles from './editorStyles.css';
 import mentions from './mentions';
 
-const mentionPlugin = createMentionPlugin({
-  mentions,
-  mentionComponent: (props) => (
-    <span
-      className={props.className}
-      // eslint-disable-next-line no-alert
-      onClick={() => alert('Clicked on the Mention!')}
-    >
-      {props.children}
-    </span>
-  ),
-});
-const { MentionSuggestions } = mentionPlugin;
-const plugins = [mentionPlugin];
-
 export default class CustomMentionEditor extends Component {
 
   state = {
@@ -43,7 +28,23 @@ export default class CustomMentionEditor extends Component {
     this.editor.focus();
   };
 
+  mentionPlugin = createMentionPlugin({
+    mentions,
+    mentionComponent: (mentionProps) => (
+      <span
+        className={mentionProps.className}
+        // eslint-disable-next-line no-alert
+        onClick={() => alert('Clicked on the Mention!')}
+      >
+        {mentionProps.children}
+      </span>
+    ),
+  });
+
   render() {
+    const { MentionSuggestions } = this.mentionPlugin;
+    const plugins = [this.mentionPlugin];
+
     return (
       <div className={editorStyles.editor} onClick={this.focus}>
         <Editor

--- a/docs/client/components/pages/Mention/CustomMentionEditor/index.js
+++ b/docs/client/components/pages/Mention/CustomMentionEditor/index.js
@@ -59,6 +59,18 @@ const Entry = (props) => {
 
 export default class CustomMentionEditor extends Component {
 
+  constructor(props) {
+    super(props);
+
+    this.mentionPlugin = createMentionPlugin({
+      mentions,
+      entityMutability: 'IMMUTABLE',
+      theme: mentionsStyles,
+      positionSuggestions,
+      mentionPrefix: '@',
+    });
+  }
+
   state = {
     editorState: EditorState.createEmpty(),
     suggestions: mentions,
@@ -79,14 +91,6 @@ export default class CustomMentionEditor extends Component {
   focus = () => {
     this.editor.focus();
   };
-
-  mentionPlugin = createMentionPlugin({
-    mentions,
-    entityMutability: 'IMMUTABLE',
-    theme: mentionsStyles,
-    positionSuggestions,
-    mentionPrefix: '@',
-  });
 
   render() {
     const { MentionSuggestions } = this.mentionPlugin;

--- a/docs/client/components/pages/Mention/CustomMentionEditor/index.js
+++ b/docs/client/components/pages/Mention/CustomMentionEditor/index.js
@@ -24,16 +24,6 @@ const positionSuggestions = ({ state, props }) => {
   };
 };
 
-const mentionPlugin = createMentionPlugin({
-  mentions,
-  entityMutability: 'IMMUTABLE',
-  theme: mentionsStyles,
-  positionSuggestions,
-  mentionPrefix: '@',
-});
-const { MentionSuggestions } = mentionPlugin;
-const plugins = [mentionPlugin];
-
 const Entry = (props) => {
   const {
     mention,
@@ -90,7 +80,18 @@ export default class CustomMentionEditor extends Component {
     this.editor.focus();
   };
 
+  mentionPlugin = createMentionPlugin({
+    mentions,
+    entityMutability: 'IMMUTABLE',
+    theme: mentionsStyles,
+    positionSuggestions,
+    mentionPrefix: '@',
+  });
+
   render() {
+    const { MentionSuggestions } = this.mentionPlugin;
+    const plugins = [this.mentionPlugin];
+
     return (
       <div className={editorStyles.editor} onClick={this.focus}>
         <Editor

--- a/docs/client/components/pages/Mention/RemoteMentionEditor/index.js
+++ b/docs/client/components/pages/Mention/RemoteMentionEditor/index.js
@@ -9,6 +9,12 @@ import editorStyles from './editorStyles.css';
 
 export default class SimpleMentionEditor extends Component {
 
+  constructor(props) {
+    super(props);
+
+    this.mentionPlugin = createMentionPlugin();
+  }
+
   state = {
     editorState: EditorState.createEmpty(),
     suggestions: fromJS([]),
@@ -45,8 +51,6 @@ export default class SimpleMentionEditor extends Component {
   focus = () => {
     this.editor.focus();
   };
-
-  mentionPlugin = createMentionPlugin();
 
   render() {
     const { MentionSuggestions } = this.mentionPlugin;

--- a/docs/client/components/pages/Mention/RemoteMentionEditor/index.js
+++ b/docs/client/components/pages/Mention/RemoteMentionEditor/index.js
@@ -7,10 +7,6 @@ import createMentionPlugin from 'draft-js-mention-plugin';
 import { fromJS } from 'immutable';
 import editorStyles from './editorStyles.css';
 
-const mentionPlugin = createMentionPlugin();
-const { MentionSuggestions } = mentionPlugin;
-const plugins = [mentionPlugin];
-
 export default class SimpleMentionEditor extends Component {
 
   state = {
@@ -50,7 +46,12 @@ export default class SimpleMentionEditor extends Component {
     this.editor.focus();
   };
 
+  mentionPlugin = createMentionPlugin();
+
   render() {
+    const { MentionSuggestions } = this.mentionPlugin;
+    const plugins = [this.mentionPlugin];
+
     return (
       <div className={editorStyles.editor} onClick={this.focus}>
         <Editor

--- a/docs/client/components/pages/Mention/SimpleMentionEditor/index.js
+++ b/docs/client/components/pages/Mention/SimpleMentionEditor/index.js
@@ -5,10 +5,6 @@ import createMentionPlugin, { defaultSuggestionsFilter } from 'draft-js-mention-
 import editorStyles from './editorStyles.css';
 import mentions from './mentions';
 
-const mentionPlugin = createMentionPlugin();
-const { MentionSuggestions } = mentionPlugin;
-const plugins = [mentionPlugin];
-
 export default class SimpleMentionEditor extends Component {
 
   state = {
@@ -36,7 +32,12 @@ export default class SimpleMentionEditor extends Component {
     this.editor.focus();
   };
 
+  mentionPlugin = createMentionPlugin();
+
   render() {
+    const { MentionSuggestions } = this.mentionPlugin;
+    const plugins = [this.mentionPlugin];
+
     return (
       <div className={editorStyles.editor} onClick={this.focus}>
         <Editor

--- a/docs/client/components/pages/Mention/SimpleMentionEditor/index.js
+++ b/docs/client/components/pages/Mention/SimpleMentionEditor/index.js
@@ -7,6 +7,12 @@ import mentions from './mentions';
 
 export default class SimpleMentionEditor extends Component {
 
+  constructor(props) {
+    super(props);
+
+    this.mentionPlugin = createMentionPlugin();
+  }
+
   state = {
     editorState: EditorState.createEmpty(),
     suggestions: mentions,
@@ -31,8 +37,6 @@ export default class SimpleMentionEditor extends Component {
   focus = () => {
     this.editor.focus();
   };
-
-  mentionPlugin = createMentionPlugin();
 
   render() {
     const { MentionSuggestions } = this.mentionPlugin;


### PR DESCRIPTION
## Implementation

As discussed in https://github.com/draft-js-plugins/draft-js-plugins/issues/298, a few people have  accidentally used the same `createMentionPlugin()` plugin for multiple editor components. This happens because they expect the [examples in the docs](https://www.draft-js-plugins.com/plugin/mention) to work, even if there are multiple instances of the editor component on the same page. While this is [mentioned in the FAQ](https://github.com/draft-js-plugins/draft-js-plugins/blob/master/FAQ.md#can-i-use-the-same-plugin-for-multiple-plugin-editors), it would be helpful to mention also this in the documentation.

What are the disadvantages to always assigning the plugin instance to a property on the component? If you don't want to suggest this for the typical use case, I can change this PR to add another example for "Multiple Editors". 

## Use-case

A common use case for draft js is comment inputs. In a news-feed-like UI, there are often multiple commentable things on the page and thus you end up with multiple draft js inputs. If you follow the current guides that define `const mentionPlugin = createMentionPlugin();` outside of the component class, reusing your mention-enabled component will result in the error described in https://github.com/draft-js-plugins/draft-js-plugins/issues/298 because every component instance will be using the same `mentionPlugin` instance.

A more robust solution would be to log a warning if multiple components are using the same `mentionPlugin` instance. But for now, I think a documentation update would help new users of the project. 

## Allow editors for maintainers

- [x] Enable "Allow edits from maintainers" for this PR
