### PR TITLE
mention-plugin: fix tapping on entries to select on mobile devices

### DIFF
--- a/draft-js-mention-plugin/CHANGELOG.md
+++ b/draft-js-mention-plugin/CHANGELOG.md
@@ -41,6 +41,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed race condition where the SuggestionPortal would unregister and not register again when inputting Japanese, etc.
 - Fixed bug where `mentionPrefix` does not appear in `editorState`. `mentionPrefix` is no longer passed to `mentionComponent`.
 - Fixed bug where `onSearchChange` didn't fire when a user switched between two different mention autocompletions with the same search value. Now it will trigger `onSearchChange` in such a case.
+- Fixed bug where tapping on entries on mobile devices would not select them. [#423](https://github.com/draft-js-plugins/draft-js-plugins/pull/423)
 
 ## 1.1.2 - 2016-06-26
 

--- a/draft-js-mention-plugin/src/MentionSuggestions/Entry/index.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/Entry/index.js
@@ -20,6 +20,13 @@ export default class Entry extends Component {
     this.mouseDown = false;
   }
 
+  onTouchStart = (event) => {
+    // this fixes an issue with onMouseDown and onMouseUp events not firing on mobile devices, making it
+    // difficult if not impossible to tap on entries to select them
+    event.preventDefault();
+    this.props.onMentionSelect(this.props.mention);
+  };
+
   onMouseUp = () => {
     if (this.mouseDown) {
       this.props.onMentionSelect(this.props.mention);
@@ -45,6 +52,7 @@ export default class Entry extends Component {
     return (
       <EntryComponent
         className={className}
+        onTouchStart={this.onTouchStart}
         onMouseDown={this.onMouseDown}
         onMouseUp={this.onMouseUp}
         onMouseEnter={this.onMouseEnter}


### PR DESCRIPTION
This fix doesn't feel 100% because it makes it impossible to scroll a list of entries on mobile devices (this is not a problem with the default components as they do not render a scrollable list, but consumers may customize the list component do so).

Feels like `onClick` would be better suited but [this commit](https://github.com/draft-js-plugins/draft-js-plugins/commit/d07d7926a) suggests otherwise.