### PR TITLE
Update contributing for different Webpack versions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,6 +116,23 @@ For your CSS loader in webpack, ensure you enable CSS modules:
   ]
 }
 ```
+If using Webpack 2+ (say for example in an ejected Create-React-App project), you can enable CSS modules by:
+
+```js
+{
+  test: /\.css$/,
+  use: [
+    require.resolve('style-loader'),
+     {
+       loader: require.resolve('css-loader'),
+       options: {
+         importLoaders: 1,
+         modules: true,
+        },
+      },
+    ]
+},
+```
 
 You'll need to use Babel Stage-0 if you aren't already. First, install it:
 
@@ -130,6 +147,18 @@ Then use it as a preset when loading your JS:
   test: /\.js$/,
   loader: 'babel-loader',
   query: {
+    presets: ['es2015', 'react', 'stage-0'],
+  },
+}
+```
+
+Webpack 2+
+
+```js
+{
+  test: /\.js$/,
+  loader: 'babel-loader',
+  options: {
     presets: ['es2015', 'react', 'stage-0'],
   },
 }


### PR DESCRIPTION
I am running Webpack 2.6.1, and the original babel presets and css webpack code for modules did not work for me, so i had to adjust to new webpack syntax.

Please check out Contributing Guidelines. By following this template you help us to review your code.
https://github.com/draft-js-plugins/draft-js-plugins/blob/master/CONTRIBUTING.md

## Checklist

- [ ] Fix any eslint errors that occur
- [ ] Update change-log for every plugin you touch
- [ ] Add/Update tests if you add/change new functionality
- [ ] Add/Update docs if you add/change functionality
- [ ] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

Whether you're fixing a bug or writing a new feature, please open an issue first and discuss with us. We're also reachable on [the draft js slack](https://draftjs.herokuapp.com/)

Briefly describe the use-case/problem you're solving, reference the issue for this bug/feature here

## Implementation

Briefly describe your solution

## Demo

If you're implementing or changing a feature, please add a gif to demo the change, thanks!
