### PR TITLE
Mentions and Emojis: Pass the aria-expanded values as boolean.

### DIFF
--- a/draft-js-emoji-plugin/src/components/EmojiSuggestions/index.js
+++ b/draft-js-emoji-plugin/src/components/EmojiSuggestions/index.js
@@ -237,7 +237,7 @@ export default class EmojiSuggestions extends Component {
     this.props.ariaProps.ariaActiveDescendantID = descendant;
     this.props.ariaProps.ariaOwneeID = `emojis-list-${this.key}`;
     this.props.ariaProps.ariaHasPopup = 'true';
-    this.props.ariaProps.ariaExpanded = 'true';
+    this.props.ariaProps.ariaExpanded = true;
     this.setState({
       isActive: true,
     });
@@ -255,7 +255,7 @@ export default class EmojiSuggestions extends Component {
     this.props.callbacks.onEscape = undefined;
     this.props.callbacks.handleReturn = undefined;
     this.props.ariaProps.ariaHasPopup = 'false';
-    this.props.ariaProps.ariaExpanded = 'false';
+    this.props.ariaProps.ariaExpanded = false;
     this.props.ariaProps.ariaActiveDescendantID = undefined;
     this.props.ariaProps.ariaOwneeID = undefined;
     this.setState({

--- a/draft-js-emoji-plugin/src/index.js
+++ b/draft-js-emoji-plugin/src/index.js
@@ -79,7 +79,7 @@ export default (config = {}) => {
 
   const ariaProps = {
     ariaHasPopup: 'false',
-    ariaExpanded: 'false',
+    ariaExpanded: false,
     ariaOwneeID: undefined,
     ariaActiveDescendantID: undefined,
   };

--- a/draft-js-mention-plugin/src/MentionSuggestions/index.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/index.js
@@ -290,7 +290,7 @@ export class MentionSuggestions extends Component {
     this.props.ariaProps.ariaActiveDescendantID = descendant;
     this.props.ariaProps.ariaOwneeID = `mentions-list-${this.key}`;
     this.props.ariaProps.ariaHasPopup = 'true';
-    this.props.ariaProps.ariaExpanded = 'true';
+    this.props.ariaProps.ariaExpanded = true;
     this.setState({
       isActive: true,
     });
@@ -308,7 +308,7 @@ export class MentionSuggestions extends Component {
     this.props.callbacks.onEscape = undefined;
     this.props.callbacks.handleReturn = undefined;
     this.props.ariaProps.ariaHasPopup = 'false';
-    this.props.ariaProps.ariaExpanded = 'false';
+    this.props.ariaProps.ariaExpanded = false;
     this.props.ariaProps.ariaActiveDescendantID = undefined;
     this.props.ariaProps.ariaOwneeID = undefined;
     this.setState({

--- a/draft-js-mention-plugin/src/index.js
+++ b/draft-js-mention-plugin/src/index.js
@@ -40,7 +40,7 @@ export default (config = {}) => {
 
   const ariaProps = {
     ariaHasPopup: 'false',
-    ariaExpanded: 'false',
+    ariaExpanded: false,
     ariaOwneeID: undefined,
     ariaActiveDescendantID: undefined,
   };

--- a/draft-js-plugins-editor/src/Editor/index.js
+++ b/draft-js-plugins-editor/src/Editor/index.js
@@ -285,8 +285,8 @@ class PluginEditor extends Component {
 
       if (accessibilityProps.ariaExpanded === undefined) {
         popupProps.ariaExpanded = props.ariaExpanded;
-      } else if (props.ariaExpanded === 'true') {
-        popupProps.ariaExpanded = 'true';
+      } else if (props.ariaExpanded === true) {
+        popupProps.ariaExpanded = true;
       }
 
       accessibilityProps = {


### PR DESCRIPTION
New to contributing to your repo, please let me know if I'm doing anything wrong 🙂

Seems to me there's no changelog for the Mentions plugin, so just thought to summarize the changelog entry here:

- Mentions and Emojis plugin: Pass the combobox `aria-expanded` values as boolean.

## Checklist

- [ x] Fix any eslint errors that occur
- [ ] Update change-log for every plugin you touch
- [ ] Add/Update tests if you add/change new functionality
- [ ] Add/Update docs if you add/change functionality
- [ x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

`draft.js` has changed something since version 0.10.2 and now uses a pattern to make sure `aria-expanded` is only set when there's a `role="combobox"`. That's perfectly fine, but the actual pattern is the following one:

`var ariaExpanded = ariaRole === 'combobox' ? !!this.props.ariaExpanded : null;`

Thus, if a value is passed as string, it's always converted to boolean `true`. Actually, the `aria-expanded` value is always true, even when the listbox dropdown is open. The values need now to be passed as boolean true/false.

## Implementation

Just changed all the passed string `'true'` / `'false'` to boolean.

To test, please check the mentions and emojis plugins: the `aria-expanded` value should be initially false, when the listbox dropdown opens, should change to true and so on.

Fixes https://github.com/draft-js-plugins/draft-js-plugins/issues/1072