### PR TITLE
Add loader module name extension

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ Because of the structure of this repository you can not just use your own fork o
 module: {
   loaders: [{
     test: /\.js$/,
-    loaders: ['babel'],
+    loaders: 'babel-loader',
     include: [
       path.join(__dirname, 'node_modules', 'draft-js-plugins', 'draft-js-plugins-editor', 'src'),
       path.join(__dirname, 'node_modules', 'draft-js-plugins', 'draft-js-hashtag-plugin', 'src'),
@@ -112,7 +112,7 @@ For your CSS loader in webpack, ensure you enable CSS modules:
 {
   test: /\.css$/,
   loaders: [
-    'style', 'css?modules'
+    'style-loader', 'css-loader?modules'
   ]
 }
 ```

--- a/docs/client/components/pages/Alignment/webpackConfig.js
+++ b/docs/client/components/pages/Alignment/webpackConfig.js
@@ -4,7 +4,7 @@ module.exports = {
       {
         test: /plugin\.css$/,
         loaders: [
-          'style', 'css',
+          'style-loader', 'css',
         ],
       },
     ],

--- a/docs/client/components/pages/Counter/webpackConfig.js
+++ b/docs/client/components/pages/Counter/webpackConfig.js
@@ -4,7 +4,7 @@ module.exports = {
       {
         test: /plugin\.css$/,
         loaders: [
-          'style', 'css',
+          'style-loader', 'css',
         ],
       },
     ],

--- a/docs/client/components/pages/DragNDrop/webpackConfig.js
+++ b/docs/client/components/pages/DragNDrop/webpackConfig.js
@@ -4,7 +4,7 @@ module.exports = {
       {
         test: /plugin\.css$/,
         loaders: [
-          'style', 'css',
+          'style-loader', 'css',
         ],
       },
     ],

--- a/docs/client/components/pages/Emoji/webpackConfig.js
+++ b/docs/client/components/pages/Emoji/webpackConfig.js
@@ -4,7 +4,7 @@ module.exports = {
       {
         test: /plugin\.css$/,
         loaders: [
-          'style', 'css',
+          'style-loader', 'css',
         ],
       },
     ],

--- a/docs/client/components/pages/Focus/webpackConfig.js
+++ b/docs/client/components/pages/Focus/webpackConfig.js
@@ -4,7 +4,7 @@ module.exports = {
       {
         test: /plugin\.css$/,
         loaders: [
-          'style', 'css',
+          'style-loader', 'css',
         ],
       },
     ],

--- a/docs/client/components/pages/Hashtag/webpackConfig.js
+++ b/docs/client/components/pages/Hashtag/webpackConfig.js
@@ -4,7 +4,7 @@ module.exports = {
       {
         test: /plugin\.css$/,
         loaders: [
-          'style', 'css',
+          'style-loader', 'css',
         ],
       },
     ],

--- a/docs/client/components/pages/Image/webpackConfig.js
+++ b/docs/client/components/pages/Image/webpackConfig.js
@@ -4,7 +4,7 @@ module.exports = {
       {
         test: /plugin\.css$/,
         loaders: [
-          'style', 'css',
+          'style-loader', 'css',
         ],
       },
     ],

--- a/docs/client/components/pages/InlineToolbar/webpackConfig.js
+++ b/docs/client/components/pages/InlineToolbar/webpackConfig.js
@@ -4,7 +4,7 @@ module.exports = {
       {
         test: /plugin\.css$/,
         loaders: [
-          'style', 'css',
+          'style-loader', 'css',
         ],
       },
     ],

--- a/docs/client/components/pages/Linkify/webpackConfig.js
+++ b/docs/client/components/pages/Linkify/webpackConfig.js
@@ -4,7 +4,7 @@ module.exports = {
       {
         test: /plugin\.css$/,
         loaders: [
-          'style', 'css',
+          'style-loader', 'css',
         ],
       },
     ],

--- a/docs/client/components/pages/Mention/webpackConfig.js
+++ b/docs/client/components/pages/Mention/webpackConfig.js
@@ -4,7 +4,7 @@ module.exports = {
       {
         test: /plugin\.css$/,
         loaders: [
-          'style', 'css',
+          'style-loader', 'css',
         ],
       },
     ],

--- a/docs/client/components/pages/Resizeable/webpackConfig.js
+++ b/docs/client/components/pages/Resizeable/webpackConfig.js
@@ -4,7 +4,7 @@ module.exports = {
       {
         test: /plugin\.css$/,
         loaders: [
-          'style', 'css',
+          'style-loader', 'css',
         ],
       },
     ],

--- a/docs/client/components/pages/SideToolbar/webpackConfig.js
+++ b/docs/client/components/pages/SideToolbar/webpackConfig.js
@@ -4,7 +4,7 @@ module.exports = {
       {
         test: /plugin\.css$/,
         loaders: [
-          'style', 'css',
+          'style-loader', 'css',
         ],
       },
     ],

--- a/docs/client/components/pages/StaticToolbar/webpackConfig.js
+++ b/docs/client/components/pages/StaticToolbar/webpackConfig.js
@@ -4,7 +4,7 @@ module.exports = {
       {
         test: /plugin\.css$/,
         loaders: [
-          'style', 'css',
+          'style-loader', 'css',
         ],
       },
     ],

--- a/docs/client/components/pages/Sticker/webpackConfig.js
+++ b/docs/client/components/pages/Sticker/webpackConfig.js
@@ -4,7 +4,7 @@ module.exports = {
       {
         test: /plugin\.css$/,
         loaders: [
-          'style', 'css',
+          'style-loader', 'css',
         ],
       },
     ],

--- a/docs/client/components/pages/Undo/webpackConfig.js
+++ b/docs/client/components/pages/Undo/webpackConfig.js
@@ -4,7 +4,7 @@ module.exports = {
       {
         test: /plugin\.css$/,
         loaders: [
-          'style', 'css',
+          'style-loader', 'css',
         ],
       },
     ],

--- a/docs/client/components/pages/Video/webpackConfig.js
+++ b/docs/client/components/pages/Video/webpackConfig.js
@@ -4,7 +4,7 @@ module.exports = {
       {
         test: /plugin\.css$/,
         loaders: [
-          'style', 'css',
+          'style-loader', 'css',
         ],
       },
     ],

--- a/draft-js-counter-plugin/README.md
+++ b/draft-js-counter-plugin/README.md
@@ -48,7 +48,7 @@ Follow the steps below to import the css file by using Webpack's `style-loader` 
       loaders: [{
         test: /\.css$/,
         loaders: [
-          'style', 'css'
+          'style-loader', 'css'
         ]
       }]
     }

--- a/draft-js-emoji-plugin/README.md
+++ b/draft-js-emoji-plugin/README.md
@@ -40,7 +40,7 @@ Follow the below steps to import the css file by using Webpack's `style-loader` 
       loaders: [{
         test: /\.css$/,
         loaders: [
-          'style', 'css'
+          'style-loader', 'css'
         ]
       }]
     }

--- a/draft-js-hashtag-plugin/README.md
+++ b/draft-js-hashtag-plugin/README.md
@@ -28,7 +28,7 @@ Follow the steps below to import the css file by using Webpack's `style-loader` 
       loaders: [{
         test: /\.css$/,
         loaders: [
-          'style', 'css'
+          'style-loader', 'css'
         ]
       }]
     }

--- a/draft-js-linkify-plugin/README.md
+++ b/draft-js-linkify-plugin/README.md
@@ -38,7 +38,7 @@ Follow the steps below to import the css file by using Webpack's `style-loader` 
       loaders: [{
         test: /\.css$/,
         loaders: [
-          'style', 'css'
+          'style-loader', 'css'
         ]
       }]
     }

--- a/draft-js-mention-plugin/README.md
+++ b/draft-js-mention-plugin/README.md
@@ -28,7 +28,7 @@ Follow the steps below to import the css file by using Webpack's `style-loader` 
       loaders: [{
         test: /\.css$/,
         loaders: [
-          'style', 'css'
+          'style-loader', 'css'
         ]
       }]
     }

--- a/draft-js-sticker-plugin/README.md
+++ b/draft-js-sticker-plugin/README.md
@@ -31,7 +31,7 @@ Follow the steps below to import the css file by using Webpack's `style-loader` 
       loaders: [{
         test: /\.css$/,
         loaders: [
-          'style', 'css'
+          'style-loader', 'css'
         ]
       }]
     }

--- a/draft-js-undo-plugin/README.md
+++ b/draft-js-undo-plugin/README.md
@@ -52,7 +52,7 @@ Follow the steps below to import the css file by using Webpack's `style-loader` 
       loaders: [{
         test: /\.css$/,
         loaders: [
-          'style', 'css'
+          'style-loader', 'css'
         ]
       }]
     }


### PR DESCRIPTION
 https://webpack.js.org/guides/migrating/#automatic-loader-module-name-extension-removed