### PR TITLE
Also update getEditorState to current editor state

### DIFF
--- a/draft-js-static-toolbar-plugin/src/index.js
+++ b/draft-js-static-toolbar-plugin/src/index.js
@@ -41,6 +41,8 @@ export default (config = {}) => {
     // Re-Render the text-toolbar on selection change
     onChange: (editorState) => {
       store.updateItem('selection', editorState.getSelection());
+      store.updateItem('getEditorState', () => editorState);
+      
       return editorState;
     },
     Toolbar: decorateComponentWithProps(Toolbar, toolbarProps),


### PR DESCRIPTION
If not, then the editorState that is used to detect if the button is active is the old editorstate.
## Implementation

The toolbar plugin passes old editorState to buttons instead of the current one. Here we change to use the current state. 

The alternative is to change how getEditorState is handled when resolving plugins in 
https://github.com/draft-js-plugins/draft-js-plugins/blob/af5f6f7ebaee985d25e7cc4d8d66c5b22fd1ec41/draft-js-plugins-editor/src/Editor/index.js#L92


## Demo
First gif: This is without the patch. The button is clicked, but it's state is not set to active before I start writing:
![recording 5](https://user-images.githubusercontent.com/211263/30802807-fa9f67d6-a1e7-11e7-85f6-1b5fe1d8df37.gif)

Here is with the patch, the button is marked active at once:
![recording 3](https://user-images.githubusercontent.com/211263/30803084-b45ffe7e-a1e8-11e7-96ff-b25a387b8591.gif)

Please note, that the first ~5s are static in the animation.

<!--
Please add a recorded gif and ideally code example how to test the feature or reproduce the bug.
-->

## Use-case

<!--
In case this is a new feature, property or function that is exposed please describe why you need it.
-->

## Allow editors for maintainers

- [x ] Enable "Allow edits from maintainers" for this PR
