### PR TITLE
Make undo buttons work inside PureComponent

### DIFF
--- a/draft-js-undo-plugin/src/ListenToSelection/index.js
+++ b/draft-js-undo-plugin/src/ListenToSelection/index.js
@@ -1,0 +1,35 @@
+import { PureComponent } from 'react';
+
+export default class extends PureComponent {
+  componentWillMount() {
+    this.props.store.subscribeToItem('selection', this.onSelectionChanged);
+  }
+
+  componentWillUnmount() {
+    this.props.store.unsubscribeFromItem('selection', this.onSelectionChanged);
+  }
+
+  onSelectionChanged = () => {
+    this.forceUpdate();
+  }
+
+  getEditorState() {
+    const { store } = this.props;
+    if (!store) {
+      return null;
+    }
+    const getEditorState = store.getItem('getEditorState');
+    if (!getEditorState) {
+      return null;
+    }
+    return getEditorState();
+  }
+
+  setEditorState(editorState) {
+    const { store } = this.props;
+    if (!store) {
+      return;
+    }
+    store.getItem('setEditorState')(editorState);
+  }
+}

--- a/draft-js-undo-plugin/src/RedoButton/__test__/index.js
+++ b/draft-js-undo-plugin/src/RedoButton/__test__/index.js
@@ -6,16 +6,17 @@ import chai, { expect } from 'chai';
 import sinonChai from 'sinon-chai';
 import { EditorState, Modifier } from 'draft-js';
 import Redo from '../index';
