### PR TITLE
[mention] fix suggestions dropdown position in case of line wrap

### DIFF
--- a/draft-js-mention-plugin/src/mentionSuggestionsStyles.css
+++ b/draft-js-mention-plugin/src/mentionSuggestionsStyles.css
@@ -1,6 +1,6 @@
 .mentionSuggestions {
   border: 1px solid #eee;
-  margin-top: 1.75em;
+  margin-top: 0.4em;
   position: absolute;
   min-width: 220px;
   max-width: 440px;

--- a/draft-js-mention-plugin/src/utils/positionSuggestions.js
+++ b/draft-js-mention-plugin/src/utils/positionSuggestions.js
@@ -21,12 +21,12 @@ const positionSuggestions = ({ decoratorRect, popover, state, props }) => {
 
     const relativeParentRect = relativeParent.getBoundingClientRect();
     relativeRect.left = decoratorRect.left - relativeParentRect.left;
-    relativeRect.top = decoratorRect.top - relativeParentRect.top;
+    relativeRect.top = decoratorRect.bottom - relativeParentRect.top;
   } else {
     relativeRect.scrollTop = window.pageYOffset || document.documentElement.scrollTop;
     relativeRect.scrollLeft = window.pageXOffset || document.documentElement.scrollLeft;
 
-    relativeRect.top = decoratorRect.top;
+    relativeRect.top = decoratorRect.bottom;
     relativeRect.left = decoratorRect.left;
   }
 


### PR DESCRIPTION
## Checklist

- [x] Fix any eslint errors that occur
- [ ] Update change-log for every plugin you touch
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

When typing @mention in the on of line, it goes to beginning of next line, but suggestion dropdown stays on the same vertical position and overlaps @mention text.

## Implementation

Calculate position of suggestion portal in relation of bottom (not top) decorated rectangle.

## Demo

Before: 
![before](https://user-images.githubusercontent.com/151676/34435415-f2456888-eca6-11e7-8235-68d13c7d5704.gif)

After fix:
![after](https://user-images.githubusercontent.com/151676/34435423-fb38bf3a-eca6-11e7-9d72-b1a9c09bbbaa.gif)
