### PR TITLE
fixed refs for draft-js-resizeable-plugin and draft-js-side-toolbar-plugin

### DIFF
--- a/draft-js-resizeable-plugin/CHANGELOG.md
+++ b/draft-js-resizeable-plugin/CHANGELOG.md
@@ -5,4 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To Be Released
 
+### Fixed
+- update access method for editor [#1039](https://github.com/draft-js-plugins/draft-js-plugins/issues/1039)
+
 ### Released the first working of DraftJS Resizeable Plugin

--- a/draft-js-resizeable-plugin/src/createDecorator.js
+++ b/draft-js-resizeable-plugin/src/createDecorator.js
@@ -88,7 +88,7 @@ export default ({ config, store }) => (WrappedComponent) => class BlockResizeabl
     const doDrag = (dragEvent) => {
       let width = (startWidth + dragEvent.clientX) - startX;
       let height = (startHeight + dragEvent.clientY) - startY;
-      const block = store.getEditorRef().refs.editor;
+      const block = store.getEditorRef().editor;
       width = block.clientWidth < width ? block.clientWidth : width;
       height = block.clientHeight < height ? block.clientHeight : height;
 

--- a/draft-js-side-toolbar-plugin/CHANGELOG.md
+++ b/draft-js-side-toolbar-plugin/CHANGELOG.md
@@ -5,4 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To Be Released
 
+### Fixed
+- update access method for editor [#1039](https://github.com/draft-js-plugins/draft-js-plugins/issues/1039)
+
 ### Released the first working of DraftJS Side Toolbar Plugin

--- a/draft-js-side-toolbar-plugin/src/components/Toolbar/index.js
+++ b/draft-js-side-toolbar-plugin/src/components/Toolbar/index.js
@@ -37,7 +37,7 @@ export default class Toolbar extends React.Component {
     setTimeout(() => {
       const node = document.querySelectorAll(`[data-offset-key="${offsetKey}"]`)[0];
       const top = node.getBoundingClientRect().top;
-      const editor = this.props.store.getItem('getEditorRef')().refs.editor;
+      const editor = this.props.store.getItem('getEditorRef')().editor;
       const scrollY = window.scrollY == null ? window.pageYOffset : window.scrollY;
       this.setState({
         position: {


### PR DESCRIPTION
## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

resolve #1021 #1023 #1024 #1039 

The ref attribute in draft-js-plugins-editor is no longer a string since [cf6653f196c0](https://github.com/draft-js-plugins/draft-js-plugins/commit/cf6653f196c0b23b191b03f968d30eace8e62d4b#diff-2180aea2d91b1762f617f66247191a4c)，so `.refs.editor` can not access the editor and cause subsequent errors.

## Implementation

Use `.editor` instead of `.refs.editor`.