### PR TITLE
draft-js-mention-plugins: Only handle up/down arrow keys when mentionSuggestions is active

### DIFF
--- a/draft-js-mention-plugin/src/MentionSuggestions/Entry/defaultEntryComponent.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/Entry/defaultEntryComponent.js
@@ -6,6 +6,7 @@ const defaultEntryComponent = (props) => {
     mention,
     theme,
     searchValue, // eslint-disable-line no-unused-vars
+    isFocused,
     ...parentProps
   } = props;
 

--- a/draft-js-mention-plugin/src/MentionSuggestions/index.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/index.js
@@ -49,14 +49,6 @@ export class MentionSuggestions extends Component {
     this.props.callbacks.onChange = this.onEditorStateChange;
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.suggestions.size === 0 && this.state.isActive) {
-      this.closeDropdown();
-    } else if (nextProps.suggestions.size > 0 && !nextProps.suggestions.equals(this.props.suggestions) && !this.state.isActive) {
-      this.openDropdown();
-    }
-  }
-
   componentDidUpdate = (prevProps, prevState) => {
     if (this.popover) {
       // In case the list shrinks there should be still an option focused.
@@ -200,9 +192,11 @@ export class MentionSuggestions extends Component {
   };
 
   onDownArrow = (keyboardEvent) => {
-    keyboardEvent.preventDefault();
-    const newIndex = this.state.focusedOptionIndex + 1;
-    this.onMentionFocus(newIndex >= this.props.suggestions.size ? 0 : newIndex);
+    if (this.state.isActive) {
+      keyboardEvent.preventDefault();
+      const newIndex = this.state.focusedOptionIndex + 1;
+      this.onMentionFocus(newIndex >= this.props.suggestions.size ? 0 : newIndex);
+    }
   };
 
   onTab = (keyboardEvent) => {
@@ -211,10 +205,12 @@ export class MentionSuggestions extends Component {
   };
 
   onUpArrow = (keyboardEvent) => {
-    keyboardEvent.preventDefault();
-    if (this.props.suggestions.size > 0) {
-      const newIndex = this.state.focusedOptionIndex - 1;
-      this.onMentionFocus(newIndex < 0 ? this.props.suggestions.size - 1 : newIndex);
+    if (this.state.isActive) {
+      keyboardEvent.preventDefault();
+      if (this.props.suggestions.size > 0) {
+        const newIndex = this.state.focusedOptionIndex - 1;
+        this.onMentionFocus(newIndex < 0 ? this.props.suggestions.size - 1 : newIndex);
+      }
     }
   };
 


### PR DESCRIPTION
Closes https://github.com/draft-js-plugins/draft-js-plugins/issues/1026

This also excludes `isFocused` from `defaultEntryComponent` because otherwise it throws this React error:

```
Warning: React does not recognize the `isFocused` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `isfocused` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
```