### PR TITLE
Fix typos and copy/paste errors in plugin guide and examples for the static toolbar.

### DIFF
--- a/HOW_TO_CREATE_A_PLUGIN.md
+++ b/HOW_TO_CREATE_A_PLUGIN.md
@@ -85,7 +85,7 @@ In addition the a plugin accepts
 
 - `initialize: (PluginFunctions) => void`
 - `onChange: (EditorState) => EditorState`
-- `willUnMount: (PluginFunctions) => void`
+- `willUnmount: (PluginFunctions) => void`
 - `decorators: Array<Decorator> => void`
 - `getAccessibilityProps: () => { ariaHasPopup: string, ariaExpanded: string }`
 
@@ -99,7 +99,7 @@ Allows to initialize a plugin once the editor becomes mounted.
 
 Allows a plugin to modify the state at the latest moment before the onChange callback of the Draft.js Editor is fired.
 
-### `willUnMount`
+### `willUnmount`
 
 Usually used to clean up.
 

--- a/docs/client/components/pages/StaticToolbar/SimpleToolbarEditor/index.js
+++ b/docs/client/components/pages/StaticToolbar/SimpleToolbarEditor/index.js
@@ -3,12 +3,12 @@ import Editor, { createEditorStateWithText } from 'draft-js-plugins-editor';
 import createToolbarPlugin from 'draft-js-static-toolbar-plugin';
 import editorStyles from './editorStyles.css';
 
-const inlineToolbarPlugin = createToolbarPlugin();
-const { Toolbar } = inlineToolbarPlugin;
-const plugins = [inlineToolbarPlugin];
+const staticToolbarPlugin = createToolbarPlugin();
+const { Toolbar } = staticToolbarPlugin;
+const plugins = [staticToolbarPlugin];
 const text = 'The toolbar above the editor can be used for formatting text, as in conventional static editors  …';
 
-export default class SimpleInlineToolbarEditor extends Component {
+export default class SimpleStaticToolbarEditor extends Component {
   state = {
     editorState: createEditorStateWithText(text),
   };

--- a/docs/client/components/pages/StaticToolbar/index.js
+++ b/docs/client/components/pages/StaticToolbar/index.js
@@ -55,13 +55,13 @@ export default class App extends Component {
         <AlternateContainer>
           <Heading level={2}>Getting Started</Heading>
           <Code code="npm install draft-js-plugins-editor@beta --save" />
-          <Code code="npm install draft-js-inline-toolbar-plugin@beta --save" />
+          <Code code="npm install draft-js-static-toolbar-plugin@beta --save" />
           <Code code={gettingStarted} name="gettingStarted.js" />
           <Heading level={3}>Importing the default styles</Heading>
           <p>
             The plugin ships with a default styling available at this location in the installed package:
             &nbsp;
-            <InlineCode code={'node_modules/draft-js-inline-toolbar-plugin/lib/plugin.css'} />
+            <InlineCode code={'node_modules/draft-js-static-toolbar-plugin/lib/plugin.css'} />
           </p>
           <Heading level={4}>Webpack Usage</Heading>
           <ul className={styles.list}>


### PR DESCRIPTION
There's a typo in the guide (willUnMount -> willUnmount) and the documentation for the static toolbar was copied from the inline toolbar without being properly updated.