### PR TITLE
Fix offset top for Toolbar

### DIFF
--- a/draft-js-side-toolbar-plugin/src/components/Toolbar/index.js
+++ b/draft-js-side-toolbar-plugin/src/components/Toolbar/index.js
@@ -52,7 +52,7 @@ export default class Toolbar extends React.Component {
 
       this.setState({
         position: {
-          top: node.offsetTop + editorRoot.offsetTop,
+          top: node.offsetTop,
           left: editorRoot.offsetLeft - 80,
           transform: 'scale(1)',
           transition: 'transform 0.15s cubic-bezier(.3,1.2,.2,1)',


### PR DESCRIPTION
If remove the editorRoot offset, then everything is okay.

## Demo

![jul-13-2018 20-44-08](https://user-images.githubusercontent.com/12086860/42706011-0234a96c-86de-11e8-8abe-88e720fa9c93.gif)


