### PR TITLE
Inline toolbar positioning fix

### DIFF
--- a/draft-js-inline-toolbar-plugin/CHANGELOG.md
+++ b/draft-js-inline-toolbar-plugin/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+## 2.0.1 - 2018-01-14
+
+- fixed positioning of the toolbar within a limited space;
+- fixed spontaneous change of toolbar sizes;

--- a/draft-js-inline-toolbar-plugin/CHANGELOG.md
+++ b/draft-js-inline-toolbar-plugin/CHANGELOG.md
@@ -7,3 +7,4 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - fixed positioning of the toolbar within a limited space;
 - fixed spontaneous change of toolbar sizes;
+- added external prop `toolbarMargin`;

--- a/draft-js-inline-toolbar-plugin/CHANGELOG.md
+++ b/draft-js-inline-toolbar-plugin/CHANGELOG.md
@@ -7,4 +7,3 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - fixed positioning of the toolbar within a limited space;
 - fixed spontaneous change of toolbar sizes;
-- added external prop `toolbarMargin`;

--- a/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
+++ b/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
@@ -81,17 +81,10 @@ export default class Toolbar extends React.Component {
       };
       // boundings of the selected text
       const selectionRect = getVisibleSelectionRect(window);
-      if (!selectionRect) return;
+      const selection = this.props.store.getItem('getEditorState')().getSelection();
+      if (!selectionRect || selection.isCollapsed()) return;
 
       const relativeParent = getRelativeParent(this.toolbar.parentElement);
-      if (relativeParent) {
-        // avoid false
-        const fontSize = window.getComputedStyle(relativeParent, null).getPropertyValue('font-size');
-        // exit if no selection was made
-        if (selectionRect.left === selectionRect.right && selectionRect.height === parseFloat(fontSize)) {
-          return;
-        }
-      }
       const relativeRect = (relativeParent || document.body).getBoundingClientRect();
 
       // if parent block width is wider than the toolbar, we must forcibly set its