+import createStore from '../../utils/createStore';
 
 chai.use(sinonChai);
 
 describe('RedoButton', () => {
   const onChange = () => sinon.spy();
   let editorState;
-  let store = {
+  let store = createStore({
     getEditorState: () => editorState,
     setEditorState: onChange,
-  };
+  });
 
   beforeEach(() => {
     editorState = EditorState.createEmpty();
@@ -77,10 +78,10 @@ describe('RedoButton', () => {
     );
     const newEditorState = EditorState.push(editorState, newContent, 'insert-text');
     const undoEditorState = EditorState.undo(newEditorState);
-    store = {
+    store = createStore({
       getEditorState: () => undoEditorState,
       setEditorState: onChange,
-    };
+    });
     const result = shallow(
       <Redo
         store={store}

--- a/draft-js-undo-plugin/src/RedoButton/index.js
+++ b/draft-js-undo-plugin/src/RedoButton/index.js
@@ -1,9 +1,11 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { EditorState } from 'draft-js';
 import unionClassNames from 'union-class-names';
 
-class RedoButton extends Component {
+import ListenToSelection from '../ListenToSelection';
+
+class RedoButton extends ListenToSelection {
 
   static propTypes = {
     children: PropTypes.node.isRequired,
@@ -11,18 +13,18 @@ class RedoButton extends Component {
   };
 
   onClick = () => {
-    this.props.store.setEditorState(EditorState.redo(this.props.store.getEditorState()));
+    this.setEditorState(EditorState.redo(this.getEditorState()));
   };
 
   render() {
     const { theme = {}, children, className } = this.props;
     const combinedClassName = unionClassNames(theme.redo, className);
+    const editorState = this.getEditorState();
+
     return (
       <button
         disabled={
-          !this.props.store ||
-          !this.props.store.getEditorState ||
-          this.props.store.getEditorState().getRedoStack().isEmpty()
+          !editorState || editorState.getRedoStack().isEmpty()
         }
         type="button"
         onClick={this.onClick}

--- a/draft-js-undo-plugin/src/UndoButton/__test__/index.js
+++ b/draft-js-undo-plugin/src/UndoButton/__test__/index.js
@@ -6,16 +6,17 @@ import chai, { expect } from 'chai';
 import sinonChai from 'sinon-chai';
 import { EditorState, Modifier } from 'draft-js';
 import Undo from '../index';
+import createStore from '../../utils/createStore';
 
 chai.use(sinonChai);
 
 describe('UndoButton', () => {
   const onChange = () => sinon.spy();
   let editorState;
-  let store = {
+  let store = createStore({
     getEditorState: () => editorState,
     setEditorState: onChange,
-  };
+  });
 
   beforeEach(() => {
     editorState = EditorState.createEmpty();
@@ -76,10 +77,10 @@ describe('UndoButton', () => {
       'hello'
     );
     const newEditorState = EditorState.push(editorState, newContent, 'insert-text');
-    store = {
+    store = createStore({
       getEditorState: () => newEditorState,
       setEditorState: onChange,
-    };
+    });
     const result = shallow(
       <Undo
         store={store}

--- a/draft-js-undo-plugin/src/UndoButton/index.js
+++ b/draft-js-undo-plugin/src/UndoButton/index.js
@@ -1,9 +1,11 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { EditorState } from 'draft-js';
 import unionClassNames from 'union-class-names';
 
-class UndoButton extends Component {
+import ListenToSelection from '../ListenToSelection';
+
+class UndoButton extends ListenToSelection {
 
   static propTypes = {
     children: PropTypes.node.isRequired,
@@ -11,18 +13,18 @@ class UndoButton extends Component {
   };
 
   onClick = () => {
-    this.props.store.setEditorState(EditorState.undo(this.props.store.getEditorState()));
+    this.setEditorState(EditorState.undo(this.getEditorState()));
   };
 
   render() {
     const { theme = {}, children, className } = this.props;
     const combinedClassName = unionClassNames(theme.undo, className);
+    const editorState = this.getEditorState();
+
     return (
       <button
         disabled={
-          !this.props.store ||
-          !this.props.store.getEditorState ||
-          this.props.store.getEditorState().getUndoStack().isEmpty()
+          !editorState || editorState.getUndoStack().isEmpty()
         }
         type="button"
         onClick={this.onClick}

--- a/draft-js-undo-plugin/src/index.js
+++ b/draft-js-undo-plugin/src/index.js
@@ -1,4 +1,5 @@
 import decorateComponentWithProps from 'decorate-component-with-props';
+import createStore from './utils/createStore';
 import UndoButton from './UndoButton';
 import RedoButton from './RedoButton';
 import styles from './styles.css';
@@ -11,10 +12,7 @@ const defaultTheme = {
 export default (config = {}) => {
   const undoContent = config.undoContent ? config.undoContent : '↺';
   const redoContent = config.redoContent ? config.redoContent : '↻';
-  const store = {
-    getEditorState: undefined,
-    setEditorState: undefined,
-  };
+  const store = createStore();
 
   // Styles are overwritten instead of merged as merging causes a lot of confusion.
   //
@@ -27,8 +25,12 @@ export default (config = {}) => {
     UndoButton: decorateComponentWithProps(UndoButton, { theme, store, children: undoContent }),
     RedoButton: decorateComponentWithProps(RedoButton, { theme, store, children: redoContent }),
     initialize: ({ getEditorState, setEditorState }) => {
-      store.getEditorState = getEditorState;
-      store.setEditorState = setEditorState;
+      store.updateItem('getEditorState', getEditorState);
+      store.updateItem('setEditorState', setEditorState);
+    },
+    onChange: (editorState) => {
+      store.updateItem('selection', editorState.getSelection());
+      return editorState;
     },
   };
 };

--- a/draft-js-undo-plugin/src/utils/createStore.js
+++ b/draft-js-undo-plugin/src/utils/createStore.js
@@ -1,0 +1,34 @@
+const createStore = (initialState) => {
+  let state = initialState || {};
+  const listeners = {};
+
+  const subscribeToItem = (key, callback) => {
+    listeners[key] = listeners[key] || [];
+    listeners[key].push(callback);
+  };
+
+  const unsubscribeFromItem = (key, callback) => {
+    listeners[key] = listeners[key].filter((listener) => listener !== callback);
+  };
+
+  const updateItem = (key, item) => {
+    state = {
+      ...state,
+      [key]: item,
+    };
+    if (listeners[key]) {
+      listeners[key].forEach((listener) => listener(state[key]));
+    }
+  };
+
+  const getItem = (key) => state[key];
+
+  return {
+    subscribeToItem,
+    unsubscribeFromItem,
+    updateItem,
+    getItem,
+  };
+};
+
+export default createStore;


### PR DESCRIPTION
Please check out Contributing Guidelines. By following this template you help us to review your code.
https://github.com/draft-js-plugins/draft-js-plugins/blob/master/CONTRIBUTING.md

## Checklist

- [ ] Fix any eslint errors that occur
- [ ] Update change-log for every plugin you touch
- [ ] Add/Update tests if you add/change new functionality
- [ ] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

Undo buttons cannot work inside `PureComponent`.

## Implementation

Listen to selection changes in buttons And make it into `PureComponent`.

## Demo
