### PR TITLE
Fix incorrect opening of suggestions

### DIFF
--- a/draft-js-mention-plugin/CHANGELOG.md
+++ b/draft-js-mention-plugin/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Fixed incorrect opening of suggestions. Thanks to @thomas88
 - Added config option `mentionSuggestionsComponent`. If provided the passed component replaces the default `MentionSuggestions` component. The provided component must implement the same interface like `MentionSuggestions`.
 - Added support popoverComponent on the `MentionSuggestions` component. Thanks to @samdroid-apps
 - Introduced a new configuration option `mentionTrigger`. By default it is set to `@`. As before by default typing `@` will trigger the search for mentions. You can provide a custom character or string to change when the search is triggered. [#320](https://github.com/draft-js-plugins/draft-js-plugins/pull/320) Thanks to @yjang1031

--- a/draft-js-mention-plugin/src/MentionSuggestions/index.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/index.js
@@ -41,7 +41,7 @@ export default class MentionSuggestions extends Component {
   componentWillReceiveProps(nextProps) {
     if (nextProps.suggestions.size === 0 && this.state.isActive) {
       this.closeDropdown();
-    } else if (nextProps.suggestions.size > 0 && !this.state.isActive) {
+    } else if (nextProps.suggestions.size > 0 && !nextProps.suggestions.equals(this.props.suggestions) && !this.state.isActive) {
       this.openDropdown();
     }
   }
@@ -153,7 +153,7 @@ export default class MentionSuggestions extends Component {
 
     // If none of the above triggered to close the window, it's safe to assume
     // the dropdown should be open. This is useful when a user focuses on another
-    // input field and then comes back: the dropdown will again.
+    // input field and then comes back: the dropdown will show again.
     if (!this.state.isActive && !this.props.store.isEscaped(this.activeOffsetKey)) {
       this.openDropdown();
     }


### PR DESCRIPTION
## Implementation

We've fixed async loading of suggestions (the issue here https://github.com/draft-js-plugins/draft-js-plugins/issues/633) by re-opening the dropdown when the `MentionSuggestions` component receives non-empty suggestions (see https://github.com/draft-js-plugins/draft-js-plugins/pull/807/files). 

This incorrectly opens the dropdown also when the component is re-rendered, but suggestions have not changed.

I'm adding a check that the suggestions have actually changed.

## Demo

Run the docs locally, focus the editor on the front page and hit enter a couple of times or try to at-mention "@ i i i i". Both issues are solved.

## Use-case

Fixes https://github.com/draft-js-plugins/draft-js-plugins/issues/825
Fixes https://github.com/draft-js-plugins/draft-js-plugins/issues/857
