### PR TITLE
Mentions and Emojis: Add IDs to the combobox listbox options

### DIFF
--- a/draft-js-emoji-plugin/CHANGELOG.md
+++ b/draft-js-emoji-plugin/CHANGELOG.md
@@ -3,9 +3,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.0.6
+- Added an `id` attribute on the listbox options so the `aria-activedescendant` value refers to the focused option.
+
 ## 2.0.4 - 2.0.5
 - bumped find-with-regex
-- Added an `id` attribute on the listbox options so the `aria-activedescendant` value refers to the focused option.
 
 ## 2.0.3
 - Added `aria-selected="true"` for the suggestions listbox focused option.

--- a/draft-js-emoji-plugin/CHANGELOG.md
+++ b/draft-js-emoji-plugin/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## 2.0.4 - 2.0.5
 - bumped find-with-regex
+- Added an `id` attribute on the listbox options so the `aria-activedescendant` value refers to the focused option.
 
 ## 2.0.3
 - Added `aria-selected="true"` for the suggestions listbox focused option.

--- a/draft-js-emoji-plugin/src/components/EmojiSuggestions/Entry/index.js
+++ b/draft-js-emoji-plugin/src/components/EmojiSuggestions/Entry/index.js
@@ -36,7 +36,7 @@ export default class Entry extends Component {
   };
 
   render() {
-    const { theme = {}, imagePath, imageType, cacheBustParam, useNativeArt, isFocused } = this.props;
+    const { theme = {}, imagePath, imageType, cacheBustParam, useNativeArt, isFocused, id } = this.props;
     const className = isFocused ? theme.emojiSuggestionsEntryFocused : theme.emojiSuggestionsEntry;
 
     let emojiDisplay = null;
@@ -63,6 +63,7 @@ export default class Entry extends Component {
         onMouseUp={this.onMouseUp}
         onMouseEnter={this.onMouseEnter}
         role="option"
+        id={id}
         aria-selected={isFocused ? 'true' : null}
       >
         {emojiDisplay}

--- a/draft-js-mention-plugin/CHANGELOG.md
+++ b/draft-js-mention-plugin/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## 3.0.2 - 3.0.3
 - bumped find-with-regex
+- Added an `id` attribute on the listbox options so the `aria-activedescendant` value refers to the focused option.
 
 ## 3.0.1
 - Added `aria-selected="true"` for the suggestions listbox focused option.

--- a/draft-js-mention-plugin/CHANGELOG.md
+++ b/draft-js-mention-plugin/CHANGELOG.md
@@ -3,9 +3,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 3.0.4
+- Added an `id` attribute on the listbox options so the `aria-activedescendant` value refers to the focused option.
+
 ## 3.0.2 - 3.0.3
 - bumped find-with-regex
-- Added an `id` attribute on the listbox options so the `aria-activedescendant` value refers to the focused option.
 
 ## 3.0.1
 - Added `aria-selected="true"` for the suggestions listbox focused option.

--- a/draft-js-mention-plugin/src/MentionSuggestions/Entry/index.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/Entry/index.js
@@ -39,7 +39,7 @@ export default class Entry extends Component {
   };
 
   render() {
-    const { theme = {}, mention, searchValue, isFocused } = this.props;
+    const { theme = {}, mention, searchValue, isFocused, id } = this.props;
     const className = isFocused ? theme.mentionSuggestionsEntryFocused : theme.mentionSuggestionsEntry;
     const EntryComponent = this.props.entryComponent;
     return (
@@ -49,6 +49,7 @@ export default class Entry extends Component {
         onMouseUp={this.onMouseUp}
         onMouseEnter={this.onMouseEnter}
         role="option"
+        id={id}
         aria-selected={isFocused ? 'true' : null}
         theme={theme}
         mention={mention}


### PR DESCRIPTION
## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [ ] Add/Update tests if you add/change new functionality
- [ ] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

To make screen readers able to read out the options in the Mentions and Emojis suggestions list, each option should have an `id` attribute that can be referenced by `aria-activedescendant` used on the textarea. See https://www.w3.org/TR/wai-aria-1.1/#aria-activedescendant
> For example, in a combobox, focus may remain on the textbox while the value of aria-activedescendant on the textbox element refers to a descendant of a popup listbox that is controlled by the textbox.

Everything is already in place, the ID value to use is available. There's just the need to pass the `id` prop. I've tested this on Windows, with various browsers / screen readers combinations:

Firefox ESR + NVDA 2018.1.1
Firefox 59.0.2 + NVDA 2018.1.1 
IE 11 + NVDA 2018.1.1
IE 11 + JAWS 2018

(Note: current Firefox 59 has some performance issues with screen readers, they're actively working on it but for now screen reader users are stuck on Firefox ESR)

A couple screenshots, where I'm cycling through the options using the arrow keys:

Firefox ESR + NVDA

![screenshot 117](https://user-images.githubusercontent.com/1682452/39299325-c02b44e0-4948-11e8-9b02-51621046a22d.png)

IE 11 + NVDA:

![screenshot 118](https://user-images.githubusercontent.com/1682452/39299369-d581d660-4948-11e8-8af5-5e19f292ff33.png)

(Note: it announces "not selected" because #1075 was not merged yet)

Fixes #1076 