### PR TITLE
Add support for clickable buttons

### DIFF
--- a/draft-js-buttons/src/index.js
+++ b/draft-js-buttons/src/index.js
@@ -1,5 +1,7 @@
 import createBlockStyleButton from './utils/createBlockStyleButton';
 import createInlineStyleButton from './utils/createInlineStyleButton';
+import createBlockAlignmentButton from './utils/createBlockAlignmentButton';
+import createOnClickButton from './utils/createOnClickButton';
 import ItalicButton from './components/ItalicButton';
 import BoldButton from './components/BoldButton';
 import CodeButton from './components/CodeButton';
@@ -19,6 +21,8 @@ import AlignBlockRightButton from './components/AlignBlockRightButton';
 export {
   createBlockStyleButton,
   createInlineStyleButton,
+  createBlockAlignmentButton,
+  createOnClickButton,
   ItalicButton,
   BoldButton,
   CodeButton,

--- a/draft-js-buttons/src/utils/createOnClickButton.js
+++ b/draft-js-buttons/src/utils/createOnClickButton.js
@@ -1,0 +1,39 @@
+/* eslint-disable react/no-children-prop */
+import React, { Component } from 'react';
+import unionClassNames from 'union-class-names';
+
+export default ({ children }) => (
+  class OnClickButton extends Component {
+
+    activate = (event) => {
+      event.preventDefault();
+      this.props.onClick({
+        getEditorState: this.props.getEditorState,
+        setEditorState: this.props.setEditorState
+      });
+    }
+
+    preventBubblingUp = (event) => { event.preventDefault(); }
+
+    // we check if this.props.getEditorState is undefined first in case the button is rendered before the editor
+    styleIsActive = () => false;
+
+    render() {
+      const { theme } = this.props;
+      const className = this.styleIsActive() ? unionClassNames(theme.button, theme.active) : theme.button;
+      return (
+        <div
+          className={theme.buttonWrapper}
+          onMouseDown={this.preventBubblingUp}
+        >
+          <button
+            className={className}
+            onClick={this.activate}
+            type="button"
+            children={children}
+          />
+        </div>
+      );
+    }
+  }
+);


### PR DESCRIPTION
Please check out Contributing Guidelines. By following this template you help us to review your code.
https://github.com/draft-js-plugins/draft-js-plugins/blob/master/CONTRIBUTING.md

## Checklist

- [ ] Fix any eslint errors that occur
- [ ] Update change-log for every plugin you touch
- [ ] Add/Update tests if you add/change new functionality
- [ ] Add/Update docs if you add/change functionality
- [ ] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

Add a toolbar button that calls an onClick prop when clicked. 

## Implementation
This implementation follows the other createXX Button HOCs to create a button that just triggers a callback that can be used to show popups etc for the user. 



