### PR TITLE
Pass through isFocused prop to mention entry

### DIFF
--- a/docs/client/components/pages/Mention/CustomMentionEditor/index.js
+++ b/docs/client/components/pages/Mention/CustomMentionEditor/index.js
@@ -39,6 +39,7 @@ const Entry = (props) => {
     mention,
     theme,
     searchValue, // eslint-disable-line no-unused-vars
+    isFocused, // eslint-disable-line no-unused-vars
     ...parentProps
   } = props;
 

--- a/draft-js-mention-plugin/CHANGELOG.md
+++ b/draft-js-mention-plugin/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Passing through `isFocused` prop to `entryComponent`. Thanks to @thomas88
 - Added support for Latin-1 Supplement and Latin Extended-A characters. Thanks to @thomas88
 - Fixed incorrect opening of suggestions. Thanks to @thomas88
 - Added multiple character support for mentionTrigger

--- a/draft-js-mention-plugin/src/MentionSuggestions/Entry/index.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/Entry/index.js
@@ -39,8 +39,8 @@ export default class Entry extends Component {
   };
 
   render() {
-    const { theme = {}, searchValue } = this.props;
-    const className = this.props.isFocused ? theme.mentionSuggestionsEntryFocused : theme.mentionSuggestionsEntry;
+    const { theme = {}, mention, searchValue, isFocused } = this.props;
+    const className = isFocused ? theme.mentionSuggestionsEntryFocused : theme.mentionSuggestionsEntry;
     const EntryComponent = this.props.entryComponent;
     return (
       <EntryComponent
@@ -50,7 +50,8 @@ export default class Entry extends Component {
         onMouseEnter={this.onMouseEnter}
         role="option"
         theme={theme}
-        mention={this.props.mention}
+        mention={mention}
+        isFocused={isFocused}
         searchValue={searchValue}
       />
     );


### PR DESCRIPTION
This is a proposal to pass through the `isFocused` prop to the mention entry. This is useful for people who are not using classNames for styling e.g. when using `styled-components`.

Currently I need to do the following in my entry component for determining wether it is focused:

```javascript
  const isFocused = className === theme.mentionSuggestionsEntryFocused;
```