### PR TITLE
draft-js-plugins-editor: fix immutable.js dependecy to match other plugins

### DIFF
--- a/draft-js-plugins-editor/CHANGELOG.md
+++ b/draft-js-plugins-editor/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.0.4
+- Tighten Immutable.js dependency requirements to ~3.7.4 to match draft-js and other plugins
+
 ## 2.0.3
 - Bugfix - componentWillReceiveProps causes infite update loop in some circumstances
 

--- a/draft-js-plugins-editor/package.json
+++ b/draft-js-plugins-editor/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "decorate-component-with-props": "^1.0.2",
     "find-with-regex": "^1.0.2",
-    "immutable": "^3.7.4",
+    "immutable": "~3.7.4",
     "prop-types": "^15.5.8",
     "union-class-names": "^1.0.0"
   },


### PR DESCRIPTION
This PR fixes a small glitch in immutable.js dependency version range that causes yarn (for example) to install multiple unnecessary versions of immutable.js when this plugin is in use.
