### PR TITLE
[mention] fix mention detection in styled text

### DIFF
--- a/draft-js-mention-plugin/src/MentionSuggestions/index.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/index.js
@@ -122,12 +122,13 @@ export class MentionSuggestions extends Component {
     const offsetDetails = searches.map((offsetKey) => decodeOffsetKey(offsetKey));
 
     // a leave can be empty when it is removed due e.g. using backspace
+    // do not check leaves, use full decorated portal text
     const leaves = offsetDetails
       .filter(({ blockKey }) => blockKey === anchorKey)
-      .map(({ blockKey, decoratorKey, leafKey }) => (
+      .map(({ blockKey, decoratorKey }) => (
         editorState
           .getBlockTree(blockKey)
-          .getIn([decoratorKey, 'leaves', leafKey])
+          .getIn([decoratorKey])
       ));
 
     // if all leaves are undefined the popover should be removed


### PR DESCRIPTION
## Checklist

- [x] Fix any eslint errors that occur
- [ ] Update change-log for every plugin you touch
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem
When trying to detect mention in differently styled text,  detection is not work. See demo.

We have more worse case with same reason of problem, in our project, where mention plugin is used. When adding mention in series: `@first_mention @second_mention` second mention is not detected.
In depth problem looks like:
1. From the portal detection decorated text is ` @second_mention` (started from space)
2. First ` `(space) goes in first leaf and `@second_mention` goes in second leaf.
3. Mention is not detected by regexp in `@second_mention` - no space here and it is not start at the begin of line.

## Implementation

Do not check leaves separately, use full decorated text to check.

## Demo

Before:
![before](https://user-images.githubusercontent.com/151676/34434427-82bb78d8-ec9f-11e7-9056-df8b3b62273c.gif)

After fix:
![after](https://user-images.githubusercontent.com/151676/34434430-862b9638-ec9f-11e7-8fa6-fbde2cbb1b4f.gif)
