### PR TITLE
Omit blockStyleFn prop from list of elementProps in image plugin

### DIFF
--- a/draft-js-image-plugin/CHANGELOG.md
+++ b/draft-js-image-plugin/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## To Be Released
+- add blockStyleFn to omitted prop list to support draft-js 0.10.5
+
 ## 2.0.0-rc9 - 2016-11-07
 - fix addImage method (place cursor after inserted image)
 - fixed critical bug in combination with focus plugin

--- a/draft-js-image-plugin/src/Image/index.js
+++ b/draft-js-image-plugin/src/Image/index.js
@@ -20,6 +20,7 @@ export default class Image extends Component {
       selection, // eslint-disable-line no-unused-vars
       tree, // eslint-disable-line no-unused-vars
       contentState,
+      blockStyleFn,
       ...elementProps
     } = otherProps;
     const combinedClassName = unionClassNames(theme.image, className);


### PR DESCRIPTION
## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

https://github.com/draft-js-plugins/draft-js-plugins/issues/1032

When using draft-js version 0.10.5 an extra prop `blockStyleFn` is passed and needs to be omitted like the others otherwise it is assigned as an elementProp and causes the error
`Unknown prop 'blockStyleFn' on <img> tag`

## Implementation
Solution is to add this `blockStyleFn` prop to the omitted props list so it is not assigned as an elementProp
