### PR TITLE
Fix side toolbar positioning when there's a positioned parent.

### DIFF
--- a/draft-js-side-toolbar-plugin/src/components/Toolbar/index.js
+++ b/draft-js-side-toolbar-plugin/src/components/Toolbar/index.js
@@ -36,13 +36,19 @@ export default class Toolbar extends React.Component {
     // Note: need to wait on tick to make sure the DOM node has been create by Draft.js
     setTimeout(() => {
       const node = document.querySelectorAll(`[data-offset-key="${offsetKey}"]`)[0];
-      const top = node.getBoundingClientRect().top;
-      const editor = this.props.store.getItem('getEditorRef')().refs.editor;
-      const scrollY = window.scrollY == null ? window.pageYOffset : window.scrollY;
+
+      // The editor root should be two levels above the node from
+      // `getEditorRef`. In case this changes in the future, we
+      // attempt to find the node dynamically by traversing upwards.
+      let editorRoot = this.props.store.getItem('getEditorRef')().refs.editor;
+      while (editorRoot.className.indexOf('DraftEditor-root') === -1) {
+        editorRoot = editorRoot.parentNode;
+      }
+
       this.setState({
         position: {
-          top: (top + scrollY),
-          left: editor.getBoundingClientRect().left - 80,
+          top: node.offsetTop + editorRoot.offsetTop,
+          left: editorRoot.offsetLeft - 80,
           transform: 'scale(1)',
           transition: 'transform 0.15s cubic-bezier(.3,1.2,.2,1)',
         },


### PR DESCRIPTION
## Checklist

- [x] Fix any eslint errors that occur
- [ ] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

This PR improves the positioning of the side toolbar. The current implementation didn't work when there's a positioned parent (see #976).

## Implementation

The class `DraftEditor-root` is applied to the very root node of the editor by draft.js itself – this class allows to find that node. The side toolbar is a sibling of the editor root node, therefore we can position the toolbar by considering the offset of the editor node within it's next positioned parent. Note that if there's no explicitly positioned parent, then `body` will be taken into account (this is the case in the docs).

Tested in Chrome, Firefox, Safari and IE11.