### PR TITLE
Center Emoji suggestion entry items

### DIFF
--- a/draft-js-emoji-plugin/src/emojiSelectStyles.css
+++ b/draft-js-emoji-plugin/src/emojiSelectStyles.css
@@ -133,6 +133,8 @@
   background: none;
   border: none;
   outline: none;
+  display: flex;
+  align-items: center;
   transition: background-color 0.4s cubic-bezier(0.27, 1.27, 0.48, 0.56);
 }
 


### PR DESCRIPTION
## Checklist

- [ x ] Fix any eslint errors that occur
- [ ] Update change-log for every plugin you touch
- [ x ] Add/Update tests if you add/change new functionality
- [ x ] Add/Update docs if you add/change functionality
- [ x ] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

Currently, if you were to change the fontsize/lineheight inside the editor, the emoji themselves would awkwardly sit at the bottom of the entry card. This will center it.

## Implementation

Make the entry a flexbox and align the children to the center.

## Demo

I'll add it shortly.
