### PR TITLE
[mention-plugin] add 'ignoreEditorChange' flag to avoid incorrectly setting editor st…

### DIFF
--- a/draft-js-mention-plugin/src/MentionSuggestions/index.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/index.js
@@ -44,6 +44,7 @@ export class MentionSuggestions extends Component {
     focusedOptionIndex: 0,
   };
 
+
   componentWillMount() {
     this.key = genKey();
     this.props.callbacks.onChange = this.onEditorStateChange;
@@ -97,6 +98,9 @@ export class MentionSuggestions extends Component {
   };
 
   onEditorStateChange = (editorState) => {
+    if (this.ignoreEditorChange) {
+      return editorState;
+    }
     const searches = this.props.store.getAllSearches();
 
     // if no search portal is active there is no need to show the popover
@@ -251,7 +255,11 @@ export class MentionSuggestions extends Component {
       this.props.mentionTrigger,
       this.props.entityMutability,
     );
+    this.setIgnoreEditorChange(true);
+    // async callback, ignore changes until it's finished to not overwrite
+    // current state
     this.props.store.setEditorState(newEditorState);
+    this.setIgnoreEditorChange(false);
   };
 
   onMentionFocus = (index) => {
@@ -264,6 +272,12 @@ export class MentionSuggestions extends Component {
     // to force a re-render of the outer component to change the aria props
     this.props.store.setEditorState(this.props.store.getEditorState());
   };
+
+  setIgnoreEditorChange(ignore) {
+    this.ignoreEditorChange = ignore;
+  }
+
+  ignoreEditorChange = false;
 
   commitSelection = () => {
     if (!this.props.store.getIsOpened()) {


### PR DESCRIPTION
…ate when selecting mention

Please check out Contributing Guidelines. By following this template you help us to review your code.
https://github.com/draft-js-plugins/draft-js-plugins/blob/master/CONTRIBUTING.md

## Checklist

- [x] Fix any eslint errors that occur
- [ ] Update change-log for every plugin you touch
- [ ] Add/Update tests if you add/change new functionality
- [ ] Add/Update docs if you add/change functionality
- [ ] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

I am quite unsure how to describe this problem because I noticed it in very specific scenarios and it took me some time to reliably reproduce it.

I am trying to capture the current state of `MentionSuggestions` popover, to see whether it is currently opened or closed. For this, I'm using `onOpen` and `onClose` callbacks to set the state to my parent component. In my application code I use this state to control keyboard shortcuts.

This seems unreliable because for some reason there is a certain combination of mention text that calls callbacks `onClose` and then `onOpen` again and triggers `onSearchChange` callback unnecessarily. This in turn filters down suggestion, it's this part of code in `draft-js-mention-plugin/src/MentionSuggestions/index.js`: 

```
    } else if (nextProps.suggestions.size > 0 && !nextProps.suggestions.equals(this.props.suggestions) && !this.state.isActive) {
      this.openDropdown();
    }
```

I think the best way to demonstrate is on this gif:

![](https://dr5mo5s7lqrtc.cloudfront.net/items/1c2S2k1v2D0D0v2G1M3w/Screen%20Recording%202018-01-26%20at%2009.51%20odp..gif?X-CloudApp-Visitor-Id=2948220&v=d089541a)

Steps to reproduce:

1. Go to sandbox https://codesandbox.io/s/mj7xzp8p2j
2. Trigger mention with "@"
3. Select first suggestion "Tester 1"
4. Move cursor before inserted mention, add space, move cursor back to beginning of editor
5. Trigger mention and select suggestion "User"

`Popover opened ?` is whether the popover is currently opened or not, you can see in the end that it is incorrect. The `No. of current suggestions` are the filtered suggestions passed down as props to `MentionSuggestions` component (this is incorrectly filtered down to 1). `Search value` is the value passed to `onSearchChange` callback. 

In the end of the gif, you can see that for some reason the part of the text from _User_ suggestion is passed to it as _ser_. I am using keyboard to move between suggestion and confirming it by hitting ENTER.

This only happens with some of the suggestions. For example if the second mention that I'd insert was the one named "Tester 2", this would not happen.

__After some further inspecting...__

It turns out this is caused by `Portal` component wrapping `MentionSuggestions`component. This "portal" component comes from `react-portal` library. I hear you, you can't be responsible for other people's code from other libraries. But I still find it quite interesting and since this plugin does not handle the suggestion pop up in containers with overflow (I use them in my application), I had to implement this somehow.

So... after removing the portal component, it's behaving a bit better:

![](https://dr5mo5s7lqrtc.cloudfront.net/items/401w3l352p3R1Z1J1i09/Screen%20Recording%202018-01-26%20at%2010.08%20odp..gif?X-CloudApp-Visitor-Id=2948220&v=8f358553)

You can check it out here in this sandbox: https://codesandbox.io/s/lykwlzqz5z

However this still does not play nice with my application code because as you can see the popover state is correctly assumed but `onSearchChange` callback is still called with the value that is part of the text in selected suggestion. And suggestions are still filtered to single item thanks to this even though I implemented `onAddMention` callback that resets the suggestions.

So after a lot of time (seriously around 1.5 day) I think I found the culprit. It's in `onMentionSelect` method where this is called:

```
    this.props.store.setEditorState(newEditorState);
```

This kinda looks like it's async, so my reasoning is that the editor state is updated somewhere in between thus causing `onOpen` callback to be called.

## Implementation

I added simple flag `ignoreEditorChange` that is set to true before the state of the editor is updated via `this.props.store.setEditorState`. This in turn triggers `onEditorStateChange` method. If the flag is `true` then current editor state is return instead of continuing on and calling `onSearchChange` method.

## Demo

See the GIFs above and codesandbox playgrounds. You can download the sandbox, it's packaged as app so you just `npm install` & `npm run`, it's probably easier to debug this way.

## Note on versions

I do realize I'm using older react and draft-js. I tried first matching the stuff from my application code, later I forked the codesandbox playground and updated all of the dependencies. It does not solve my problem.