### PR TITLE
Add missing decorators to editorState when props update

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1,46 +1,5 @@
 # Frequently Asked Questions
 
-## How to reset the content?
-
-Since the decorators are stored in the EditorState it's important to not reset
-the complete EditorState. The proper way is to reset the ContentState which is
-part of the EditorState. In addition this ensures proper undo/redo behavior.
-
-Right:
-```js
-import { EditorState, ContentState } from 'draft-js';
-
-const editorState = EditorState.push(this.state.editorState, ContentState.createFromText(''));
-this.setState({ editorState });
-```
-
-Wrong:
-```js
-import { EditorState } from 'draft-js';
-
-this.setState({ editorState: EditorState.createEmpty() })
-```
-
-## Why are mentions broken after using `convertFromRaw` and throwing an error?
-
-__Please Note: this has been fixed in the beta version, from now on you can use a plain array for your mention suggestions__
-
-We design the API to accept an Immutable Map for a Mention. After saving your data structure to the server and using `convertFromRaw`, the mentions in there are plain objects. I (Nik) believe this is a flaw in our design and the mention data should be a plain object. Hint: we might fix this with v2.0.0 of the mentions plugin.
-
-What you can do now is fixing the datastructure before converting it:
-
-```JS
-import { fromJS} from 'immutable';
-import forEach from 'lodash/forEach';
-
-forEach(rawContent.entityMap, function(value, key) {
-  value.data.mention = fromJS(value.data.mention)
-})
-
-const contentState = Draft.convertFromRaw(rawContent)
-const editorState = Draft.EditorState.createWithContent(contentState)
-```
-
 ## Why is there no Popover for Mentions/Emoji plugin?
 
 The MentionSuggestions/EmojiSuggestions component is internally connected to the

--- a/draft-js-plugins-editor/CHANGELOG.md
+++ b/draft-js-plugins-editor/CHANGELOG.md
@@ -3,10 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## To Be Released
+## 2.0.2
+- Automatically update decoratorless editorState upon props update
 
-### Added
-
+## 2.0.1
 - blockStyleFn returns '' instead of false
 - `handleKeyCommand` now receives the arguments `(command, editorState, pluginFunctions)`
 - `handlePastedText` now receives the arguments `(text, html, editorState, pluginFunctions)`

--- a/draft-js-plugins-editor/package.json
+++ b/draft-js-plugins-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "draft-js-plugins-editor",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Editor for DraftJS Plugins",
   "author": {
     "name": "Nik Graf",

--- a/draft-js-plugins-editor/src/Editor/__test__/index.js
+++ b/draft-js-plugins-editor/src/Editor/__test__/index.js
@@ -15,6 +15,12 @@ class TestEditor extends Component {
     this.state.editorState = createEditorStateWithText(this.props.text);
   }
 
+  componentWillReceiveProps(props) {
+    this.setState({
+      editorState: createEditorStateWithText(props.text),
+    });
+  }
+
   onChange = (editorState) => {
     this.setState({
       editorState,
@@ -664,6 +670,21 @@ describe('Editor', () => {
       expect(simplePluginDecoratorStrategy).has.been.called();
       expect(customPluginDecorator).has.been.called();
       expect(decoratorStrategy).has.been.called();
+    });
+
+    it('reassigns decorators to editorState when props are updated with naked editorState', (done) => {
+      const props = { plugins, text };
+      const comp = mount(<TestEditor {...props} />);
+
+      const decoratorNumber = comp.state('editorState').getDecorator().decorators.size;
+
+      setTimeout(() => {
+        const newText = 'Yoyoyoyo dude';
+        comp.setProps({ text: newText });
+        expect(comp.state('editorState').getDecorator().decorators.size).to.eq(decoratorNumber);
+        expect(comp.state('editorState').getCurrentContent().getPlainText()).to.eq(newText);
+        done();
+      }, 100);
     });
   });
 });

