### PR TITLE
fix atomic block deletion

### DIFF
--- a/draft-js-plugins-editor/src/Editor/handleAtomicBlocks.js
+++ b/draft-js-plugins-editor/src/Editor/handleAtomicBlocks.js
@@ -1,0 +1,18 @@
+import { RichUtils } from 'draft-js';
+
+export default {
+  // TODO: Find a better place for this.
+  // This solves atomic block removes
+  // it's not placed inside draft-js-image-plugin because it's required by
+  // all atomic blocks.
+  // A similar fix is done also inside draft-js-focus-plugin and is there
+  // because the fix is just for the focus case
+  handleKeyCommand: (command, _, { getEditorState, setEditorState }) => {
+    const newState = RichUtils.handleKeyCommand(getEditorState(), command);
+    if (newState) {
+      setEditorState(newState);
+      return 'handled';
+    }
+    return 'not-handled';
+  },
+};

--- a/draft-js-plugins-editor/src/Editor/index.js
+++ b/draft-js-plugins-editor/src/Editor/index.js
@@ -8,6 +8,7 @@ import {
 } from 'draft-js';
 import { List, Map } from 'immutable';
 import MultiDecorator from './MultiDecorator';
+import handleAtomicBlocks from './handleAtomicBlocks';
 import createCompositeDecorator from './createCompositeDecorator';
 import moveSelectionToEnd from './moveSelectionToEnd';
 import proxies from './proxies';
@@ -235,7 +236,7 @@ class PluginEditor extends Component {
     if (this.props.defaultKeyBindings) {
       plugins.push(defaultKeyBindingPlugin);
     }
-
+    plugins.push(handleAtomicBlocks);
     return plugins;
   };
 


### PR DESCRIPTION
fixes issue #952 
initial state:
<img width="1440" alt="initial_state" src="https://user-images.githubusercontent.com/4092865/32487941-55ae28a8-c3ab-11e7-8a0f-9c78e383554e.png">

result after deleting the block:
- before:
<img width="1440" alt="before" src="https://user-images.githubusercontent.com/4092865/32487962-6b6dc2d4-c3ab-11e7-808e-b589389a0411.png">

- after:
<img width="1440" alt="after" src="https://user-images.githubusercontent.com/4092865/32487976-73c2ba20-c3ab-11e7-8490-7e897339a363.png">

As this bug occurs for every atomic block i placed the principal fix in the plugins editor. Do you think it's the right place for this or it can be a better place?
This issue shows up even when pressing backspace on a focused block. So i placed the relative fix into the focus plugin
