### PR TITLE
Add support for changing toolbar icon including link button icon

### DIFF
--- a/docs/client/components/pages/Anchor/CustomInlineToolbarEditor/index.js
+++ b/docs/client/components/pages/Anchor/CustomInlineToolbarEditor/index.js
@@ -15,7 +15,7 @@ import linkStyles from './linkStyles.css';
 const linkPlugin = createLinkPlugin({
   theme: linkStyles,
   placeholder: 'http://…',
-  wrapIcon: (defaultIcon) => (
+  wrapIcon: (buttonType, style, defaultIcon, isActive) => ( // eslint-disable-line no-unused-vars
     <span className="my-class">{defaultIcon}</span>
   )
 });

--- a/docs/client/components/pages/Anchor/CustomInlineToolbarEditor/index.js
+++ b/docs/client/components/pages/Anchor/CustomInlineToolbarEditor/index.js
@@ -14,7 +14,10 @@ import linkStyles from './linkStyles.css';
 
 const linkPlugin = createLinkPlugin({
   theme: linkStyles,
-  placeholder: 'http://…'
+  placeholder: 'http://…',
+  wrapIcon: (defaultIcon) => (
+    <span className="my-class">{defaultIcon}</span>
+  )
 });
 const inlineToolbarPlugin = createInlineToolbarPlugin({
   theme: { buttonStyles, toolbarStyles },

--- a/docs/client/components/pages/Anchor/index.js
+++ b/docs/client/components/pages/Anchor/index.js
@@ -85,7 +85,7 @@ export default class App extends Component {
           </div>
           <div>
             <span className={styles.paramName}>wrapIcon</span>
-            <span>Function to wrap icon to your icon. (defaultIcon, hasLinkSelected) =&gt; IconComponent </span>
+            <span>Function to wrap icon to your icon. (buttonType, style, defaultIcon, hasLinkSelected) =&gt; IconComponent </span>
           </div>
         </Container>
         <Container>

--- a/docs/client/components/pages/Anchor/index.js
+++ b/docs/client/components/pages/Anchor/index.js
@@ -83,6 +83,10 @@ export default class App extends Component {
             <span className={styles.paramName}>Link</span>
             <span>Specify the link component that will be rendered.</span>
           </div>
+          <div>
+            <span className={styles.paramName}>wrapIcon</span>
+            <span>Function to wrap icon to your icon. (defaultIcon, hasLinkSelected) =&gt; IconComponent </span>
+          </div>
         </Container>
         <Container>
           <Heading level={2}>Simple Link Plugin Example</Heading>

--- a/docs/client/components/pages/InlineToolbar/CustomInlineToolbarEditor/index.js
+++ b/docs/client/components/pages/InlineToolbar/CustomInlineToolbarEditor/index.js
@@ -77,7 +77,7 @@ const inlineToolbarPlugin = createInlineToolbarPlugin({
     BlockquoteButton,
     CodeBlockButton
   ],
-  wrapIcon: (icon) => <span className="my-class">{icon}</span>
+  wrapIcon: (buttonType, style, icon, isActive) => <span className="my-class">{icon}</span> // eslint-disable-line no-unused-vars
 });
 const { InlineToolbar } = inlineToolbarPlugin;
 const plugins = [inlineToolbarPlugin];

--- a/docs/client/components/pages/InlineToolbar/CustomInlineToolbarEditor/index.js
+++ b/docs/client/components/pages/InlineToolbar/CustomInlineToolbarEditor/index.js
@@ -76,7 +76,8 @@ const inlineToolbarPlugin = createInlineToolbarPlugin({
     OrderedListButton,
     BlockquoteButton,
     CodeBlockButton
-  ]
+  ],
+  wrapIcon: (icon) => <span className="my-class">{icon}</span>
 });
 const { InlineToolbar } = inlineToolbarPlugin;
 const plugins = [inlineToolbarPlugin];

--- a/docs/client/components/pages/InlineToolbar/index.js
+++ b/docs/client/components/pages/InlineToolbar/index.js
@@ -88,6 +88,13 @@ export default class App extends Component {
           </p>
         </AlternateContainer>
         <Container>
+          <Heading level={2}>Configuration Parameters</Heading>
+          <div>
+            <span className={styles.paramName}>wrapIcon</span>
+            <span>Function to wrap icon to your icon. (defaultIcon: Component, isActive: boolean) =&gt; IconComponent </span>
+          </div>
+        </Container>
+        <Container>
           <Heading level={2}>Simple Inline Toolbar Example</Heading>
           <SimpleInlineToolbarEditor />
           <Code code={simpleExampleCode} name="SimpleInlineToolbarEditor.js" />

--- a/docs/client/components/pages/InlineToolbar/index.js
+++ b/docs/client/components/pages/InlineToolbar/index.js
@@ -93,6 +93,10 @@ export default class App extends Component {
             <span className={styles.paramName}>wrapIcon</span>
             <span>Function to wrap icon to your icon. (defaultIcon: Component, isActive: boolean) =&gt; IconComponent </span>
           </div>
+          <div>
+            <span className={styles.paramName}>extra</span>
+            <span>Extra params passed to buttons.</span>
+          </div>
         </Container>
         <Container>
           <Heading level={2}>Simple Inline Toolbar Example</Heading>

--- a/docs/client/components/pages/SideToolbar/index.js
+++ b/docs/client/components/pages/SideToolbar/index.js
@@ -83,6 +83,17 @@ export default class App extends Component {
           </p>
         </AlternateContainer>
         <Container>
+          <Heading level={2}>Configuration Parameters</Heading>
+          <div>
+            <span className={styles.paramName}>wrapIcon</span>
+            <span>Function to wrap icon to your icon. (defaultIcon: Component, isActive: boolean) =&gt; IconComponent </span>
+          </div>
+          <div>
+            <span className={styles.paramName}>extra</span>
+            <span>Extra params passed to buttons.</span>
+          </div>
+        </Container>
+        <Container>
           <Heading level={2}>Simple Side Toolbar Example</Heading>
           <SimpleSideToolbarEditor />
           <Code code={simpleExampleCode} name="SimpleSideToolbarEditor.js" />

--- a/docs/client/components/pages/StaticToolbar/CustomToolbarEditor/index.js
+++ b/docs/client/components/pages/StaticToolbar/CustomToolbarEditor/index.js
@@ -77,7 +77,7 @@ const toolbarPlugin = createToolbarPlugin({
     BlockquoteButton,
     CodeBlockButton
   ],
-  wrapIcon: (icon) => <span className="my-class">{icon}</span>
+  wrapIcon: (buttonType, style, icon, isActive) => <span className="my-class">{icon}</span> // eslint-disable-line no-unused-vars
 });
 const { Toolbar } = toolbarPlugin;
 const plugins = [toolbarPlugin];

--- a/docs/client/components/pages/StaticToolbar/CustomToolbarEditor/index.js
+++ b/docs/client/components/pages/StaticToolbar/CustomToolbarEditor/index.js
@@ -76,7 +76,8 @@ const toolbarPlugin = createToolbarPlugin({
     OrderedListButton,
     BlockquoteButton,
     CodeBlockButton
-  ]
+  ],
+  wrapIcon: (icon) => <span className="my-class">{icon}</span>
 });
 const { Toolbar } = toolbarPlugin;
 const plugins = [toolbarPlugin];

--- a/docs/client/components/pages/StaticToolbar/index.js
+++ b/docs/client/components/pages/StaticToolbar/index.js
@@ -93,6 +93,10 @@ export default class App extends Component {
             <span className={styles.paramName}>wrapIcon</span>
             <span>Function to wrap icon to your icon. (defaultIcon: Component, isActive: boolean) =&gt; IconComponent </span>
           </div>
+          <div>
+            <span className={styles.paramName}>extra</span>
+            <span>Extra params passed to buttons.</span>
+          </div>
         </Container>
         <Container>
           <Heading level={2}>Simple Static Toolbar Example</Heading>

--- a/docs/client/components/pages/StaticToolbar/index.js
+++ b/docs/client/components/pages/StaticToolbar/index.js
@@ -88,6 +88,13 @@ export default class App extends Component {
           </p>
         </AlternateContainer>
         <Container>
+          <Heading level={2}>Configuration Parameters</Heading>
+          <div>
+            <span className={styles.paramName}>wrapIcon</span>
+            <span>Function to wrap icon to your icon. (defaultIcon: Component, isActive: boolean) =&gt; IconComponent </span>
+          </div>
+        </Container>
+        <Container>
           <Heading level={2}>Simple Static Toolbar Example</Heading>
           <SimpleToolbarEditor />
           <Code code={simpleExampleCode} name="SimpleToolbarEditor.js" />

--- a/draft-js-anchor-plugin/src/components/LinkButton/index.js
+++ b/draft-js-anchor-plugin/src/components/LinkButton/index.js
@@ -43,7 +43,7 @@ export default class LinkButton extends Component {
     );
 
     if (wrapIcon) {
-      icon = wrapIcon(icon, hasLinkSelected);
+      icon = wrapIcon('link', null, icon, hasLinkSelected);
     }
 
     return (

--- a/draft-js-anchor-plugin/src/components/LinkButton/index.js
+++ b/draft-js-anchor-plugin/src/components/LinkButton/index.js
@@ -26,7 +26,7 @@ export default class LinkButton extends Component {
   }
 
   render() {
-    const { theme, onRemoveLinkAtSelection } = this.props;
+    const { theme, onRemoveLinkAtSelection, wrapIcon } = this.props;
     const hasLinkSelected = EditorUtils.hasEntity(
       this.props.store.getEditorState(),
       'LINK'
@@ -34,6 +34,17 @@ export default class LinkButton extends Component {
     const className = hasLinkSelected
       ? unionClassNames(theme.button, theme.active)
       : theme.button;
+
+    let icon = (
+      <svg height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+        <path d="M0 0h24v24H0z" fill="none" />
+        <path d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z" />
+      </svg>
+    );
+
+    if (wrapIcon) {
+      icon = wrapIcon(icon, hasLinkSelected);
+    }
 
     return (
       <div
@@ -45,10 +56,7 @@ export default class LinkButton extends Component {
           onClick={hasLinkSelected ? onRemoveLinkAtSelection : this.onAddLinkClick}
           type="button"
         >
-          <svg height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-            <path d="M0 0h24v24H0z" fill="none" />
-            <path d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z" />
-          </svg>
+          {icon}
         </button>
       </div>
     );

--- a/draft-js-anchor-plugin/src/index.js
+++ b/draft-js-anchor-plugin/src/index.js
@@ -8,7 +8,13 @@ import linkStyles from './linkStyles.css';
 export default (config = {}) => {
   const defaultTheme = linkStyles;
 
-  const { theme = defaultTheme, placeholder, Link, linkTarget } = config;
+  const {
+    theme = defaultTheme,
+    placeholder,
+    Link,
+    linkTarget,
+    wrapIcon,
+  } = config;
 
   const store = {
     getEditorState: undefined,
@@ -36,6 +42,7 @@ export default (config = {}) => {
       ownTheme: theme,
       store,
       placeholder,
+      wrapIcon,
       onRemoveLinkAtSelection: () => store.setEditorState(
         EditorUtils.removeLinkAtSelection(store.getEditorState())
       )

--- a/draft-js-buttons/src/utils/createBlockAlignmentButton.js
+++ b/draft-js-buttons/src/utils/createBlockAlignmentButton.js
@@ -21,7 +21,7 @@ export default ({ alignment, children }) => (
       let icon = children;
 
       if (wrapIcon) {
-        icon = wrapIcon(icon, isActive);
+        icon = wrapIcon('alignment', alignment, icon, isActive);
       }
 
       return (

--- a/draft-js-buttons/src/utils/createBlockAlignmentButton.js
+++ b/draft-js-buttons/src/utils/createBlockAlignmentButton.js
@@ -15,8 +15,15 @@ export default ({ alignment, children }) => (
     isActive = () => this.props.alignment === alignment;
 
     render() {
-      const { theme } = this.props;
-      const className = this.isActive() ? unionClassNames(theme.button, theme.active) : theme.button;
+      const { theme, wrapIcon } = this.props;
+      const isActive = this.isActive();
+      const className = isActive ? unionClassNames(theme.button, theme.active) : theme.button;
+      let icon = children;
+
+      if (wrapIcon) {
+        icon = wrapIcon(icon, isActive);
+      }
+
       return (
         <div
           className={theme.buttonWrapper}
@@ -26,7 +33,7 @@ export default ({ alignment, children }) => (
             className={className}
             onClick={this.activate}
             type="button"
-            children={children}
+            children={icon}
           />
         </div>
       );

--- a/draft-js-buttons/src/utils/createBlockStyleButton.js
+++ b/draft-js-buttons/src/utils/createBlockStyleButton.js
@@ -39,7 +39,7 @@ export default ({ blockType, children }) => (
       let icon = children;
 
       if (wrapIcon) {
-        icon = wrapIcon(icon, isActive);
+        icon = wrapIcon('block', blockType, icon, isActive);
       }
 
       return (

--- a/draft-js-buttons/src/utils/createBlockStyleButton.js
+++ b/draft-js-buttons/src/utils/createBlockStyleButton.js
@@ -33,8 +33,15 @@ export default ({ blockType, children }) => (
     }
 
     render() {
-      const { theme } = this.props;
-      const className = this.blockTypeIsActive() ? unionClassNames(theme.button, theme.active) : theme.button;
+      const { theme, wrapIcon } = this.props;
+      const isActive = this.blockTypeIsActive();
+      const className = isActive ? unionClassNames(theme.button, theme.active) : theme.button;
+      let icon = children;
+
+      if (wrapIcon) {
+        icon = wrapIcon(icon, isActive);
+      }
+
       return (
         <div
           className={theme.buttonWrapper}
@@ -44,7 +51,7 @@ export default ({ blockType, children }) => (
             className={className}
             onClick={this.toggleStyle}
             type="button"
-            children={children}
+            children={icon}
           />
         </div>
       );

--- a/draft-js-buttons/src/utils/createInlineStyleButton.js
+++ b/draft-js-buttons/src/utils/createInlineStyleButton.js
@@ -22,8 +22,15 @@ export default ({ style, children }) => (
     styleIsActive = () => this.props.getEditorState && this.props.getEditorState().getCurrentInlineStyle().has(style);
 
     render() {
-      const { theme } = this.props;
-      const className = this.styleIsActive() ? unionClassNames(theme.button, theme.active) : theme.button;
+      const { theme, wrapIcon } = this.props;
+      const isActive = this.styleIsActive();
+      const className = isActive ? unionClassNames(theme.button, theme.active) : theme.button;
+      let icon = children;
+
+      if (wrapIcon) {
+        icon = wrapIcon(icon, isActive);
+      }
+
       return (
         <div
           className={theme.buttonWrapper}
@@ -33,7 +40,7 @@ export default ({ style, children }) => (
             className={className}
             onClick={this.toggleStyle}
             type="button"
-            children={children}
+            children={icon}
           />
         </div>
       );

--- a/draft-js-buttons/src/utils/createInlineStyleButton.js
+++ b/draft-js-buttons/src/utils/createInlineStyleButton.js
@@ -28,7 +28,7 @@ export default ({ style, children }) => (
       let icon = children;
 
       if (wrapIcon) {
-        icon = wrapIcon(icon, isActive);
+        icon = wrapIcon('inline', style, icon, isActive);
       }
 
       return (

--- a/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
+++ b/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
@@ -97,7 +97,8 @@ export default class Toolbar extends React.Component {
       theme,
       store,
       structure,
-      wrapIcon
+      wrapIcon,
+      extra
     } = this.props;
     const { overrideContent: OverrideContent } = this.state;
     const childrenProps = {
@@ -106,6 +107,8 @@ export default class Toolbar extends React.Component {
       setEditorState: store.getItem('setEditorState'),
       onOverrideContent: this.onOverrideContent,
       wrapIcon,
+      store,
+      extra
     };
 
     return (

--- a/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
+++ b/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
@@ -93,13 +93,19 @@ export default class Toolbar extends React.Component {
   };
 
   render() {
-    const { theme, store, structure } = this.props;
+    const {
+      theme,
+      store,
+      structure,
+      wrapIcon
+    } = this.props;
     const { overrideContent: OverrideContent } = this.state;
     const childrenProps = {
       theme: theme.buttonStyles,
       getEditorState: store.getItem('getEditorState'),
       setEditorState: store.getItem('setEditorState'),
-      onOverrideContent: this.onOverrideContent
+      onOverrideContent: this.onOverrideContent,
+      wrapIcon,
     };
 
     return (

--- a/draft-js-inline-toolbar-plugin/src/index.js
+++ b/draft-js-inline-toolbar-plugin/src/index.js
@@ -27,13 +27,15 @@ export default (config = {}) => {
       CodeButton,
     ],
     wrapIcon,
+    extra,
   } = config;
 
   const toolbarProps = {
     store,
     structure,
     theme,
-    wrapIcon
+    wrapIcon,
+    extra
   };
 
   return {

--- a/draft-js-inline-toolbar-plugin/src/index.js
+++ b/draft-js-inline-toolbar-plugin/src/index.js
@@ -25,13 +25,15 @@ export default (config = {}) => {
       ItalicButton,
       UnderlineButton,
       CodeButton,
-    ]
+    ],
+    wrapIcon,
   } = config;
 
   const toolbarProps = {
     store,
     structure,
     theme,
+    wrapIcon
   };
 
   return {

--- a/draft-js-side-toolbar-plugin/src/components/BlockTypeSelect/index.js
+++ b/draft-js-side-toolbar-plugin/src/components/BlockTypeSelect/index.js
@@ -32,7 +32,14 @@ export default class BlockTypeSelect extends React.Component {
   }
 
   render() {
-    const { theme, getEditorState, setEditorState } = this.props;
+    const {
+      theme,
+      getEditorState,
+      setEditorState,
+      wrapIcon,
+      extra,
+      store
+    } = this.props;
     return (
       <div
         onMouseEnter={this.onMouseEnter}
@@ -57,6 +64,9 @@ export default class BlockTypeSelect extends React.Component {
               getEditorState={getEditorState}
               setEditorState={setEditorState}
               theme={theme.buttonStyles}
+              store={store}
+              extra={extra}
+              wrapIcon={wrapIcon}
             />
           ))}
         </div>

--- a/draft-js-side-toolbar-plugin/src/components/DefaultBlockTypeSelect/index.js
+++ b/draft-js-side-toolbar-plugin/src/components/DefaultBlockTypeSelect/index.js
@@ -11,7 +11,14 @@ import {
 
 import BlockTypeSelect from '../BlockTypeSelect';
 
-const DefaultBlockTypeSelect = ({ getEditorState, setEditorState, theme }) => (
+const DefaultBlockTypeSelect = ({
+  getEditorState,
+  setEditorState,
+  theme,
+  store,
+  wrapIcon,
+  extra
+}) => (
   <BlockTypeSelect
     getEditorState={getEditorState}
     setEditorState={setEditorState}
@@ -24,6 +31,9 @@ const DefaultBlockTypeSelect = ({ getEditorState, setEditorState, theme }) => (
       BlockquoteButton,
       CodeBlockButton,
     ]}
+    store={store}
+    wrapIcon={wrapIcon}
+    extra={extra}
   />
 );
 

--- a/draft-js-side-toolbar-plugin/src/components/Toolbar/index.js
+++ b/draft-js-side-toolbar-plugin/src/components/Toolbar/index.js
@@ -51,7 +51,7 @@ export default class Toolbar extends React.Component {
   }
 
   render() {
-    const { theme, store } = this.props;
+    const { theme, store, wrapIcon, extra } = this.props;
     return (
       <div
         className={theme.toolbarStyles.wrapper}
@@ -63,6 +63,9 @@ export default class Toolbar extends React.Component {
             getEditorState={store.getItem('getEditorState')}
             setEditorState={store.getItem('setEditorState')}
             theme={theme}
+            store={store}
+            wrapIcon={wrapIcon}
+            extra={extra}
           />
         ))}
       </div>

--- a/draft-js-side-toolbar-plugin/src/index.js
+++ b/draft-js-side-toolbar-plugin/src/index.js
@@ -17,13 +17,17 @@ export default (config = {}) => {
     theme = defaultTheme,
     structure = [
       DefaultBlockTypeSelect
-    ]
+    ],
+    wrapIcon,
+    extra
   } = config;
 
   const toolbarProps = {
     store,
     structure,
     theme,
+    wrapIcon,
+    extra
   };
 
   return {

--- a/draft-js-static-toolbar-plugin/src/components/Toolbar/index.js
+++ b/draft-js-static-toolbar-plugin/src/components/Toolbar/index.js
@@ -29,13 +29,22 @@ export default class Toolbar extends React.Component {
   onOverrideContent = (overrideContent) => this.setState({ overrideContent });
 
   render() {
-    const { theme, store, structure } = this.props;
+    const {
+      theme,
+      store,
+      structure,
+      wrapIcon,
+      extra
+    } = this.props;
     const { overrideContent: OverrideContent } = this.state;
     const childrenProps = {
       theme: theme.buttonStyles,
       getEditorState: store.getItem('getEditorState'),
       setEditorState: store.getItem('setEditorState'),
-      onOverrideContent: this.onOverrideContent
+      onOverrideContent: this.onOverrideContent,
+      wrapIcon,
+      store,
+      extra
     };
 
     return (

--- a/draft-js-static-toolbar-plugin/src/index.js
+++ b/draft-js-static-toolbar-plugin/src/index.js
@@ -24,14 +24,16 @@ export default (config = {}) => {
       UnderlineButton,
       CodeButton,
     ],
-    wrapIcon
+    wrapIcon,
+    extra,
   } = config;
 
   const toolbarProps = {
     store,
     structure,
     theme,
-    wrapIcon
+    wrapIcon,
+    extra
   };
 
   return {

--- a/draft-js-static-toolbar-plugin/src/index.js
+++ b/draft-js-static-toolbar-plugin/src/index.js
@@ -23,13 +23,15 @@ export default (config = {}) => {
       ItalicButton,
       UnderlineButton,
       CodeButton,
-    ]
+    ],
+    wrapIcon
   } = config;
 
   const toolbarProps = {
     store,
     structure,
     theme,
+    wrapIcon
   };
 
   return {


### PR DESCRIPTION
## Checklist

- [ ] Fix any eslint errors that occur
- [ ] Update change-log for every plugin you touch
- [ ] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

Add support for changing toolbar button icon including link button icon.
Therefore, when I want to add a className to icon or wrap a `span` element for icon, I don't need to copy it and write my owner button; when I want to change link button icon, I don't need override the whole anchor plugin.

## Implementation

Add a `wrapIcon` config for toobarl and link button.

## Demo
```javascript
const toolbarPlugin = createToolbarPlugin({
  structure: [
    BoldButton,
    ItalicButton,
    UnderlineButton,
    CodeButton,
    Separator,
    HeadlinesButton,
    UnorderedListButton,
    OrderedListButton,
    BlockquoteButton,
    CodeBlockButton
  ],
  wrapIcon: (icon) => <span className="my-class">{icon}</span>
});
const linkPlugin = createLinkPlugin({
  theme: linkStyles,
  placeholder: 'http://…',
  wrapIcon: (defaultIcon) => (
    <span className="my-class">{defaultIcon}</span>
  )
});
```

  
  