### PR TITLE
Mentions and Emoji: Use aria-selected for the focused listbox option

### DIFF
--- a/draft-js-emoji-plugin/CHANGELOG.md
+++ b/draft-js-emoji-plugin/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - render props.children instead, fixes editing behaviour
 
 ## To Be Released
+- Added `aria-selected="true"` for the suggestions listbox focused option.
 
 ### Fixed
 - Added type="button" to EmojiSelect button to prevent submitting forms, thanks to @alanwflood [for the pr](https://github.com/draft-js-plugins/draft-js-plugins/pull/829)

--- a/draft-js-emoji-plugin/src/components/EmojiSuggestions/Entry/index.js
+++ b/draft-js-emoji-plugin/src/components/EmojiSuggestions/Entry/index.js
@@ -36,8 +36,8 @@ export default class Entry extends Component {
   };
 
   render() {
-    const { theme = {}, imagePath, imageType, cacheBustParam, useNativeArt } = this.props;
-    const className = this.props.isFocused ? theme.emojiSuggestionsEntryFocused : theme.emojiSuggestionsEntry;
+    const { theme = {}, imagePath, imageType, cacheBustParam, useNativeArt, isFocused } = this.props;
+    const className = isFocused ? theme.emojiSuggestionsEntryFocused : theme.emojiSuggestionsEntry;
 
     let emojiDisplay = null;
     if (useNativeArt === true) {
@@ -63,6 +63,7 @@ export default class Entry extends Component {
         onMouseUp={this.onMouseUp}
         onMouseEnter={this.onMouseEnter}
         role="option"
+        aria-selected={isFocused ? 'true' : null}
       >
         {emojiDisplay}
         <span className={theme.emojiSuggestionsEntryText}>

--- a/draft-js-mention-plugin/CHANGELOG.md
+++ b/draft-js-mention-plugin/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Updated dependencies to support react 16
 
 ## To Be Released
+- Added `aria-selected="true"` for the suggestions listbox focused option.
 
 ### Added
 

--- a/draft-js-mention-plugin/CHANGELOG.md
+++ b/draft-js-mention-plugin/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.0.3
+- Added `aria-selected="true"` for the suggestions listbox focused option.
+
 ## 2.0.2
 (Much thanks to "dem" aka "Michael Deryugin" - https://github.com/dem)
 - fix suggestions dropdown position in case of line wrap
@@ -10,8 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed bug where a user typed not existing mention @xxx and cursor is not moved with up/down arrow key
 - Updated dependencies to support react 16
 
-## To Be Released
-- Added `aria-selected="true"` for the suggestions listbox focused option.
+## 2.0 alpha
 
 ### Added
 

--- a/draft-js-mention-plugin/src/MentionSuggestions/Entry/index.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/Entry/index.js
@@ -49,6 +49,7 @@ export default class Entry extends Component {
         onMouseUp={this.onMouseUp}
         onMouseEnter={this.onMouseEnter}
         role="option"
+        aria-selected={isFocused ? 'true' : null}
         theme={theme}
         mention={mention}
         isFocused={isFocused}


### PR DESCRIPTION
First time submitting a PR to your repo, please let me know if I'm doing anything wrong 🙂 

Seems to me there's no changelog for the Mentions plugin, so just thought to summarize the changelog entry here:
- Add `aria-selected="true"` for the Mentions and Emojis listbox focused option.

## Checklist

- [ x] Fix any eslint errors that occur
- [ ] Update change-log for every plugin you touch
- [ ] Add/Update tests if you add/change new functionality
- [ ] Add/Update docs if you add/change functionality
- [ x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

Based on the ARIA spec and the ARIA Authoring Practices, `aria-selected="true"` is a required ARIA state for the suggested option that is visually indicated as the currently selected option. For more details please refer to the related issue https://github.com/draft-js-plugins/draft-js-plugins/issues/1073

## Implementation

Just using the existing `isFocused` prop to render an `aria-selected="true"` attribute. Avoiding to render the attribute when is not focused.

To test, please check the Mentions or Emojis plugins and inspect the rendered DOM in your browser's console. When highlighting one of the options in the listbox (whether with mouse or keyboard) the highlighted option should get an `aria-selected="true"`.

Fixes https://github.com/draft-js-plugins/draft-js-plugins/issues/1073