### PR TITLE
Fix critical bug in image plugin

### DIFF
--- a/draft-js-image-plugin/CHANGELOG.md
+++ b/draft-js-image-plugin/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To Be Released
+### fixed critical bug in combination with focus plugin
 
 ### Released the first working of DraftJS State Plugin
 

--- a/draft-js-image-plugin/src/index.js
+++ b/draft-js-image-plugin/src/index.js
@@ -18,8 +18,9 @@ export default (config = {}) => {
     blockRendererFn: (block, { getEditorState }) => {
       if (block.getType() === 'atomic') {
         const contentState = getEditorState().getCurrentContent();
-        const entity = contentState.getEntity(block.getEntityAt(0));
-        const type = entity.getType();
+        const entity = block.getEntityAt(0);
+        if (!entity) return;
+        const type = contentState.getEntity(entity).getType();
         if (type === 'image') {
           return {
             component: ThemedImage,

--- a/draft-js-image-plugin/src/index.js
+++ b/draft-js-image-plugin/src/index.js
@@ -19,7 +19,7 @@ export default (config = {}) => {
       if (block.getType() === 'atomic') {
         const contentState = getEditorState().getCurrentContent();
         const entity = block.getEntityAt(0);
-        if (!entity) return;
+        if (!entity) return null;
         const type = contentState.getEntity(entity).getType();
         if (type === 'image') {
           return {
@@ -27,6 +27,7 @@ export default (config = {}) => {
             editable: false,
           };
         }
+        return null;
       }
 
       return null;


### PR DESCRIPTION
All this does is introduce a check to make sure we don't crash the
editor when no entity with a certain ID is found.

Closes #778