### PR TITLE
Added support for custom method for creating custom entities

### DIFF
--- a/docs/client/components/pages/Mention/index.js
+++ b/docs/client/components/pages/Mention/index.js
@@ -208,6 +208,10 @@ export default class App extends Component {
               <span>Component to be used to render the suggestions dropdown. It must implement the same interface like <InlineCode code="MentionSuggestions" />.  Defaults to <InlineCode code="MentionSuggestions" />.</span>
             </div>
             <div className={styles.param}>
+              <span className={styles.paramName}>addMentionToEditor</span>
+              <span>For advanced usage: if you need to handle the creation of the DraftJS Entity on your own, you can provide this function.</span>
+            </div>
+            <div className={styles.param}>
               <span>Additional properties are passed to the <InlineCode code="popoverComponent" /></span>
             </div>
           </div>

--- a/draft-js-mention-plugin/CHANGELOG.md
+++ b/draft-js-mention-plugin/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## NEXT
+- Added `addMentionToEditor` function to `MentionSuggestions` to allow custom entity creation.
+
 ## 3.0.4
 - Added an `id` attribute on the listbox options so the `aria-activedescendant` value refers to the focused option.
 

--- a/draft-js-mention-plugin/src/MentionSuggestions/index.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/index.js
@@ -17,6 +17,7 @@ export class MentionSuggestions extends Component {
     ]),
     entryComponent: PropTypes.func,
     onAddMention: PropTypes.func,
+    addMentionToEditor: PropTypes.func,
     suggestions: PropTypes.array,
   };
 
@@ -226,7 +227,7 @@ export class MentionSuggestions extends Component {
     }
 
     this.closeDropdown();
-    const newEditorState = addMention(
+    const newEditorState = (this.props.addMentionToEditor ? this.props.addMentionToEditor : addMention)(
       this.props.store.getEditorState(),
       mention,
       this.props.mentionPrefix,


### PR DESCRIPTION
## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [x] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

My use case requires to use mentions and it's logic, but after a mention has been picked - I need to add it as custom entity I have in my editor, and apply some custom logic to handle it's creation in DraftJS.

## Implementation

Added new prop `addMentionToEditor` to `MentionSuggestions` that allow the developer to provide an alternative method for `addMention`.