### PR TITLE
Update blockRendererFn

### DIFF
--- a/draft-js-image-plugin/src/index.js
+++ b/draft-js-image-plugin/src/index.js
@@ -18,7 +18,9 @@ export default (config = {}) => {
     blockRendererFn: (block, { getEditorState }) => {
       if (block.getType() === 'atomic') {
         const contentState = getEditorState().getCurrentContent();
-        const entity = contentState.getEntity(block.getEntityAt(0));
+        const entityKey = block.getEntityAt(0);
+        if (!entityKey) return;
+        const entity = contentState.getEntity(entityKey);
         const type = entity.getType();
         if (type === 'image') {
           return {


### PR DESCRIPTION
fix 'Unknown DraftEntity key' error happened on pressing enter key or other command to image

<!--
Please check out Contributing Guidelines. By following this template you help us to review your code.
https://github.com/draft-js-plugins/draft-js-plugins/blob/master/CONTRIBUTING.md
-->

## Implementation

<!--
Briefly describe the feature or fix
-->

After inserting an image, one may click the image to get it focused and do some operations, like pressing `enter` or upload anther image.
At this time, in this method `blockRendererFn`, using `block.getEntityAt(0)` will get `null`, and an uncaught error '**Unknown DraftEntity key**' would be thrown.

## Demo

<!--
Please add a recorded gif and ideally code example how to test the feature or reproduce the bug.
-->
bug reproduce（the error was thrown while I'm pressing enter）

![bug-reproduce](https://user-images.githubusercontent.com/11664604/30652137-359f5b60-9ded-11e7-8cad-5cce17b2b71a.gif)

<!--
In case this is a new feature, property or function that is exposed please describe why you need it.
-->

## Allow editors for maintainers

- [x] Enable "Allow edits from maintainers" for this PR
