### PR TITLE
Add ability to customize AlignmentTool styles

### DIFF
--- a/docs/client/components/pages/Alignment/ThemedAlignmentEditor/alignmentToolStyles.css
+++ b/docs/client/components/pages/Alignment/ThemedAlignmentEditor/alignmentToolStyles.css
@@ -1,0 +1,37 @@
+.alignmentTool {
+  left: 50%;
+  transform: translate(-50%) scale(0);
+  position: absolute;
+  border: 1px solid #111;
+  background: #333;
+  border-radius: 4px;
+  box-shadow: 0px 1px 3px 0px rgba(220, 220, 220, 1);
+  z-index: 2;
+  box-sizing: border-box;
+}
+
+.alignmentTool:after,
+.alignmentTool:before {
+  top: 100%;
+  left: 50%;
+  border: solid transparent;
+  content: " ";
+  height: 0;
+  width: 0;
+  position: absolute;
+  pointer-events: none;
+}
+
+.alignmentTool:after {
+  border-color: rgba(255, 255, 255, 0);
+  border-top-color: #333;
+  border-width: 4px;
+  margin-left: -4px;
+}
+
+.alignmentTool:before {
+  border-color: rgba(221, 221, 221, 0);
+  border-top-color: #111;
+  border-width: 6px;
+  margin-left: -6px;
+}

--- a/docs/client/components/pages/Alignment/ThemedAlignmentEditor/buttonStyles.css
+++ b/docs/client/components/pages/Alignment/ThemedAlignmentEditor/buttonStyles.css
@@ -1,0 +1,33 @@
+.buttonWrapper {
+  display: inline-block;
+}
+
+.button {
+  background: #333;
+  color: #ddd;
+  font-size: 18px;
+  border: 0;
+  padding-top: 5px;
+  vertical-align: bottom;
+  height: 34px;
+  width: 36px;
+  border-radius: 4px;
+}
+
+.button svg {
+  fill: #ddd;
+}
+
+.button:hover,
+.button:focus {
+  background: #444;
+  outline: 0; /* reset for :focus */
+}
+
+.active {
+  color: #6a9cc9;
+}
+
+.active svg {
+  fill: #6a9cc9;
+}

--- a/docs/client/components/pages/Alignment/ThemedAlignmentEditor/colorBlockPlugin.js
+++ b/docs/client/components/pages/Alignment/ThemedAlignmentEditor/colorBlockPlugin.js
@@ -1,0 +1,43 @@
+import React from 'react';
+
+const ColorBlock = ({
+  block, // eslint-disable-line no-unused-vars
+  blockProps, // eslint-disable-line no-unused-vars
+  customStyleMap, // eslint-disable-line no-unused-vars
+  customStyleFn, // eslint-disable-line no-unused-vars
+  decorator, // eslint-disable-line no-unused-vars
+  forceSelection, // eslint-disable-line no-unused-vars
+  offsetKey, // eslint-disable-line no-unused-vars
+  selection, // eslint-disable-line no-unused-vars
+  tree, // eslint-disable-line no-unused-vars
+  contentState, // eslint-disable-line no-unused-vars
+  style,
+  ...elementProps
+}) => (
+  <div
+    {...elementProps}
+    style={{ width: 200, height: 80, backgroundColor: '#9bc0c7', ...style }}
+  />
+  );
+
+const createColorBlockPlugin = (config = {}) => {
+  const component = config.decorator ? config.decorator(ColorBlock) : ColorBlock;
+  return {
+    blockRendererFn: (block, { getEditorState }) => {
+      if (block.getType() === 'atomic') {
+        const contentState = getEditorState().getCurrentContent();
+        const entity = contentState.getEntity(block.getEntityAt(0));
+        const type = entity.getType();
+        if (type === 'colorBlock') {
+          return {
+            component,
+            editable: false,
+          };
+        }
+      }
+      return null;
+    },
+  };
+};
+
+export default createColorBlockPlugin;

