### PR TITLE
fixed image resizing bugs in Firefox

### DIFF
--- a/draft-js-plugins-editor/src/Editor/index.js
+++ b/draft-js-plugins-editor/src/Editor/index.js
@@ -73,7 +73,7 @@ class PluginEditor extends Component {
     if (currDec === nextDec) return;
     // If the old and the new decorator are the same, but no the same object, also don't call onChange to avoid infinite loops
     if (currDec && nextDec && currDec.decorators.size === nextDec.decorators.size) return;
- 
+
     const editorState = EditorState.set(next.editorState, { decorator: currDec });
     this.onChange(moveSelectionToEnd(editorState));
   }

--- a/draft-js-resizeable-plugin/CHANGELOG.md
+++ b/draft-js-resizeable-plugin/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+### 2.0.4
+- fixed image resizing bugs in Firefox [#1020](https://github.com/draft-js-plugins/draft-js-plugins/issues/1020)
+
 ### 2.0.3
 - fixed incorrect behavior when resized from the left edge [#582](https://github.com/draft-js-plugins/draft-js-plugins/issues/582)
 

--- a/draft-js-resizeable-plugin/package.json
+++ b/draft-js-resizeable-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "draft-js-resizeable-plugin",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Resizeable Plugin for DraftJS",
   "author": {
     "name": "Benjamin Kniffler",

--- a/draft-js-resizeable-plugin/src/createDecorator.js
+++ b/draft-js-resizeable-plugin/src/createDecorator.js
@@ -74,7 +74,7 @@ export default ({ config, store }) => (WrappedComponent) => class BlockResizeabl
       return;
     }
 
-    event.preventDefault();    
+    event.preventDefault();
     const { resizeSteps, vertical, horizontal } = this.props;
     const { hoverPosition } = this.state;
     const { isTop, isLeft, isRight, isBottom } = hoverPosition;

--- a/draft-js-resizeable-plugin/src/createDecorator.js
+++ b/draft-js-resizeable-plugin/src/createDecorator.js
@@ -73,6 +73,8 @@ export default ({ config, store }) => (WrappedComponent) => class BlockResizeabl
     if (!this.state.hoverPosition.canResize) {
       return;
     }
+
+    event.preventDefault();    
     const { resizeSteps, vertical, horizontal } = this.props;
     const { hoverPosition } = this.state;
     const { isTop, isLeft, isRight, isBottom } = hoverPosition;


### PR DESCRIPTION
## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

fixes #1020 

## Implementation

disable default drag and drop if there is mouse-hover-position data (going to resize)

## Demo

tested on Firefox 59.0.2 and Chrome 65.0.3325.181

![2018-04-25 10 02 52](https://user-images.githubusercontent.com/11409069/39222555-e0a54484-486f-11e8-9747-877194cec3a5.gif)

