### PR TITLE
Remove duplicate dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,6 @@
     "react-icons": "^2.2.3",
     "tlds": "^1.197.0",
     "to-style": "^1.3.3",
-    "union-class-names": "^1.0.0",
-    "webpack": "^2.2.1"
+    "union-class-names": "^1.0.0"
   }
 }


### PR DESCRIPTION
Fix https://github.com/draft-js-plugins/draft-js-plugins/issues/913

> @kornil 
https://github.com/draft-js-plugins/draft-js-plugins/commit/1f71cf2c68970118ae8489b2e89a3560c5691762 this commit over one year ago introduced webpack as normal dependency of the project (it was already there as devDep), I could not find a reason for it.
Is it needed? I tried to play around removing it and it does not look like it's doing anything at all, let me know if it can be removed. I'll gladly make a PR for it.

> @freedomlang 
 it is unneeded, PR is welcome!

## Checklist

- [ ] ~Fix any eslint errors that occur~
- [ ] ~Update change-log for every plugin you touch~
- [ ] ~Add/Update tests if you add/change new functionality~
- [ ] ~Add/Update docs if you add/change functionality~
- [x] Enable "Allow edits from maintainers" for this PR

Checks are disabled as nothing is affected, it's just a minor dependency cleanup.

## Use-case/Problem

Briefly describe the use-case/problem you're solving, reference the issue for this bug/feature here

## Implementation

There was an unneeded dependency (webpack is used as devDep, but was wrongly installed as normal dep too)

## Demo

Nothing changes, functionality is untouched.
