### PR TITLE
fix native emojis

### DIFF
--- a/draft-js-emoji-plugin/CHANGELOG.md
+++ b/draft-js-emoji-plugin/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.0.0-rc9
+
+### Fix native emojis
+- render props.children instead, fixes editing behaviour
+
 ## To Be Released
 
 ### Fixed

--- a/draft-js-emoji-plugin/package.json
+++ b/draft-js-emoji-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "draft-js-emoji-plugin",
-  "version": "2.0.0-rc8",
+  "version": "2.0.0-rc9",
   "description": "Emoji Plugin for DraftJS",
   "author": {
     "name": "Nik Graf",

--- a/draft-js-emoji-plugin/src/components/Emoji/index.js
+++ b/draft-js-emoji-plugin/src/components/Emoji/index.js
@@ -1,20 +1,17 @@
 import React from 'react';
 import unionClassNames from 'union-class-names';
 import emojione from 'emojione';
-import emojiList from '../../utils/emojiList';
-import convertShortNameToUnicode from '../../utils/convertShortNameToUnicode';
 
 const Emoji = ({ theme = {}, cacheBustParam, imagePath, imageType, className, decoratedText, useNativeArt, ...props }) => {
   const shortName = emojione.toShort(decoratedText);
 
   let emojiDisplay = null;
   if (useNativeArt === true) {
-    const unicode = emojiList.list[shortName][0];
     emojiDisplay = (
       <span
         title={emojione.toShort(decoratedText)}
       >
-        {convertShortNameToUnicode(unicode)}
+        {props.children}
       </span>
     );
   } else {


### PR DESCRIPTION
## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

fixes #886

## Implementation

The problem is that we weren't using `props.children` for the decorated component, that screws up draft-js internal logic...

## Demo
Native emojis are working again:

![emoji-works](https://user-images.githubusercontent.com/1188186/30832994-178f4372-a245-11e7-97c0-165f2b272990.gif)

