### PR TITLE
fix for newline when focusable atomic block is selected

### DIFF
--- a/draft-js-focus-plugin/CHANGELOG.md
+++ b/draft-js-focus-plugin/CHANGELOG.md
@@ -4,5 +4,6 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To Be Released
+### Fixed bug when pressing enter on a focussed block
 
 ### Released the first working of DraftJS State Plugin

--- a/draft-js-focus-plugin/src/index.js
+++ b/draft-js-focus-plugin/src/index.js
@@ -1,4 +1,5 @@
 import { EditorState } from 'draft-js';
+import insertNewLine from './modifiers/insertNewLine';
 import setSelection from './modifiers/setSelection';
 import setSelectionToBlock from './modifiers/setSelectionToBlock';
 import createDecorator from './createDecorator';
@@ -24,6 +25,14 @@ export default (config = {}) => {
   let lastContentState;
 
   return {
+    handleReturn: (event, editorState, { setEditorState }) => {
+      // if a focusable block is selected then overwrite new line behavior to custom
+      if (focusableBlockIsSelected(editorState, blockKeyStore)) {
+        setEditorState(insertNewLine(editorState));
+        return 'handled';
+      }
+      return 'not-handled';
+    },
     onChange: (editorState) => {
       // in case the content changed there is no need to re-render blockRendererFn
       // since if a block was added it will be rendered anyway and if it was text

--- a/draft-js-focus-plugin/src/modifiers/insertNewLine.js
+++ b/draft-js-focus-plugin/src/modifiers/insertNewLine.js
@@ -1,0 +1,42 @@
+import { List } from 'immutable';
+import {
+  Modifier,
+  ContentBlock,
+  EditorState,
+  BlockMapBuilder,
+  genKey as generateRandomKey,
+} from 'draft-js';
+
+export default function insertNewLine(editorState) {
+  const newEditorState = EditorState.forceSelection(
+    editorState,
+    editorState.getCurrentContent().getSelectionAfter(),
+  );
+  const contentState = newEditorState.getCurrentContent();
+  const selectionState = newEditorState.getSelection();
+  const insertionTarget = contentState.getSelectionAfter();
+
+  const fragmentArray = [
+    new ContentBlock({
+      key: generateRandomKey(),
+      type: 'unstyled',
+      text: '',
+      characterList: List(),
+    }),
+  ];
+
+  const fragment = BlockMapBuilder.createFromArray(fragmentArray);
+
+  const withUnstyledBlock = Modifier.replaceWithFragment(
+    contentState,
+    insertionTarget,
+    fragment,
+  );
+
+  const newContent = withUnstyledBlock.merge({
+    selectionBefore: selectionState,
+    selectionAfter: withUnstyledBlock.getSelectionAfter().set('hasFocus', true),
+  });
+
+  return EditorState.push(newEditorState, newContent, 'insert-fragment');
+}


### PR DESCRIPTION
fixes #885 
Current behaviour: when i press enter on a focused block the newline is generated before the block
Now: the newline is generated after the focused block