### PR TITLE
onEmojiFocus wasn't properly setting state using `setState`

### DIFF
--- a/draft-js-emoji-plugin/src/components/EmojiSuggestions/index.js
+++ b/draft-js-emoji-plugin/src/components/EmojiSuggestions/index.js
@@ -185,7 +185,7 @@ export default class EmojiSuggestions extends Component {
   onEmojiFocus = (index) => {
     const descendant = `emoji-option-${this.key}-${index}`;
     this.props.ariaProps.ariaActiveDescendantID = descendant;
-    this.state.focusedOptionIndex = index;
+    this.setState({ focusedOptionIndex: index });
 
     // to force a re-render of the outer component to change the aria props
     this.props.store.setEditorState(this.props.store.getEditorState());


### PR DESCRIPTION
## Use-case/Problem
 Same issue as https://github.com/draft-js-plugins/draft-js-plugins/pull/762 but for the emoji suggestions.