### PR TITLE
Add support for missing latin characters

### DIFF
--- a/draft-js-mention-plugin/CHANGELOG.md
+++ b/draft-js-mention-plugin/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Added support for Latin-1 Supplement and Latin Extended-A characters. Thanks to @thomas88
 - Added config option `mentionSuggestionsComponent`. If provided the passed component replaces the default `MentionSuggestions` component. The provided component must implement the same interface like `MentionSuggestions`.
 - Added support popoverComponent on the `MentionSuggestions` component. Thanks to @samdroid-apps
 - Introduced a new configuration option `mentionTrigger`. By default it is set to `@`. As before by default typing `@` will trigger the search for mentions. You can provide a custom character or string to change when the search is triggered. [#320](https://github.com/draft-js-plugins/draft-js-plugins/pull/320) Thanks to @yjang1031

--- a/draft-js-mention-plugin/src/defaultRegExp.js
+++ b/draft-js-mention-plugin/src/defaultRegExp.js
@@ -1,8 +1,30 @@
-// common chinese symbols: \u4e00-\u9eff - http://stackoverflow.com/a/1366113/837709
-// hiragana (japanese): \u3040-\u309F - https://gist.github.com/ryanmcgrath/982242#file-japaneseregex-js
-// katakana (japanese): \u30A0-\u30FF - https://gist.github.com/ryanmcgrath/982242#file-japaneseregex-js
-// For an advanced explaination about Hangul see https://github.com/draft-js-plugins/draft-js-plugins/pull/480#issuecomment-254055437
-// Hangul Syllables (korean): \uAC00-\uD7A3 - https://en.wikipedia.org/wiki/Korean_language_and_computers#Hangul_in_Unicode
-// Hangul Jamo (korean): \u3130-\u318F - https://en.wikipedia.org/wiki/Korean_language_and_computers#Hangul_in_Unicode
-// Cyrillic symbols: \u0410-\u044F - https://en.wikipedia.org/wiki/Cyrillic_script_in_Unicode
-export default '[\\w\u4e00-\u9eff\u3040-\u309F\u30A0-\u30FF\uAC00-\uD7A3\u3130-\u318F\u0410-\u044F]*';
+export default '[' +
+  'a-zA-Z0-9-' +
+
+  // Latin-1 Supplement (letters only) - https://en.wikipedia.org/wiki/List_of_Unicode_characters#Latin-1_Supplement
+  '\u00C0-\u00D6' +
+  '\u00D8-\u00F6' +
+  '\u00F8-\u00FF' +
+
+  // Latin Extended-A (without deprecated character) - https://en.wikipedia.org/wiki/List_of_Unicode_characters#Latin_Extended-A
+  '\u0100-\u0148' +
+  '\u014A-\u017F' +
+
+  // Cyrillic symbols: \u0410-\u044F - https://en.wikipedia.org/wiki/Cyrillic_script_in_Unicode
+  '\u0410-\u044F' +
+
+  // hiragana (japanese): \u3040-\u309F - https://gist.github.com/ryanmcgrath/982242#file-japaneseregex-js
+  '\u3040-\u309F' +
+
+  // katakana (japanese): \u30A0-\u30FF - https://gist.github.com/ryanmcgrath/982242#file-japaneseregex-js
+  '\u30A0-\u30FF' +
+
+  // For an advanced explaination about Hangul see https://github.com/draft-js-plugins/draft-js-plugins/pull/480#issuecomment-254055437
+  // Hangul Jamo (korean): \u3130-\u318F - https://en.wikipedia.org/wiki/Korean_language_and_computers#Hangul_in_Unicode
+  // Hangul Syllables (korean): \uAC00-\uD7A3 - https://en.wikipedia.org/wiki/Korean_language_and_computers#Hangul_in_Unicode
+  '\u3130-\u318F' +
+  '\uAC00-\uD7A3' +
+
+  // common chinese symbols: \u4e00-\u9eff - http://stackoverflow.com/a/1366113/837709
+  '\u4e00-\u9eff' +
+']*';

--- a/draft-js-mention-plugin/src/defaultRegExp.js
+++ b/draft-js-mention-plugin/src/defaultRegExp.js
@@ -1,5 +1,5 @@
 export default '[' +
-  'a-zA-Z0-9-' +
+  '\\w-' +
 
   // Latin-1 Supplement (letters only) - https://en.wikipedia.org/wiki/List_of_Unicode_characters#Latin-1_Supplement
   '\u00C0-\u00D6' +


### PR DESCRIPTION
## Implementation

- Adding support for Latin-1 Supplement and Latin Extended-A characters to the `defaultRegExp` in mentions plugin to allow searching European names.
- I've also replaced the `\w` with `a-zA-Z0-9-` (support `-` instead of `_`)
- Further I've split the regex into multiple strings and ordered them roughly by occurance in the unicode table.

Let me know if you'd like me to change anything.

## Demo

Add names like Anna Glöckner, María-Jose Quiñones, László Horvát or Linnéa Månsson to mentions.js in the simple editor example. You'll only be able to search them with the extended regex.
