### PR TITLE
add default width and height for resizable plugin

### DIFF
--- a/docs/client/components/pages/Resizeable/index.js
+++ b/docs/client/components/pages/Resizeable/index.js
@@ -89,6 +89,14 @@ export default class App extends Component {
         </AlternateContainer>
         <Container>
           <Heading level={2}>Configuration Parameters</Heading>
+          <div className={styles.param}>
+            <span className={styles.paramName}>defaultHorizontalWidth</span>
+            <span>Default width for horizontal mode. Default value is 40.</span>
+          </div>
+          <div className={styles.param}>
+            <span className={styles.paramName}>defaultVerticalHeight</span>
+            <span>Default height for vertical mode. Default value is 40.</span>
+          </div>
         </Container>
         <Container>
           <Heading level={2}>Simple Resizeable Example</Heading>

--- a/draft-js-resizeable-plugin/src/createDecorator.js
+++ b/draft-js-resizeable-plugin/src/createDecorator.js
@@ -15,6 +15,8 @@ export default ({ config, store }) => (WrappedComponent) => class BlockResizeabl
     horizontal: 'relative',
     vertical: false,
     resizeSteps: 1,
+    defaultHorizontalWidth: 40,
+    defaultVerticalHeight: 40,
     ...config
   };
   state = {
@@ -134,6 +136,8 @@ export default ({ config, store }) => (WrappedComponent) => class BlockResizeabl
   render() {
     const {
       blockProps,
+      defaultHorizontalWidth,
+      defaultVerticalHeight,
       vertical,
       horizontal,
       style,
@@ -149,17 +153,17 @@ export default ({ config, store }) => (WrappedComponent) => class BlockResizeabl
     if (horizontal === 'auto') {
       styles.width = 'auto';
     } else if (horizontal === 'relative') {
-      styles.width = `${(width || blockProps.resizeData.width || 40)}%`;
+      styles.width = `${(width || blockProps.resizeData.width || defaultHorizontalWidth)}%`;
     } else if (horizontal === 'absolute') {
-      styles.width = `${(width || blockProps.resizeData.width || 40)}px`;
+      styles.width = `${(width || blockProps.resizeData.width || defaultHorizontalWidth)}px`;
     }
 
     if (vertical === 'auto') {
       styles.height = 'auto';
     } else if (vertical === 'relative') {
-      styles.height = `${(height || blockProps.resizeData.height || 40)}%`;
+      styles.height = `${(height || blockProps.resizeData.height || defaultVerticalHeight)}%`;
     } else if (vertical === 'absolute') {
-      styles.height = `${(height || blockProps.resizeData.height || 40)}px`;
+      styles.height = `${(height || blockProps.resizeData.height || defaultVerticalHeight)}px`;
     }
 
     // Handle cursor


### PR DESCRIPTION
Please check out Contributing Guidelines. By following this template you help us to review your code.
https://github.com/draft-js-plugins/draft-js-plugins/blob/master/CONTRIBUTING.md

## Checklist

- [ ] Fix any eslint errors that occur
- [ ] Update change-log for every plugin you touch
- [ ] Add/Update tests if you add/change new functionality
- [ ] Add/Update docs if you add/change functionality
- [ ] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

Make  default width or height configable for resizable plugin.

## Implementation

Move default width or height (40) to defaultProps.

## Demo

```javascript
createResizeablePlugin({
    defaultHorizontalWidth: 50,
    defaultVerticalHeight: 50,
})
```
