### PR TITLE
draft-js-inline-toolbar-plugin: do not show inline toolbar when selection is in code-block

### DIFF
--- a/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
+++ b/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
@@ -1,6 +1,7 @@
 /* eslint-disable react/no-array-index-key */
 import React from 'react';
 import { getVisibleSelectionRect } from 'draft-js';
+import inCodeBlock from './../../utils/inCodeBlock';
 
 export default class Toolbar extends React.Component {
 
@@ -76,10 +77,11 @@ export default class Toolbar extends React.Component {
   getStyle() {
     const { store } = this.props;
     const { overrideContent, position } = this.state;
-    const selection = store.getItem('getEditorState')().getSelection();
+    const editorState = store.getItem('getEditorState')();
+    const selection = editorState.getSelection();
     // overrideContent could for example contain a text input, hence we always show overrideContent
     // TODO: Test readonly mode and possibly set isVisible to false if the editor is readonly
-    const isVisible = (!selection.isCollapsed() && selection.getHasFocus()) || overrideContent;
+    const isVisible = (!selection.isCollapsed() && selection.getHasFocus() && !inCodeBlock(editorState)) || overrideContent;
     const style = { ...position };
 
     if (isVisible) {

--- a/draft-js-inline-toolbar-plugin/src/utils/inCodeBlock.js
+++ b/draft-js-inline-toolbar-plugin/src/utils/inCodeBlock.js
@@ -1,0 +1,14 @@
+const inCodeBlock = (editorState) => {
+  const startKey = editorState.getSelection().getStartKey();
+  if (startKey) {
+    const currentBlockType = editorState
+      .getCurrentContent()
+      .getBlockForKey(startKey)
+      .getType();
+    if (currentBlockType === 'code-block') return true;
+  }
+
+  return false;
+};
+
+export default inCodeBlock;

--- a/draft-js-inline-toolbar-plugin/src/utils/inCodeBlock.js
+++ b/draft-js-inline-toolbar-plugin/src/utils/inCodeBlock.js
@@ -1,11 +1,16 @@
 const inCodeBlock = (editorState) => {
   const startKey = editorState.getSelection().getStartKey();
-  if (startKey) {
-    const currentBlockType = editorState
-      .getCurrentContent()
-      .getBlockForKey(startKey)
-      .getType();
-    if (currentBlockType === 'code-block') return true;
+  const endKey = editorState.getSelection().getEndKey();
+  if (startKey && endKey) {
+    const contentState = editorState.getCurrentContent();
+    const blocks = contentState.getBlocksAsArray();
+
+    const selectedBlocks = blocks.slice(
+      Math.max(blocks.indexOf(contentState.getBlockForKey(startKey)) - 1, 0),
+      Math.min(blocks.indexOf(contentState.getBlockForKey(endKey)) + 1, blocks.length)
+    );
+
+    return selectedBlocks.find((block) => block.getType() === 'code-block');
   }
 
   return false;


### PR DESCRIPTION
Please check out Contributing Guidelines. By following this template you help us to review your code.
https://github.com/draft-js-plugins/draft-js-plugins/blob/master/CONTRIBUTING.md

## Checklist

- [ ] Fix any eslint errors that occur
- [ ] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [ ] Add/Update docs if you add/change functionality
- [ ] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

When the user selects text inside code block inline toolbar should not appear (`Slack post` redactor has the same functionality)

## Implementation

Just check current block type
