### PR TITLE
Rendering emoji select popover only on emoji select button press

### DIFF
--- a/draft-js-emoji-plugin/src/components/EmojiSelect/Popover/index.js
+++ b/draft-js-emoji-plugin/src/components/EmojiSelect/Popover/index.js
@@ -15,12 +15,7 @@ export default class Popover extends Component {
     groups: PropTypes.arrayOf(PropTypes.object).isRequired,
     emojis: PropTypes.object.isRequired,
     toneSelectOpenDelay: PropTypes.number.isRequired,
-    isOpen: PropTypes.bool,
     useNativeArt: PropTypes.bool,
-  };
-
-  static defaultProps = {
-    isOpen: false,
   };
 
   state = {
@@ -167,12 +162,9 @@ export default class Popover extends Component {
       theme = {},
       groups = [],
       emojis,
-      isOpen = false,
       useNativeArt,
     } = this.props;
-    const className = isOpen ?
-      theme.emojiSelectPopover :
-      theme.emojiSelectPopoverClosed;
+    const className = theme.emojiSelectPopover;
     const { activeGroup } = this.state;
 
     return (

--- a/draft-js-emoji-plugin/src/components/EmojiSelect/index.js
+++ b/draft-js-emoji-plugin/src/components/EmojiSelect/index.js
@@ -103,18 +103,19 @@ export default class EmojiSelect extends Component {
         >
           {selectButtonContent}
         </button>
-        <Popover
-          cacheBustParam={cacheBustParam}
-          imagePath={imagePath}
-          imageType={imageType}
-          theme={theme}
-          store={store}
-          groups={selectGroups}
-          emojis={emojis}
-          toneSelectOpenDelay={toneSelectOpenDelay}
-          isOpen={this.state.isOpen}
-          useNativeArt={useNativeArt}
-        />
+        {this.state.isOpen &&
+          <Popover
+            cacheBustParam={cacheBustParam}
+            imagePath={imagePath}
+            imageType={imageType}
+            theme={theme}
+            store={store}
+            groups={selectGroups}
+            emojis={emojis}
+            toneSelectOpenDelay={toneSelectOpenDelay}
+            useNativeArt={useNativeArt}
+          />
+        }
       </div>
     );
   }


### PR DESCRIPTION
First of all thank you for the great plugins. 

While using `emoji select` page was loading very slow as it was making network requests to get all the images of the emojis of the `emoji select` popover. Now i am only rendering `emoji select popover` when user wants to see it. This way we are saving **1361** network requests for the images of emojis and hence making the page load time faster. 

This change will also come in handy when user is using multiple instances of emoji select. A normal example is comment boxes.