--- a/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
+++ b/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
@@ -73,10 +73,6 @@ export default class Toolbar extends React.Component {
 
       if (typeof this.state.width !== 'number') {
         this.setState({ width: this.toolbar.offsetWidth });
-      } else {
-        // toolbar width must forcibly overwritten to prevent unexpected geometry
-        // changes
-        this.toolbar.style.width = `${this.state.width}px`;
       }
 
       const metrics = {
@@ -176,6 +172,9 @@ export default class Toolbar extends React.Component {
       style.visibility = 'visible';
       style.transform = 'translate(-50%) scale(1)';
       style.transition = 'transform 0.15s cubic-bezier(.3,1.2,.2,1)';
+      // toolbar width must forcibly overwritten to prevent unexpected geometry
+      // changes
+      style.width = this.state.width;
     } else {
       style.transform = 'translate(-50%) scale(0)';
       style.visibility = 'hidden';

--- a/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
+++ b/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
@@ -160,8 +160,6 @@ export default class Toolbar extends React.Component {
       }
 
       if (typeof metrics.shift === 'string') {
-        this.toolbar.classList.add(this.state.pointerClassName);
-
         if (metrics.shift === 'left') {
           metrics.shiftValue = fromBeginningToMiddle - this.props.toolbarMargin;
         } else {
@@ -224,7 +222,7 @@ export default class Toolbar extends React.Component {
 
     return (
       <div
-        className={theme.toolbarStyles.toolbar}
+        className={[theme.toolbarStyles.toolbar, pointerClassName].join(' ')}
         style={this.getStyle()}
         ref={this.handleToolbarRef}
       >

--- a/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
+++ b/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
@@ -75,16 +75,13 @@ export default class Toolbar extends React.Component {
         this.setState({ width: this.toolbar.offsetWidth });
       }
 
-      const metrics = {
-        rule: 'left',
-        ruleValue: 0,
-        shift: null,
-        shiftValue: 0
-      };
+      let alignment = null;
+      let horizontalOffset = 0;
+
       // boundings of the selected text
       const selectionRect = getVisibleSelectionRect(window);
       const selection = this.props.store.getItem('getEditorState')().getSelection();
-      if (!selectionRect || selection.isCollapsed()) return;
+      if (selection.isCollapsed()) return;
 
       const relativeParent = getRelativeParent(this.toolbar.parentElement);
       const relativeRect = (relativeParent || document.body).getBoundingClientRect();
@@ -116,8 +113,8 @@ export default class Toolbar extends React.Component {
         const leftShift = relativeParent
           ? relativeRect.left
           : 0;
-        metrics.ruleValue = (toolbarHalfWidth - leftShift) + leftToolbarMargin;
-        metrics.shift = 'left';
+        horizontalOffset = (toolbarHalfWidth - leftShift) + leftToolbarMargin;
+        alignment = 'left';
       } else if (beforeWindowEnd < (toolbarHalfWidth + (2 * rightToolbarMargin))) {
         // the same, but relative to the parent end
         // +-----------------------------------------------+
@@ -133,24 +130,23 @@ export default class Toolbar extends React.Component {
         const rightShift = relativeParent
           ? windowWidth - relativeRect.right
           : 0;
-        metrics.ruleValue = (-toolbarHalfWidth - rightShift) + rightToolbarMargin;
-        metrics.rule = 'right';
-        metrics.shift = 'right';
+        horizontalOffset = (-toolbarHalfWidth - rightShift) + rightToolbarMargin;
+        alignment = 'right';
       } else {
         // selection somewhere in the middle within the parent and there is a
         // free place for toolbar
-        metrics.ruleValue = (selectionRect.left - relativeRect.left)
+        horizontalOffset = (selectionRect.left - relativeRect.left)
           + (((selectionRect.width / 2) + bodyMargin) - leftToolbarMargin);
       }
 
       const position = {
         top: (selectionRect.top - relativeRect.top) - this.toolbar.offsetHeight - 10,
-        [metrics.rule]: metrics.ruleValue
+        [alignment || 'left']: horizontalOffset
       };
       this.setState({
         position,
         pointerCSS: this.calculatePointerPosition(
-          metrics.shift,
+          alignment,
           selectionRect,
           fromBeginningToMiddle,
           windowWidth
@@ -185,17 +181,17 @@ export default class Toolbar extends React.Component {
 
   /**
    * calculate toolbar pointer (css arrow) position
-   * @param shift
+   * @param alignment
    * @param selectionRect
    * @param fromBeginningToMiddle
    * @param windowWidth
    * @returns {string|number}
    */
   calculatePointerPosition = (
-    shift, selectionRect, fromBeginningToMiddle, windowWidth
+    alignment, selectionRect, fromBeginningToMiddle, windowWidth
   ) => {
-    if (typeof shift === 'string') {
-      if (shift === 'left') {
+    if (typeof alignment === 'string') {
+      if (alignment === 'left') {
         return `{ left: ${fromBeginningToMiddle - (2 * getMargin(this.toolbar))}px; }`;
       }
 

--- a/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
+++ b/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/no-array-index-key */
 import React from 'react';
-import { getVisibleSelectionRect } from 'draft-js';
+import { getVisibleSelectionRect, genKey } from 'draft-js';
 
 const getRelativeParent = (element) => {
   if (!element) {
@@ -16,21 +16,37 @@ const getRelativeParent = (element) => {
 };
 
 export default class Toolbar extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isVisible: false,
+      position: undefined,
 
-  state = {
-    isVisible: false,
-    position: undefined,
+      /**
+       * If this is set, the toolbar will render this instead of the regular
+       * structure and will also be shown when the editor loses focus.
+       * @type {Component}
+       */
+      overrideContent: undefined,
+      /**
+       * We should use different classNames for toolbars within different Editor
+       * instances
+       */
+      nonce: null,
+      /**
+       * We are holding default toolbar width to prevent geometry changing, that
+       * happens very often
+       */
+      width: null
+    };
 
-    /**
-     * If this is set, the toolbar will render this instead of the regular
-     * structure and will also be shown when the editor loses focus.
-     * @type {Component}
-     */
-    overrideContent: undefined
+    // we need to flush toolbar styles on each appearance (especially its width)
+    this.toolbar = null;
   }
 
   componentWillMount() {
     this.props.store.subscribeToItem('selection', this.onSelectionChanged);
+    this.setState({ nonce: genKey() });
   }
 
   componentWillUnmount() {
@@ -52,16 +68,89 @@ export default class Toolbar extends React.Component {
     // when focusing editor with already present selection
     setTimeout(() => {
       if (!this.toolbar) return;
-      const relativeParent = getRelativeParent(this.toolbar.parentElement);
-      const toolbarHeight = this.toolbar.clientHeight;
-      const relativeRect = (relativeParent || document.body).getBoundingClientRect();
-      const selectionRect = getVisibleSelectionRect(window);
 
+      if (typeof this.state.width !== 'number') {
+        this.setState({ width: this.toolbar.offsetWidth });
+      }
+
+      const metrics = {
+        rule: 'left',
+        ruleValue: 0,
+        shift: null,
+        shiftValue: 0
+      };
+
+      const selectionRect = getVisibleSelectionRect(window);
       if (!selectionRect) return;
 
+      const relativeParent = getRelativeParent(this.toolbar.parentElement);
+      const relativeRect = (relativeParent || document.body).getBoundingClientRect();
+
+      // if parentWidth is wider than the toolbar, we must forcibly set its
+      // height to prevent unexpected geometry changes
+      if (relativeRect.width > this.toolbar.offsetWidth) {
+        this.toolbar.style.width = `${this.state.width}px`;
+      }
+
+      const toolbarHalfWidth = this.toolbar.offsetWidth / 2;
+
+      const fromBeginningToMiddle = (selectionRect.left + (selectionRect.width / 2));
+      const fromParentBeginning = fromBeginningToMiddle - relativeRect.left;
+      const beforeParentEnd = relativeRect.right - fromBeginningToMiddle;
+
+      // the selection is closer to parent beginning than half of the toolbar
+      if (fromParentBeginning < toolbarHalfWidth) {
+        metrics.ruleValue = toolbarHalfWidth;
+        metrics.shift = 'left';
+      } else if (beforeParentEnd < toolbarHalfWidth) {
+        // the same, but relative to the parent end
+        metrics.ruleValue = -toolbarHalfWidth;
+        metrics.rule = 'right';
+        metrics.shift = 'right';
+      } else {
+        // selection somewhere in the middle within the parent and there is a
+        // free place for toolbar
+        metrics.ruleValue = (selectionRect.left - relativeRect.left)
+          + (selectionRect.width / 2);
+      }
+
+      const pointerClassName = 'draft-js-inline-toolbar-pointer';
+      const styleId = 'draft-js-inline-toolbar-pointer-pseudo';
+
+      if (this.toolbar.classList.contains(pointerClassName)) {
+        this.toolbar.classList.remove(pointerClassName);
+      }
+      // We are recreating style element on every toolbar appearance. It is
+      // better for us to use individual style element rather than join new
+      // styles to some of the existent elements, because we can easely remove
+      // it next time
+      if (document.getElementById(`${styleId}-${this.state.nonce}`)) {
+        document.head.removeChild(
+          document.getElementById(`${styleId}-${this.state.nonce}`)
+        );
+      }
+
+      if (typeof metrics.shift === 'string') {
+        const styleEl = document.createElement('style');
+        styleEl.setAttribute('id', `${styleId}-${this.state.nonce}`);
+        document.head.appendChild(styleEl);
+        this.toolbar.classList.add(pointerClassName);
+
+        if (metrics.shift === 'left') {
+          metrics.shiftValue = toolbarHalfWidth - metrics.ruleValue -
+            fromParentBeginning;
+        } else {
+          metrics.shiftValue = this.toolbar.offsetWidth -
+            (relativeRect.right - (selectionRect.right + (selectionRect.width / 2)));
+        }
+
+        styleEl.sheet.insertRule(`.${pointerClassName}::after { left: ${metrics.shiftValue}px}`, 0);
+        styleEl.sheet.insertRule(`.${pointerClassName}::before { left: ${metrics.shiftValue}px}`, 0);
+      }
+
       const position = {
-        top: (selectionRect.top - relativeRect.top) - toolbarHeight,
-        left: (selectionRect.left - relativeRect.left) + (selectionRect.width / 2),
+        top: (selectionRect.top - relativeRect.top) - this.toolbar.offsetHeight - 10,
+        [metrics.rule]: metrics.ruleValue
       };
       this.setState({ position });
     });

--- a/draft-js-inline-toolbar-plugin/src/toolbarStyles.css
+++ b/draft-js-inline-toolbar-plugin/src/toolbarStyles.css
@@ -1,4 +1,5 @@
 .toolbar {
+  margin: 0 5px;
   transform: translate(-50%) scale(0);
   position: absolute;
   border: 1px solid #ddd;

--- a/draft-js-inline-toolbar-plugin/src/toolbarStyles.css
+++ b/draft-js-inline-toolbar-plugin/src/toolbarStyles.css
@@ -1,5 +1,4 @@
 .toolbar {
-  left: 50%;
   transform: translate(-50%) scale(0);
   position: absolute;
   border: 1px solid #ddd;


### PR DESCRIPTION
## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [ ] Add/Update tests if you add/change new functionality
- [ ] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem
Hi.
This PR tries to fix two things: outputting the toolbar beyond the relative parent (editor) and changing the size of the toolbar in some cases. These bugs will be demonstrated in demos.

## Implementation

Fix introduce new logic that not allows toolbar to go beyond the editor block. To make it looks good we have to make pointer positioning floating. The way I used to do this is an external style elements for each toolbar (there may be several editors on the screen), because pointers are working via `before`, `after` preudo classes.

## Demo
Here how it was before:
![before-1](https://user-images.githubusercontent.com/11130487/39175525-c91a9b8e-47d4-11e8-8c56-051b2b08a30f.gif)
and on a small screens:
![before-2](https://user-images.githubusercontent.com/11130487/39175545-d6b230f4-47d4-11e8-95bb-c52e96d698ea.gif)

and after this implementation:
![after-1](https://user-images.githubusercontent.com/11130487/39175563-e18e3748-47d4-11e8-8a4b-eecdabd6c25b.gif)
![after-2](https://user-images.githubusercontent.com/11130487/39175576-e7786bb0-47d4-11e8-9707-81cbf02f5df9.gif)