--- a/draft-js-plugins-editor/src/Editor/index.js
+++ b/draft-js-plugins-editor/src/Editor/index.js
@@ -65,11 +65,7 @@ class PluginEditor extends Component {
   componentWillReceiveProps(next) {
     if (
       this.props.editorState.getDecorator() !== null &&
-      (
-        next.editorState.getDecorator() === null ||
-        next.editorState.getDecorator().decorators.size
-          !== this.props.editorState.getDecorator().decorators.size
-      )
+      this.props.editorState.getDecorator() !== next.editorState.getDecorator()
     ) {
       const decorator = this.props.editorState.getDecorator();
       const editorState = EditorState.set(next.editorState, { decorator });

--- a/draft-js-plugins-editor/src/Editor/index.js
+++ b/draft-js-plugins-editor/src/Editor/index.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-continue,no-restricted-syntax */
-import React, { PureComponent } from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import {
   EditorState,
@@ -15,7 +15,7 @@ import * as defaultKeyBindingPlugin from './defaultKeyBindingPlugin';
 /**
  * The main editor component
  */
-class PluginEditor extends PureComponent {
+class PluginEditor extends Component {
 
   static propTypes = {
     editorState: PropTypes.object.isRequired,

--- a/draft-js-plugins-editor/src/Editor/index.js
+++ b/draft-js-plugins-editor/src/Editor/index.js
@@ -1,22 +1,21 @@
 /* eslint-disable no-continue,no-restricted-syntax */
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import {
-  Editor,
   EditorState,
+  Editor,
   DefaultDraftBlockRenderMap,
 } from 'draft-js';
-import { List, Map } from 'immutable';
-import MultiDecorator from './MultiDecorator';
-import createCompositeDecorator from './createCompositeDecorator';
-import moveSelectionToEnd from './moveSelectionToEnd';
+import { Map } from 'immutable';
 import proxies from './proxies';
+import moveSelectionToEnd from './moveSelectionToEnd';
+import resolveDecorators from './resolveDecorators';
 import * as defaultKeyBindingPlugin from './defaultKeyBindingPlugin';
 
 /**
  * The main editor component
  */
-class PluginEditor extends Component {
+class PluginEditor extends PureComponent {
 
   static propTypes = {
     editorState: PropTypes.object.isRequired,
@@ -25,6 +24,7 @@ class PluginEditor extends Component {
     defaultKeyBindings: PropTypes.bool,
     defaultBlockRenderMap: PropTypes.bool,
     customStyleMap: PropTypes.object,
+    // eslint-disable-next-line react/no-unused-prop-types
     decorators: PropTypes.array,
   };
 
@@ -56,20 +56,25 @@ class PluginEditor extends Component {
   }
 
   componentWillMount() {
-    const decorators = this.resolveDecorators();
-    const compositeDecorator = createCompositeDecorator(
-      decorators.filter((decorator) => !this.decoratorIsCustom(decorator)),
-      this.getEditorState,
-      this.onChange);
+    const decorator = resolveDecorators(this.props, this.getEditorState, this.onChange);
 
-    const customDecorators = decorators
-      .filter((decorator) => this.decoratorIsCustom(decorator));
-
-    const multiDecorator = new MultiDecorator(
-      customDecorators.push(compositeDecorator));
-
-    const editorState = EditorState.set(this.props.editorState, { decorator: multiDecorator });
+    const editorState = EditorState.set(this.props.editorState, { decorator });
     this.onChange(moveSelectionToEnd(editorState));
+  }
+
+  componentWillReceiveProps(next) {
+    if (
+      this.props.editorState.getDecorator() !== null &&
+      (
+        next.editorState.getDecorator() === null ||
+        next.editorState.getDecorator().decorators.size
+          !== this.props.editorState.getDecorator().decorators.size
+      )
+    ) {
+      const decorator = this.props.editorState.getDecorator();
+      const editorState = EditorState.set(next.editorState, { decorator });
+      this.onChange(moveSelectionToEnd(editorState));
+    }
   }
 
   componentWillUnmount() {
@@ -238,20 +243,6 @@ class PluginEditor extends Component {
 
     return plugins;
   };
-
-  resolveDecorators = () => {
-    const { decorators, plugins } = this.props;
-    return List([{ decorators }, ...plugins])
-      .filter((plugin) => plugin.decorators !== undefined)
-      .flatMap((plugin) => plugin.decorators);
-  };
-
-  // Return true if decorator implements the DraftDecoratorType interface
-  // @see https://github.com/facebook/draft-js/blob/master/src/model/decorators/DraftDecoratorType.js
-  decoratorIsCustom = (decorator) => typeof decorator.getDecorations === 'function' &&
-    typeof decorator.getComponentForKey === 'function' &&
-    typeof decorator.getPropsForKey === 'function';
-
 
   resolveCustomStyleMap = () => (
     this.props.plugins

--- a/draft-js-plugins-editor/src/Editor/resolveDecorators.js
+++ b/draft-js-plugins-editor/src/Editor/resolveDecorators.js
@@ -1,0 +1,30 @@
+import { List } from 'immutable';
+import createCompositeDecorator from './createCompositeDecorator';
+import MultiDecorator from './MultiDecorator';
+
+// Return true if decorator implements the DraftDecoratorType interface
+// @see https://github.com/facebook/draft-js/blob/master/src/model/decorators/DraftDecoratorType.js
+const decoratorIsCustom = (decorator) => typeof decorator.getDecorations === 'function' &&
+  typeof decorator.getComponentForKey === 'function' &&
+  typeof decorator.getPropsForKey === 'function';
+
+
+const getDecoratorsFromProps = ({ decorators, plugins }) => List(
+  [{ decorators }, ...plugins]
+).filter((plugin) => plugin.decorators !== undefined)
+.flatMap((plugin) => plugin.decorators);
+
+const resolveDecorators = (props, getEditorState, onChange) => {
+  const decorators = getDecoratorsFromProps(props);
+  const compositeDecorator = createCompositeDecorator(
+    decorators.filter((decorator) => !decoratorIsCustom(decorator)),
+    getEditorState,
+    onChange);
+
+  const customDecorators = decorators
+    .filter((decorator) => decoratorIsCustom(decorator));
+
+  return new MultiDecorator(customDecorators.push(compositeDecorator));
+};
+
+export default resolveDecorators;


### PR DESCRIPTION
## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Tested in storybook

## Use-case/Problem
We add decorators to the editorState upon initalisation of the Editor but not when props update. This fixes this!

fixes #359 
fixes #262

## Implementation

- [x] reuse resolveDecorators function in willReceiveProps
- [x] add missing decorators to editorState object if editorState decorators are missing
- [x] refactor decorator resolving into separate function