### PR TITLE
Fix draft-js-drag-n-drop plugin

### DIFF
--- a/draft-js-drag-n-drop-plugin/src/createDecorator.js
+++ b/draft-js-drag-n-drop-plugin/src/createDecorator.js
@@ -21,7 +21,9 @@ export default ({ store }) => (WrappedComponent) => (
     }
 
     render() {
-      const readOnly = store.getReadOnly();
+      // If this is rendered before the store is initialized default to read only
+      // NOTE(@mxstbr): Reference issue: draft-js-plugins/draft-js-plugins#926
+      const readOnly = store.getReadOnly ? store.getReadOnly() : true;
       return (
         <WrappedComponent
           {...this.props}


### PR DESCRIPTION
While I still don't know why or how this can happen, this should at least make it so the breaking #926 bug doesn't happen anymore.