--- a/docs/client/components/pages/Alignment/ThemedAlignmentEditor/editorStyles.css
+++ b/docs/client/components/pages/Alignment/ThemedAlignmentEditor/editorStyles.css
@@ -1,0 +1,18 @@
+.editor {
+  box-sizing: border-box;
+  border: 1px solid #ddd;
+  cursor: text;
+  padding: 16px;
+  border-radius: 2px;
+  margin-bottom: 2em;
+  box-shadow: inset 0px 1px 8px -3px #ABABAB;
+  background: #fefefe;
+}
+
+.editor :global(.public-DraftEditor-content) {
+  min-height: 140px;
+}
+
+.options {
+  margin-bottom: 20px;
+}

--- a/docs/client/components/pages/Alignment/ThemedAlignmentEditor/index.js
+++ b/docs/client/components/pages/Alignment/ThemedAlignmentEditor/index.js
@@ -1,0 +1,109 @@
+import React, { Component } from 'react';
+import { convertFromRaw, EditorState } from 'draft-js';
+import Editor, { composeDecorators } from 'draft-js-plugins-editor';
+import createAlignmentPlugin from 'draft-js-alignment-plugin';
+import createFocusPlugin from 'draft-js-focus-plugin';
+import createColorBlockPlugin from './colorBlockPlugin';
+import editorStyles from './editorStyles.css';
+import alignmentToolStyles from './alignmentToolStyles.css';
+import buttonStyles from './buttonStyles.css';
+
+const focusPlugin = createFocusPlugin();
+const alignmentPlugin = createAlignmentPlugin({
+  theme: {
+    alignmentToolStyles,
+    buttonStyles,
+  },
+});
+const { AlignmentTool } = alignmentPlugin;
+
+const decorator = composeDecorators(
+  alignmentPlugin.decorator,
+  focusPlugin.decorator,
+);
+
+const colorBlockPlugin = createColorBlockPlugin({ decorator });
+const plugins = [focusPlugin, alignmentPlugin, colorBlockPlugin];
+
+/* eslint-disable */
+const initialState = {
+  entityMap: {
+    '0': {
+      type: 'colorBlock',
+      mutability: 'IMMUTABLE',
+      data: {},
+    },
+  },
+  blocks: [
+    {
+      key: '9gm3s',
+      text:
+        'This is a simple example. Focus the block by clicking on it and change alignment via the toolbar.',
+      type: 'unstyled',
+      depth: 0,
+      inlineStyleRanges: [],
+      entityRanges: [],
+      data: {},
+    },
+    {
+      key: 'ov7r',
+      text: ' ',
+      type: 'atomic',
+      depth: 0,
+      inlineStyleRanges: [],
+      entityRanges: [
+        {
+          offset: 0,
+          length: 1,
+          key: 0,
+        },
+      ],
+      data: {},
+    },
+    {
+      key: 'e23a8',
+      text:
+        'More text here to demonstrate how inline left/right alignment works …',
+      type: 'unstyled',
+      depth: 0,
+      inlineStyleRanges: [],
+      entityRanges: [],
+      data: {},
+    },
+  ],
+};
+/* eslint-enable */
+
+export default class ThemedAlignmentEditor extends Component {
+  state = {
+    editorState: EditorState.createWithContent(convertFromRaw(initialState)),
+  };
+
+  onChange = (editorState) => {
+    this.setState({
+      editorState,
+    });
+  };
+
+  focus = () => {
+    this.editor.focus();
+  };
+
+  render() {
+    return (
+      <div>
+        <div className={editorStyles.editor} onClick={this.focus}>
+          <Editor
+            editorState={this.state.editorState}
+            onChange={this.onChange}
+            plugins={plugins}
+            ref={(element) => {
+              this.editor = element;
+            }}
+          />
+          <AlignmentTool />
+        </div>
+      </div>
+    );
+  }
+}

