### PR TITLE
Add ability to use custom buttons and decorator styling in alignment plugin like inline-toolbar

### DIFF
--- a/draft-js-alignment-plugin/CHANGELOG.md
+++ b/draft-js-alignment-plugin/CHANGELOG.md
@@ -5,4 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To Be Released
 
+### Added
+
+- Added the option to customize the buttons in the toolbar and the styling that would be applied to the block based on the alignment. Check [#887](https://github.com/draft-js-plugins/draft-js-plugins/pull/887)
+
 ### Released the first working of DraftJS State Plugin

--- a/draft-js-alignment-plugin/src/AlignmentTool/index.js
+++ b/draft-js-alignment-plugin/src/AlignmentTool/index.js
@@ -66,7 +66,7 @@ export default class AlignmentTool extends React.Component {
 
   render() {
     const { structure } = this.props;
-    
+
     return (
       <div
         className={styles.alignmentTool}

--- a/draft-js-alignment-plugin/src/AlignmentTool/index.js
+++ b/draft-js-alignment-plugin/src/AlignmentTool/index.js
@@ -1,11 +1,5 @@
 /* eslint-disable react/no-array-index-key */
 import React from 'react';
-import {
-  AlignBlockDefaultButton,
-  AlignBlockLeftButton,
-  AlignBlockCenterButton,
-  AlignBlockRightButton,
-} from 'draft-js-buttons';
 import styles from '../alignmentToolStyles.css';
 import buttonStyles from '../buttonStyles.css';
 
@@ -71,19 +65,15 @@ export default class AlignmentTool extends React.Component {
   }
 
   render() {
-    const defaultButtons = [
-      AlignBlockDefaultButton,
-      AlignBlockLeftButton,
-      AlignBlockCenterButton,
-      AlignBlockRightButton,
-    ];
+    const { structure } = this.props;
+    
     return (
       <div
         className={styles.alignmentTool}
         style={this.state.position}
         ref={(toolbar) => { this.toolbar = toolbar; }}
       >
-        {defaultButtons.map((Button, index) => (
+        {structure.map((Button, index) => (
           <Button
             /* the index can be used here as the buttons list won't change */
             key={index}

--- a/draft-js-alignment-plugin/src/createDecorator.js
+++ b/draft-js-alignment-plugin/src/createDecorator.js
@@ -6,17 +6,17 @@ const getDisplayName = (WrappedComponent) => {
   return component.displayName || component.name || 'Component';
 };
 
-const defaultDecoratorRenderStyling = (alignment,{style, className}) => {
+const defaultDecoratorRenderStyling = (alignment, { style, className }) => {
   let newStyle = style;
-    if (alignment === 'left') {
-      newStyle = { ...style, float: 'left' };
-    } else if (alignment === 'right') {
-      newStyle = { ...style, float: 'right' };
-    } else if (alignment === 'center') {
-      newStyle = { ...style, marginLeft: 'auto', marginRight: 'auto', display: 'block' };
-    }
-  return {style: newStyle,className};
-}
+  if (alignment === 'left') {
+    newStyle = { ...style, float: 'left' };
+  } else if (alignment === 'right') {
+    newStyle = { ...style, float: 'right' };
+  } else if (alignment === 'center') {
+    newStyle = { ...style, marginLeft: 'auto', marginRight: 'auto', display: 'block' };
+  }
+  return { style: newStyle, className };
+};
 
 export default ({ config, store }) => (WrappedComponent) => class BlockAlignmentDecorator extends Component {
   static displayName = `BlockDraggable(${getDisplayName(WrappedComponent)})`;
@@ -54,12 +54,12 @@ export default ({ config, store }) => (WrappedComponent) => class BlockAlignment
       ...elementProps
     } = this.props;
     const alignment = blockProps.alignment;
-    
+
     const {
       decoratorRenderStyling = defaultDecoratorRenderStyling
     } = config;
 
-    const styling = decoratorRenderStyling(alignment,{style,className})
+    const styling = decoratorRenderStyling(alignment, { style, className });
 
     return (
       <WrappedComponent

--- a/draft-js-alignment-plugin/src/createDecorator.js
+++ b/draft-js-alignment-plugin/src/createDecorator.js
@@ -6,7 +6,19 @@ const getDisplayName = (WrappedComponent) => {
   return component.displayName || component.name || 'Component';
 };
 
-export default ({ store }) => (WrappedComponent) => class BlockAlignmentDecorator extends Component {
+const defaultDecoratorRenderStyling = (alignment,{style, className}) => {
+  let newStyle = style;
+    if (alignment === 'left') {
+      newStyle = { ...style, float: 'left' };
+    } else if (alignment === 'right') {
+      newStyle = { ...style, float: 'right' };
+    } else if (alignment === 'center') {
+      newStyle = { ...style, marginLeft: 'auto', marginRight: 'auto', display: 'block' };
+    }
+  return {style: newStyle,className};
+}
+
+export default ({ config, store }) => (WrappedComponent) => class BlockAlignmentDecorator extends Component {
   static displayName = `BlockDraggable(${getDisplayName(WrappedComponent)})`;
   static WrappedComponent = WrappedComponent.WrappedComponent || WrappedComponent;
 
@@ -37,24 +49,23 @@ export default ({ store }) => (WrappedComponent) => class BlockAlignmentDecorato
     const {
       blockProps,
       style,
+      className,
       // using destructuring to make sure unused props are not passed down to the block
       ...elementProps
     } = this.props;
     const alignment = blockProps.alignment;
-    let newStyle = style;
-    if (alignment === 'left') {
-      newStyle = { ...style, float: 'left' };
-    } else if (alignment === 'right') {
-      newStyle = { ...style, float: 'right' };
-    } else if (alignment === 'center') {
-      newStyle = { ...style, marginLeft: 'auto', marginRight: 'auto', display: 'block' };
-    }
+    
+    const {
+      decoratorRenderStyling = defaultDecoratorRenderStyling
+    } = config;
+
+    const styling = decoratorRenderStyling(alignment,{style,className})
 
     return (
       <WrappedComponent
         {...elementProps}
         blockProps={blockProps}
-        style={newStyle}
+        {...styling}
       />
     );
   }

--- a/draft-js-alignment-plugin/src/index.js
+++ b/draft-js-alignment-plugin/src/index.js
@@ -3,10 +3,13 @@ import decorateComponentWithProps from 'decorate-component-with-props';
 import createDecorator from './createDecorator';
 import AlignmentTool from './AlignmentTool';
 import createStore from './utils/createStore';
+import {
+  AlignBlockDefaultButton,
+  AlignBlockLeftButton,
+  AlignBlockCenterButton,
+  AlignBlockRightButton,
+} from 'draft-js-buttons';
 
-const store = createStore({
-  isVisible: false,
-});
 
 const createSetAlignment = (contentBlock, { getEditorState, setEditorState }) => (data) => {
   const entityKey = contentBlock.getEntityAt(0);
@@ -18,10 +21,27 @@ const createSetAlignment = (contentBlock, { getEditorState, setEditorState }) =>
   }
 };
 
-export default (config) => {
+
+export default (config = {}) => {
+
+  const store = createStore({
+    isVisible: false,
+  });
+
+  const {
+    structure = [
+      AlignBlockDefaultButton,
+      AlignBlockLeftButton,
+      AlignBlockCenterButton,
+      AlignBlockRightButton
+    ]
+  } = config;
+
   const alignmentToolProps = {
+    structure,
     store
   };
+  
   return {
     initialize: ({ getReadOnly, getEditorState, setEditorState }) => {
       store.updateItem('getReadOnly', getReadOnly);

--- a/draft-js-alignment-plugin/src/index.js
+++ b/draft-js-alignment-plugin/src/index.js
@@ -1,14 +1,14 @@
 import { EditorState } from 'draft-js';
 import decorateComponentWithProps from 'decorate-component-with-props';
-import createDecorator from './createDecorator';
-import AlignmentTool from './AlignmentTool';
-import createStore from './utils/createStore';
 import {
   AlignBlockDefaultButton,
   AlignBlockLeftButton,
   AlignBlockCenterButton,
   AlignBlockRightButton,
 } from 'draft-js-buttons';
+import createDecorator from './createDecorator';
+import AlignmentTool from './AlignmentTool';
+import createStore from './utils/createStore';
 
 
 const createSetAlignment = (contentBlock, { getEditorState, setEditorState }) => (data) => {
@@ -23,7 +23,6 @@ const createSetAlignment = (contentBlock, { getEditorState, setEditorState }) =>
 
 
 export default (config = {}) => {
-
   const store = createStore({
     isVisible: false,
   });
@@ -41,7 +40,7 @@ export default (config = {}) => {
     structure,
     store
   };
-  
+
   return {
     initialize: ({ getReadOnly, getEditorState, setEditorState }) => {
       store.updateItem('getReadOnly', getReadOnly);

--- a/stories/Alignment/CustomAlignmentEditor/colorBlockPlugin.js
+++ b/stories/Alignment/CustomAlignmentEditor/colorBlockPlugin.js
@@ -1,0 +1,43 @@
+import React from 'react';
+
+const ColorBlock = ({
+  block, // eslint-disable-line no-unused-vars
+  blockProps, // eslint-disable-line no-unused-vars
+  customStyleMap, // eslint-disable-line no-unused-vars
+  customStyleFn, // eslint-disable-line no-unused-vars
+  decorator, // eslint-disable-line no-unused-vars
+  forceSelection, // eslint-disable-line no-unused-vars
+  offsetKey, // eslint-disable-line no-unused-vars
+  selection, // eslint-disable-line no-unused-vars
+  tree, // eslint-disable-line no-unused-vars
+  contentState, // eslint-disable-line no-unused-vars
+  style,
+  ...elementProps
+}) => (
+  <div
+    {...elementProps}
+    style={{ width: 200, height: 80, backgroundColor: '#9bc0c7', ...style }}
+  />
+  );
+
+const createColorBlockPlugin = (config = {}) => {
+  const component = config.decorator ? config.decorator(ColorBlock) : ColorBlock;
+  return {
+    blockRendererFn: (block, { getEditorState }) => {
+      if (block.getType() === 'atomic') {
+        const contentState = getEditorState().getCurrentContent();
+        const entity = contentState.getEntity(block.getEntityAt(0));
+        const type = entity.getType();
+        if (type === 'colorBlock') {
+          return {
+            component,
+            editable: false,
+          };
+        }
+      }
+      return null;
+    },
+  };
+};
+
+export default createColorBlockPlugin;

--- a/stories/Alignment/CustomAlignmentEditor/editorStyles.css
+++ b/stories/Alignment/CustomAlignmentEditor/editorStyles.css
@@ -1,0 +1,18 @@
+.editor {
+  box-sizing: border-box;
+  border: 1px solid #ddd;
+  cursor: text;
+  padding: 16px;
+  border-radius: 2px;
+  margin-bottom: 2em;
+  box-shadow: inset 0px 1px 8px -3px #ABABAB;
+  background: #fefefe;
+}
+
+.editor :global(.public-DraftEditor-content) {
+  min-height: 140px;
+}
+
+.options {
+  margin-bottom: 20px;
+}

--- a/stories/Alignment/CustomAlignmentEditor/index.js
+++ b/stories/Alignment/CustomAlignmentEditor/index.js
@@ -6,24 +6,25 @@ import {
 import Editor, { composeDecorators } from 'draft-js-plugins-editor';
 import createAlignmentPlugin from 'draft-js-alignment-plugin';
 import createFocusPlugin from 'draft-js-focus-plugin';
-import createColorBlockPlugin from './colorBlockPlugin';
-import editorStyles from './editorStyles.css';
 import {
   AlignBlockDefaultButton,
   AlignBlockLeftButton
 } from 'draft-js-buttons';
+import createColorBlockPlugin from './colorBlockPlugin';
+import editorStyles from './editorStyles.css';
 
-const decoratorRenderStyling = (alignment,{style, className}) => {
+const decoratorRenderStyling = (alignment, { style, className }) => {
   let newStyle = style;
-    if (alignment === 'left') {
-      newStyle = { ...style, backgroundColor: "red" };
-    } 
-  return {style: newStyle,className};
-}
+  if (alignment === 'left') {
+    newStyle = { ...style, backgroundColor: 'red' };
+  }
+  return { style: newStyle, className };
+};
 
 const focusPlugin = createFocusPlugin();
-const alignmentPlugin = createAlignmentPlugin({structure: [AlignBlockDefaultButton,
-  AlignBlockLeftButton],decoratorRenderStyling});
+const alignmentPlugin = createAlignmentPlugin({ structure: [AlignBlockDefaultButton,
+  AlignBlockLeftButton],
+  decoratorRenderStyling });
 const { AlignmentTool } = alignmentPlugin;
 
 const decorator = composeDecorators(

--- a/stories/Alignment/CustomAlignmentEditor/index.js
+++ b/stories/Alignment/CustomAlignmentEditor/index.js
@@ -1,0 +1,109 @@
+import React, { Component } from 'react';
+import {
+  convertFromRaw,
+  EditorState,
+} from 'draft-js';
+import Editor, { composeDecorators } from 'draft-js-plugins-editor';
+import createAlignmentPlugin from 'draft-js-alignment-plugin';
+import createFocusPlugin from 'draft-js-focus-plugin';
+import createColorBlockPlugin from './colorBlockPlugin';
+import editorStyles from './editorStyles.css';
+import {
+  AlignBlockDefaultButton,
+  AlignBlockLeftButton
+} from 'draft-js-buttons';
+
+const decoratorRenderStyling = (alignment,{style, className}) => {
+  let newStyle = style;
+    if (alignment === 'left') {
+      newStyle = { ...style, backgroundColor: "red" };
+    } 
+  return {style: newStyle,className};
+}
+
+const focusPlugin = createFocusPlugin();
+const alignmentPlugin = createAlignmentPlugin({structure: [AlignBlockDefaultButton,
+  AlignBlockLeftButton],decoratorRenderStyling});
+const { AlignmentTool } = alignmentPlugin;
+
+const decorator = composeDecorators(
+  alignmentPlugin.decorator,
+  focusPlugin.decorator,
+);
+
+const colorBlockPlugin = createColorBlockPlugin({ decorator });
+const plugins = [focusPlugin, alignmentPlugin, colorBlockPlugin];
+
+/* eslint-disable */
+const initialState = {
+    "entityMap": {
+        "0": {
+            "type": "colorBlock",
+            "mutability": "IMMUTABLE",
+            "data": {}
+        }
+    },
+    "blocks": [{
+        "key": "9gm3s",
+        "text": "This is a simple example. Focus the block by clicking on it and change alignment via the toolbar.",
+        "type": "unstyled",
+        "depth": 0,
+        "inlineStyleRanges": [],
+        "entityRanges": [],
+        "data": {}
+    }, {
+        "key": "ov7r",
+        "text": " ",
+        "type": "atomic",
+        "depth": 0,
+        "inlineStyleRanges": [],
+        "entityRanges": [{
+            "offset": 0,
+            "length": 1,
+            "key": 0
+        }],
+        "data": {}
+    }, {
+        "key": "e23a8",
+        "text": "More text here to demonstrate how inline left/right alignment works …",
+        "type": "unstyled",
+        "depth": 0,
+        "inlineStyleRanges": [],
+        "entityRanges": [],
+        "data": {}
+    }]
+};
+/* eslint-enable */
+
+export default class CustomAlignmentEditor extends Component {
+
+  state = {
+    editorState: EditorState.createWithContent(convertFromRaw(initialState)),
+  };
+
+  onChange = (editorState) => {
+    this.setState({
+      editorState,
+    });
+  };
+
+  focus = () => {
+    this.editor.focus();
+  };
+
+  render() {
+    return (
+      <div>
+        <div className={editorStyles.editor} onClick={this.focus}>
+          <Editor
+            editorState={this.state.editorState}
+            onChange={this.onChange}
+            plugins={plugins}
+            ref={(element) => { this.editor = element; }}
+          />
+          <AlignmentTool />
+        </div>
+      </div>
+    );
+  }
+}

--- a/stories/index.js
+++ b/stories/index.js
@@ -6,6 +6,7 @@ import { storiesOf } from '@storybook/react';
 
 // Alignment
 import SimpleAlignmentEditor from './Alignment/SimpleAlignmentEditor';
+import CustomAlignmentEditor from './Alignment/CustomAlignmentEditor';
 
 // Anchor
 import AnchorSimpleLinkPluginEditor from './Anchor/SimpleLinkPluginEditor';
@@ -67,7 +68,8 @@ import CustomVideoEditor from './Video/CustomVideoEditor';
 import CustomAddVideoEditor from './Video/CustomAddVideoEditor';
 
 storiesOf('Alignment Plugin', module)
-  .add('Editor with Alignment Plugin', () => <SimpleAlignmentEditor />);
+  .add('Editor with Alignment Plugin', () => <SimpleAlignmentEditor />)
+  .add('Editor with Alignment Plugin and only two buttons enabled', () => <CustomAlignmentEditor />);
 
 storiesOf('Anchor Plugin', module)
   .add('Editor with Anchor Plugin', () => <AnchorSimpleLinkPluginEditor />);


### PR DESCRIPTION


## Implementation

The config argument of createAlignmentPlugin now accepts two children:
- structure : an array containing buttons to be on the toolbar (from draft-js-buttons)
- decoratorRenderStyling : a function that takes in `(alignment, {style, className})` and outputs props to be used on the decorated block.

## Screenshot

![image](https://user-images.githubusercontent.com/5086419/30774198-54baa1c8-a0b1-11e7-901b-98bcecabf840.png)
![image](https://user-images.githubusercontent.com/5086419/30774210-8454bb6c-a0b1-11e7-8d88-4c22f8f1d86b.png)

## Demo

I have added a new story to the storybook to show this new feature.

## Use-case

There should be away to customize the rendering of this plugin.

