### PR TITLE
Move cursor after image when inserting

### DIFF
--- a/draft-js-image-plugin/CHANGELOG.md
+++ b/draft-js-image-plugin/CHANGELOG.md
@@ -3,10 +3,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## To Be Released
-### fixed critical bug in combination with focus plugin
-
-### Released the first working of DraftJS State Plugin
+## 2.0.0-rc9 - 2016-11-07
+- fix addImage method (place cursor after inserted image)
+- fixed critical bug in combination with focus plugin
 
 ## 2.0.0-rc8 - 2016-08-16
-### added `extraData` parameter to addImage modifier, so additional parameters can be passed.
+- added `extraData` parameter to addImage modifier, so additional parameters can be passed.

--- a/draft-js-image-plugin/package.json
+++ b/draft-js-image-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "draft-js-image-plugin",
-  "version": "2.0.0-rc8",
+  "version": "2.0.0-rc9",
   "description": "Image Plugin for DraftJS",
   "author": {
     "name": "Benjamin Kniffler",

--- a/draft-js-image-plugin/src/modifiers/addImage.js
+++ b/draft-js-image-plugin/src/modifiers/addImage.js
@@ -15,6 +15,6 @@ export default (editorState, url, extraData) => {
   );
   return EditorState.forceSelection(
     newEditorState,
-    newEditorState.getCurrentContent().getSelectionAfter()
+    editorState.getCurrentContent().getSelectionAfter()
   );
 };

--- a/draft-js-image-plugin/src/modifiers/addImage.js
+++ b/draft-js-image-plugin/src/modifiers/addImage.js
@@ -15,6 +15,6 @@ export default (editorState, url, extraData) => {
   );
   return EditorState.forceSelection(
     newEditorState,
-    editorState.getCurrentContent().getSelectionAfter()
+    newEditorState.getCurrentContent().getSelectionAfter()
   );
 };


### PR DESCRIPTION
Right now, when you insert an image the cursor is afterwards _above_ the image, rather than below it. With this fix the cursor is correctly moved after the image, which makes for a much nicer writing experience.