### PR TITLE
[mention-plugin] Remove react warning

### DIFF
--- a/draft-js-mention-plugin/CHANGELOG.md
+++ b/draft-js-mention-plugin/CHANGELOG.md
@@ -41,6 +41,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed race condition where the SuggestionPortal would unregister and not register again when inputting Japanese, etc.
 - Fixed bug where `mentionPrefix` does not appear in `editorState`. `mentionPrefix` is no longer passed to `mentionComponent`.
 - Fixed bug where `onSearchChange` didn't fire when a user switched between two different mention autocompletions with the same search value. Now it will trigger `onSearchChange` in such a case.
+- Fixed unrecognized `isFocused` React prop.
 
 ## 1.1.2 - 2016-06-26
 

--- a/draft-js-mention-plugin/src/MentionSuggestions/Entry/defaultEntryComponent.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/Entry/defaultEntryComponent.js
@@ -5,6 +5,7 @@ const defaultEntryComponent = (props) => {
   const {
     mention,
     theme,
+    isFocused, // eslint-disable-line no-unused-vars
     searchValue, // eslint-disable-line no-unused-vars
     ...parentProps
   } = props;


### PR DESCRIPTION
## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

I'm getting this warning `React does not recognize the 'isFocused' prop on a DOM element.`

## Implementation

Remove `isFocused ` from the passed props.