--- a/docs/client/components/pages/Alignment/index.js
+++ b/docs/client/components/pages/Alignment/index.js
@@ -7,6 +7,14 @@ import simpleExampleEditorStylesCode from '!!../../../loaders/prism-loader?langu
 // eslint-disable-next-line import/no-unresolved
 import simpleExampleColorBlockCode from '!!../../../loaders/prism-loader?language=javascript!./SimpleAlignmentEditor/colorBlockPlugin';
 // eslint-disable-next-line import/no-unresolved
+import themedExampleCode from '!!../../../loaders/prism-loader?language=javascript!./ThemedAlignmentEditor';
+// eslint-disable-next-line import/no-unresolved
+import themedExampleEditorStylesCode from '!!../../../loaders/prism-loader?language=css!./ThemedAlignmentEditor/editorStyles.css';
+// eslint-disable-next-line import/no-unresolved
+import themedExampleAlignmentToolStylesCode from '!!../../../loaders/prism-loader?language=css!./ThemedAlignmentEditor/alignmentToolStyles.css';
+// eslint-disable-next-line import/no-unresolved
+import themedExampleButtonStylesCode from '!!../../../loaders/prism-loader?language=css!./ThemedAlignmentEditor/buttonStyles.css';
+// eslint-disable-next-line import/no-unresolved
 import webpackConfig from '!!../../../loaders/prism-loader?language=javascript!./webpackConfig';
 // eslint-disable-next-line import/no-unresolved
 import webpackImport from '!!../../../loaders/prism-loader?language=javascript!./webpackImport';
@@ -17,6 +25,7 @@ import Heading from '../../shared/Heading';
 import styles from './styles.css';
 import Code from '../../shared/Code';
 import SimpleAlignmentEditor from './SimpleAlignmentEditor';
+import ThemedAlignmentEditor from './ThemedAlignmentEditor';
 import ExternalLink from '../../shared/Link';
 import InlineCode from '../../shared/InlineCode';
 import SocialBar from '../../shared/SocialBar';
