### PR TITLE
[mention] fix cursor not moving up/down on non existing mention

### DIFF
--- a/draft-js-mention-plugin/CHANGELOG.md
+++ b/draft-js-mention-plugin/CHANGELOG.md
@@ -26,6 +26,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed bug where a user typed not existing mention @xxx and cursor is not moved with up/down arrow key
 - Escape spaces before mention trigger properly
 - Escape mention trigger regex properly
 - Fix bug that selects candidate on hitting return key even if the dropdown was closed. Thanks to @ngs [#720](https://github.com/draft-js-plugins/draft-js-plugins/pull/720)

--- a/draft-js-mention-plugin/src/MentionSuggestions/index.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/index.js
@@ -171,7 +171,7 @@ export class MentionSuggestions extends Component {
     // If none of the above triggered to close the window, it's safe to assume
     // the dropdown should be open. This is useful when a user focuses on another
     // input field and then comes back: the dropdown will show again.
-    if (!this.state.isActive && !this.props.store.isEscaped(this.activeOffsetKey)) {
+    if (!this.state.isActive && !this.props.store.isEscaped(this.activeOffsetKey) && this.props.suggestions.size > 0) {
       this.openDropdown();
     }
 


### PR DESCRIPTION

## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

When typing non-existing mention, empty dropdown open and up/down arrow catch by mention plugin. Cursor stick on  @non_exists_mention line.

## Demo

Before:
![before](https://user-images.githubusercontent.com/151676/34433529-742a34cc-ec99-11e7-815f-79cf1e42ca46.gif)

After problem fixed:
![after](https://user-images.githubusercontent.com/151676/34433548-8eee3ca4-ec99-11e7-9919-607a9a0952c6.gif)
