### PR TITLE
Changing src to iframe embeded src

### DIFF
--- a/draft-js-video-plugin/src/video/components/DefaultVideoComponent.js
+++ b/draft-js-video-plugin/src/video/components/DefaultVideoComponent.js
@@ -1,27 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import utils from '../utils';
-
-const YOUTUBE_PREFIX = 'https://www.youtube.com/embed/';
-const VIMEO_PREFIX = 'https://player.vimeo.com/video/';
-
-const getSrc = ({ src }) => {
-  const {
-    isYoutube,
-    getYoutubeSrc,
-    isVimeo,
-    getVimeoSrc,
-  } = utils;
-  if (isYoutube(src)) {
-    const { srcID } = getYoutubeSrc(src);
-    return `${YOUTUBE_PREFIX}${srcID}`;
-  }
-  if (isVimeo(src)) {
-    const { srcID } = getVimeoSrc(src);
-    return `${VIMEO_PREFIX}${srcID}`;
-  }
-  return undefined;
-};
 
 const DefaultVideoCompoent = ({
   blockProps,
@@ -29,7 +7,7 @@ const DefaultVideoCompoent = ({
   style,
   theme,
 }) => {
-  const src = getSrc(blockProps);
+  const { src } = blockProps;
   if (src) {
     return (
       <div style={style} >

--- a/draft-js-video-plugin/src/video/modifiers/addVideo.js
+++ b/draft-js-video-plugin/src/video/modifiers/addVideo.js
@@ -5,6 +5,29 @@ import {
 
 import * as types from '../constants';
 
+import utils from '../utils';
+
+const YOUTUBE_PREFIX = 'https://www.youtube.com/embed/';
+const VIMEO_PREFIX = 'https://player.vimeo.com/video/';
+
+const getIframeSrc = (src) => {
+  const {
+    isYoutube,
+    getYoutubeSrc,
+    isVimeo,
+    getVimeoSrc,
+  } = utils;
+  if (isYoutube(src)) {
+    const { srcID } = getYoutubeSrc(src);
+    return `${YOUTUBE_PREFIX}${srcID}`;
+  }
+  if (isVimeo(src)) {
+    const { srcID } = getVimeoSrc(src);
+    return `${VIMEO_PREFIX}${srcID}`;
+  }
+  return undefined;
+};
+
 export default function addVideo(editorState, { src }) {
   if (RichUtils.getCurrentBlockType(editorState) === types.ATOMIC) {
     return editorState;
@@ -13,7 +36,7 @@ export default function addVideo(editorState, { src }) {
   const contentStateWithEntity = contentState.createEntity(
     types.VIDEOTYPE,
     'IMMUTABLE',
-    { src }
+    { src: getIframeSrc(src) },
   );
   const entityKey = contentStateWithEntity.getLastCreatedEntityKey();
   return AtomicBlockUtils.insertAtomicBlock(editorState, entityKey, ' ');


### PR DESCRIPTION
## Checklist

- [x] Fix any eslint errors that occur
- [ ] Update change-log for every plugin you touch
- [ ] Add/Update tests if you add/change new functionality
- [ ] Add/Update docs if you add/change functionality
- [ ] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

When you are exporting a contentState to HTML using, for example, https://www.npmjs.com/package/draft-js-export-html , there is no source link to video iframe inside entityData. So we cannot display it while parsing a contentState
- For example what we have inside entityData - https://www.youtube.com/watch?v=c1cPBPyuJ9g
- What we are expecting to have - https://www.youtube.com/embed/c1cPBPyuJ9g

## Implementation

Moving the code, that converts video link to iframe link, from:
`components/DefaultVideoComponent.js`
to:
`modifiers/addVideo.js`
And injecting iframe link to entityData at once