@@ -33,23 +42,24 @@ export default class App extends Component {
           <Heading level={2}>Alignment</Heading>
           <Heading level={3}>Prerequisite</Heading>
           <p>
-            This plugin exposes a decorator for blocks. You can use it in combination with any kind of plugin that manages a Draft.js block e.g. image or video. Keep in mind the plugin must accept a decorator for the block. The `Simple Alignment Example` further down contains an example plugin rendering a colored div. In addition this plugin only works in combination with the draft-js-focus-plugin.
+            This plugin exposes a decorator for blocks. You can use it in
+            combination with any kind of plugin that manages a Draft.js block
+            e.g. image or video. Keep in mind the plugin must accept a decorator
+            for the block. The `Simple Alignment Example` further down contains
+            an example plugin rendering a colored div. In addition this plugin
+            only works in combination with the draft-js-focus-plugin.
           </p>
           <Heading level={3}>Usage</Heading>
           <p>
-            Select (via mouse or keyboard) a block supporting alignment modifications. A tooltip will pop up and you can update the alignment.
+            Select (via mouse or keyboard) a block supporting alignment
+            modifications. A tooltip will pop up and you can update the
+            alignment.
           </p>
           <Heading level={3}>Supported Environment</Heading>
           <ul className={styles.list}>
-            <li className={styles.listEntry}>
-              Desktop: Yes
-            </li>
-            <li className={styles.listEntry}>
-              Mobile: No
-            </li>
-            <li className={styles.listEntry}>
-              Screen-reader: No
-            </li>
+            <li className={styles.listEntry}>Desktop: Yes</li>
+            <li className={styles.listEntry}>Mobile: No</li>
+            <li className={styles.listEntry}>Screen-reader: No</li>
           </ul>
         </Container>
         <AlternateContainer>
@@ -59,32 +69,37 @@ export default class App extends Component {
           <Code code="npm install draft-js-alignment-plugin" />
           <Heading level={3}>Importing the default styles</Heading>
           <p>
-            The plugin ships with a default styling available at this location in the installed package:
-            &nbsp;
-            <InlineCode code={'node_modules/draft-js-alignment-plugin/lib/plugin.css'} />
+            The plugin ships with a default styling available at this location
+            in the installed package: &nbsp;
+            <InlineCode
+              code={'node_modules/draft-js-alignment-plugin/lib/plugin.css'}
+            />
           </p>
           <Heading level={4}>Webpack Usage</Heading>
           <ul className={styles.list}>
             <li className={styles.listEntry}>
-              1. Install Webpack loaders:
-              &nbsp;
+              1. Install Webpack loaders: &nbsp;
               <InlineCode code={'npm i style-loader css-loader --save-dev'} />
             </li>
             <li className={styles.listEntry}>
-              2. Add the below section to Webpack config (if your config already has a loaders array, simply add the below loader object to your existing list.
+              2. Add the below section to Webpack config (if your config already
+              has a loaders array, simply add the below loader object to your
+              existing list.
               <Code code={webpackConfig} className={styles.guideCodeBlock} />
             </li>
             <li className={styles.listEntry}>
-              3. Add the below import line to your component to tell Webpack to inject the style to your component.
+              3. Add the below import line to your component to tell Webpack to
+              inject the style to your component.
               <Code code={webpackImport} className={styles.guideCodeBlock} />
             </li>
-            <li className={styles.listEntry}>
-              4. Restart Webpack.
-            </li>
+            <li className={styles.listEntry}>4. Restart Webpack.</li>
           </ul>
           <Heading level={4}>Browserify Usage</Heading>
           <p>
-            Please help, by submiting a Pull Request to the <ExternalLink href="https://github.com/draft-js-plugins/draft-js-plugins/blob/master/docs/client/components/pages/Image/index.js">documentation</ExternalLink>.
+            Please help, by submiting a Pull Request to the{' '}
+            <ExternalLink href="https://github.com/draft-js-plugins/draft-js-plugins/blob/master/docs/client/components/pages/Image/index.js">
+              documentation
+            </ExternalLink>.
           </p>
         </AlternateContainer>
         <Container>
@@ -96,6 +111,17 @@ export default class App extends Component {
           <Code code={simpleExampleCode} name="SimpleAlignmentEditor.js" />
           <Code code={simpleExampleColorBlockCode} name="colorBlockPlugin.js" />
           <Code code={simpleExampleEditorStylesCode} name="editorStyles.css" />
+        </Container>
+        <Container>
+          <Heading level={2}>Themed Alignment Example</Heading>
+          <ThemedAlignmentEditor />
+          <Code code={themedExampleCode} name="SimpleAlignmentEditor.js" />
+          <Code code={themedExampleEditorStylesCode} name="editorStyles.css" />
+          <Code
+            code={themedExampleAlignmentToolStylesCode}
+            name="alignmentToolStyles.css"
+          />
+          <Code code={themedExampleButtonStylesCode} name="buttonStyles.css" />
         </Container>
         <SocialBar />
       </div>

--- a/draft-js-alignment-plugin/src/AlignmentTool/index.js
+++ b/draft-js-alignment-plugin/src/AlignmentTool/index.js
@@ -6,15 +6,15 @@ import {
   AlignBlockCenterButton,
   AlignBlockRightButton,
 } from 'draft-js-buttons';
-import styles from '../alignmentToolStyles.css';
-import buttonStyles from '../buttonStyles.css';
 
 const getRelativeParent = (element) => {
   if (!element) {
     return null;
   }
 
-  const position = window.getComputedStyle(element).getPropertyValue('position');
+  const position = window
+    .getComputedStyle(element)
+    .getPropertyValue('position');
   if (position !== 'static') {
     return element;
   }
@@ -23,11 +23,10 @@ const getRelativeParent = (element) => {
 };
 
 export default class AlignmentTool extends React.Component {
-
   state = {
     position: {},
     alignment: null,
-  }
+  };
 
   componentWillMount() {
     this.props.store.subscribeToItem('visibleBlock', this.onVisibilityChanged);
@@ -35,7 +34,10 @@ export default class AlignmentTool extends React.Component {
   }
 
   componentWillUnmount() {
-    this.props.store.unsubscribeFromItem('visibleBlock', this.onVisibilityChanged);
+    this.props.store.unsubscribeFromItem(
+      'visibleBlock',
+      this.onVisibilityChanged,
+    );
     this.props.store.unsubscribeFromItem('alignment', this.onAlignmentChange);
   }
 
@@ -68,7 +70,7 @@ export default class AlignmentTool extends React.Component {
     this.setState({
       alignment,
     });
-  }
+  };
 
   render() {
     const defaultButtons = [
@@ -77,11 +79,16 @@ export default class AlignmentTool extends React.Component {
       AlignBlockCenterButton,
       AlignBlockRightButton,
     ];
+
+    const { theme } = this.props;
+
     return (
       <div
-        className={styles.alignmentTool}
+        className={theme.alignmentToolStyles.alignmentTool}
         style={this.state.position}
-        ref={(toolbar) => { this.toolbar = toolbar; }}
+        ref={(toolbar) => {
+          this.toolbar = toolbar;
+        }}
       >
         {defaultButtons.map((Button, index) => (
           <Button
@@ -89,7 +96,7 @@ export default class AlignmentTool extends React.Component {
             key={index}
             alignment={this.state.alignment}
             setAlignment={this.props.store.getItem('setAlignment')}
-            theme={buttonStyles}
+            theme={theme.buttonStyles}
           />
         ))}
       </div>

--- a/draft-js-alignment-plugin/src/index.js
+++ b/draft-js-alignment-plugin/src/index.js
@@ -3,6 +3,8 @@ import decorateComponentWithProps from 'decorate-component-with-props';
 import createDecorator from './createDecorator';
 import AlignmentTool from './AlignmentTool';
 import createStore from './utils/createStore';
+import buttonStyles from './buttonStyles.css';
+import alignmentToolStyles from './alignmentToolStyles.css';
 
 const store = createStore({
   isVisible: false,
@@ -18,10 +20,21 @@ const createSetAlignment = (contentBlock, { getEditorState, setEditorState }) =>
   }
 };
 
-export default (config) => {
-  const alignmentToolProps = {
-    store
+export default (config = {}) => {
+  const defaultAlignmentToolTheme = {
+    buttonStyles,
+    alignmentToolStyles,
   };
+
+  const {
+    theme = defaultAlignmentToolTheme,
+  } = config;
+
+  const alignmentToolProps = {
+    store,
+    theme,
+  };
+
   return {
     initialize: ({ getReadOnly, getEditorState, setEditorState }) => {
       store.updateItem('getReadOnly', getReadOnly);

--- a/stories/Alignment/ThemedAlignmentEditor/alignmentToolStyles.css
+++ b/stories/Alignment/ThemedAlignmentEditor/alignmentToolStyles.css
@@ -1,0 +1,37 @@
+.alignmentTool {
+  left: 50%;
+  transform: translate(-50%) scale(0);
+  position: absolute;
+  border: 1px solid #111;
+  background: #333;
+  border-radius: 4px;
+  box-shadow: 0px 1px 3px 0px rgba(220, 220, 220, 1);
+  z-index: 2;
+  box-sizing: border-box;
+}
+
+.alignmentTool:after,
+.alignmentTool:before {
+  top: 100%;
+  left: 50%;
+  border: solid transparent;
+  content: " ";
+  height: 0;
+  width: 0;
+  position: absolute;
+  pointer-events: none;
+}
+
+.alignmentTool:after {
+  border-color: rgba(255, 255, 255, 0);
+  border-top-color: #333;
+  border-width: 4px;
+  margin-left: -4px;
+}
+
+.alignmentTool:before {
+  border-color: rgba(221, 221, 221, 0);
+  border-top-color: #111;
+  border-width: 6px;
+  margin-left: -6px;
+}

--- a/stories/Alignment/ThemedAlignmentEditor/buttonStyles.css
+++ b/stories/Alignment/ThemedAlignmentEditor/buttonStyles.css
@@ -1,0 +1,33 @@
+.buttonWrapper {
+  display: inline-block;
+}
+
+.button {
+  background: #333;
+  color: #ddd;
+  font-size: 18px;
+  border: 0;
+  padding-top: 5px;
+  vertical-align: bottom;
+  height: 34px;
+  width: 36px;
+  border-radius: 4px;
+}
+
+.button svg {
+  fill: #ddd;
+}
+
+.button:hover,
+.button:focus {
+  background: #444;
+  outline: 0; /* reset for :focus */
+}
+
+.active {
+  color: #6a9cc9;
+}
+
+.active svg {
+  fill: #6a9cc9;
+}

--- a/stories/Alignment/ThemedAlignmentEditor/colorBlockPlugin.js
+++ b/stories/Alignment/ThemedAlignmentEditor/colorBlockPlugin.js
@@ -1,0 +1,43 @@
+import React from 'react';
+
+const ColorBlock = ({
+  block, // eslint-disable-line no-unused-vars
+  blockProps, // eslint-disable-line no-unused-vars
+  customStyleMap, // eslint-disable-line no-unused-vars
+  customStyleFn, // eslint-disable-line no-unused-vars
+  decorator, // eslint-disable-line no-unused-vars
+  forceSelection, // eslint-disable-line no-unused-vars
+  offsetKey, // eslint-disable-line no-unused-vars
+  selection, // eslint-disable-line no-unused-vars
+  tree, // eslint-disable-line no-unused-vars
+  contentState, // eslint-disable-line no-unused-vars
+  style,
+  ...elementProps
+}) => (
+  <div
+    {...elementProps}
+    style={{ width: 200, height: 80, backgroundColor: '#9bc0c7', ...style }}
+  />
+  );
+
+const createColorBlockPlugin = (config = {}) => {
+  const component = config.decorator ? config.decorator(ColorBlock) : ColorBlock;
+  return {
+    blockRendererFn: (block, { getEditorState }) => {
+      if (block.getType() === 'atomic') {
+        const contentState = getEditorState().getCurrentContent();
+        const entity = contentState.getEntity(block.getEntityAt(0));
+        const type = entity.getType();
+        if (type === 'colorBlock') {
+          return {
+            component,
+            editable: false,
+          };
+        }
+      }
+      return null;
+    },
+  };
+};
+
+export default createColorBlockPlugin;

--- a/stories/Alignment/ThemedAlignmentEditor/editorStyles.css
+++ b/stories/Alignment/ThemedAlignmentEditor/editorStyles.css
@@ -1,0 +1,18 @@
+.editor {
+  box-sizing: border-box;
+  border: 1px solid #ddd;
+  cursor: text;
+  padding: 16px;
+  border-radius: 2px;
+  margin-bottom: 2em;
+  box-shadow: inset 0px 1px 8px -3px #ABABAB;
+  background: #fefefe;
+}
+
+.editor :global(.public-DraftEditor-content) {
+  min-height: 140px;
+}
+
+.options {
+  margin-bottom: 20px;
+}

--- a/stories/Alignment/ThemedAlignmentEditor/index.js
+++ b/stories/Alignment/ThemedAlignmentEditor/index.js
@@ -1,0 +1,109 @@
+import React, { Component } from 'react';
+import { convertFromRaw, EditorState } from 'draft-js';
+import Editor, { composeDecorators } from 'draft-js-plugins-editor';
+import createAlignmentPlugin from 'draft-js-alignment-plugin';
+import createFocusPlugin from 'draft-js-focus-plugin';
+import createColorBlockPlugin from './colorBlockPlugin';
+import editorStyles from './editorStyles.css';
+import alignmentToolStyles from './alignmentToolStyles.css';
+import buttonStyles from './buttonStyles.css';
+
+const focusPlugin = createFocusPlugin();
+const alignmentPlugin = createAlignmentPlugin({
+  theme: {
+    alignmentToolStyles,
+    buttonStyles,
+  },
+});
+const { AlignmentTool } = alignmentPlugin;
+
+const decorator = composeDecorators(
+  alignmentPlugin.decorator,
+  focusPlugin.decorator,
+);
+
+const colorBlockPlugin = createColorBlockPlugin({ decorator });
+const plugins = [focusPlugin, alignmentPlugin, colorBlockPlugin];
+
+/* eslint-disable */
+const initialState = {
+  entityMap: {
+    '0': {
+      type: 'colorBlock',
+      mutability: 'IMMUTABLE',
+      data: {},
+    },
+  },
+  blocks: [
+    {
+      key: '9gm3s',
+      text:
+        'This is a simple example. Focus the block by clicking on it and change alignment via the toolbar.',
+      type: 'unstyled',
+      depth: 0,
+      inlineStyleRanges: [],
+      entityRanges: [],
+      data: {},
+    },
+    {
+      key: 'ov7r',
+      text: ' ',
+      type: 'atomic',
+      depth: 0,
+      inlineStyleRanges: [],
+      entityRanges: [
+        {
+          offset: 0,
+          length: 1,
+          key: 0,
+        },
+      ],
+      data: {},
+    },
+    {
+      key: 'e23a8',
+      text:
+        'More text here to demonstrate how inline left/right alignment works …',
+      type: 'unstyled',
+      depth: 0,
+      inlineStyleRanges: [],
+      entityRanges: [],
+      data: {},
+    },
+  ],
+};
+/* eslint-enable */
+
+export default class ThemedAlignmentEditor extends Component {
+  state = {
+    editorState: EditorState.createWithContent(convertFromRaw(initialState)),
+  };
+
+  onChange = (editorState) => {
+    this.setState({
+      editorState,
+    });
+  };
+
+  focus = () => {
+    this.editor.focus();
+  };
+
+  render() {
+    return (
+      <div>
+        <div className={editorStyles.editor} onClick={this.focus}>
+          <Editor
+            editorState={this.state.editorState}
+            onChange={this.onChange}
+            plugins={plugins}
+            ref={(element) => {
+              this.editor = element;
+            }}
+          />
+          <AlignmentTool />
+        </div>
+      </div>
+    );
+  }
+}

--- a/stories/index.js
+++ b/stories/index.js
@@ -6,6 +6,7 @@ import { storiesOf } from '@storybook/react';
 
 // Alignment
 import SimpleAlignmentEditor from './Alignment/SimpleAlignmentEditor';
+import ThemedAlignmentEditor from './Alignment/ThemedAlignmentEditor';
 
 // Anchor
 import AnchorSimpleLinkPluginEditor from './Anchor/SimpleLinkPluginEditor';
@@ -73,7 +74,8 @@ import ThemedToolbarEditor from './StaticToolbar/ThemedToolbarEditor';
 import SimpleToolbarEditor from './StaticToolbar/SimpleToolbarEditor';
 
 storiesOf('Alignment Plugin', module)
-  .add('Editor with Alignment Plugin', () => <SimpleAlignmentEditor />);
+  .add('Editor with Alignment Plugin', () => <SimpleAlignmentEditor />)
+  .add('Editor with custom themed Alignment Plugin', () => <ThemedAlignmentEditor />);
 
 storiesOf('Anchor Plugin', module)
   .add('Editor with Anchor Plugin', () => <AnchorSimpleLinkPluginEditor />);


### PR DESCRIPTION
## Use-case/Problem

Currently, I cannot customize `AlignmentTool` component, because styles are hard coded. 

## Implementation

I added `theme` object to customize `AlignmentTool`, like `InlineToolbar`.
I also added `ThemedAlignmentEditor` story.

## Demo

[
![screen shot 2017-11-17 at 3 46 23 pm](https://user-images.githubusercontent.com/10040154/32934101-9b965862-cbae-11e7-8652-c379f45b73c9.png)
](url)
