### PR TITLE
Remove unused packages from project and trigger fresh publish

### DIFF
--- a/draft-js-anchor-plugin/CHANGELOG.md
+++ b/draft-js-anchor-plugin/CHANGELOG.md
@@ -3,8 +3,8 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## 2.0.0-rc9 - 2018-09-25
-### Replaced url-regex with local util
+## 2.0.0-rc9 - 2017-10-03
+### Removed unused packages (immutable, ip-regex) from project
 
 ## 2.0.0-rc8 - 2016-08-16
 ### Released the first working version of the DraftJS Anchor Plugin

--- a/draft-js-anchor-plugin/package.json
+++ b/draft-js-anchor-plugin/package.json
@@ -33,8 +33,6 @@
   "license": "MIT",
   "dependencies": {
     "decorate-component-with-props": "^1.0.2",
-    "immutable": "~3.7.4",
-    "ip-regex": "^2.1.0",
     "prepend-http": "1.0.4",
     "prop-types": "^15.5.8",
     "tlds": "^1.197.0",


### PR DESCRIPTION
## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

Functionality of the packages has already been removed previously, but the packages were not removed from the package.json.
Previous published Lib of the draft-js-anchor-plugin does not reflect current project state (still uses package ip-regex), and needs to be refreshed.
As discussed with @juliankrispel over [Draft.js Slack](https://draftjs.slack.com/)

## Implementation

Removed unused packages from package.json to tidy up and to trigger a new publish procedure.

## Demo

No demo for removed packages.
