### PR TITLE
Fix wait a tick to properly set overrideContent in inline plugin

### DIFF
--- a/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
+++ b/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
@@ -68,24 +68,28 @@ export default class Toolbar extends React.Component {
   };
 
   getStyle() {
-    const { store } = this.props;
-    const { overrideContent, position } = this.state;
-    const selection = store.getItem('getEditorState')().getSelection();
-    // overrideContent could for example contain a text input, hence we always show overrideContent
-    // TODO: Test readonly mode and possibly set isVisible to false if the editor is readonly
-    const isVisible = (!selection.isCollapsed() && selection.getHasFocus()) || overrideContent;
-    const style = { ...position };
+    // need to wait a tick for children onClick that will set overrideContent
+    // and mentain the visibilty state of the inline menu
+    setTimeout(() => {
+      const { store } = this.props;
+      const { overrideContent, position } = this.state;
+      const selection = store.getItem('getEditorState')().getSelection();
+      // overrideContent could for example contain a text input, hence we always show overrideContent
+      // TODO: Test readonly mode and possibly set isVisible to false if the editor is readonly
+      const isVisible = (!selection.isCollapsed() && selection.getHasFocus()) || overrideContent;
+      const style = { ...position };
 
-    if (isVisible) {
-      style.visibility = 'visible';
-      style.transform = 'translate(-50%) scale(1)';
-      style.transition = 'transform 0.15s cubic-bezier(.3,1.2,.2,1)';
-    } else {
-      style.transform = 'translate(-50%) scale(0)';
-      style.visibility = 'hidden';
-    }
+      if (isVisible) {
+        style.visibility = 'visible';
+        style.transform = 'translate(-50%) scale(1)';
+        style.transition = 'transform 0.15s cubic-bezier(.3,1.2,.2,1)';
+      } else {
+        style.transform = 'translate(-50%) scale(0)';
+        style.visibility = 'hidden';
+      }
 
-    return style;
+      return style;
+    });
   }
 
   handleToolbarRef = (node) => {


### PR DESCRIPTION
Please check out Contributing Guidelines. By following this template you help us to review your code.
https://github.com/draft-js-plugins/draft-js-plugins/blob/master/CONTRIBUTING.md

## Checklist

- [X ] Fix any eslint errors that occur
- [X] Update change-log for every plugin you touch
- [] Add/Update tests if you add/change new functionality
- [] Add/Update docs if you add/change functionality
- [X] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

There is current bug visible in Custom Inline Toolbar Example
https://www.draft-js-plugins.com/plugin/inline-toolbar
Clicking on Headline button instead of replacing the inline toolbar content as intended it closes the toolbar as Headline button was a normal button.

## Implementation

This bugfix adds delay just enough so the Headline button, in this case, to set overrideContent so the Inline toolbar will remain visible awaiting for further user action based on overrideContent rendition.

## Demo
