### PR TITLE
emoji-plugin: Fix call the forceSelect if the Editor is ReadOnly.

### DIFF
--- a/draft-js-emoji-plugin/src/index.js
+++ b/draft-js-emoji-plugin/src/index.js
@@ -162,6 +162,7 @@ export default (config = {}) => {
     toneSelectOpenDelay,
     useNativeArt,
   };
+  let getEditorReadOnly;
   return {
     EmojiSuggestions: decorateComponentWithProps(EmojiSuggestions, suggestionsProps),
     EmojiSelect: decorateComponentWithProps(EmojiSelect, selectProps),
@@ -186,9 +187,10 @@ export default (config = {}) => {
       }
     ),
 
-    initialize: ({ getEditorState, setEditorState }) => {
+    initialize: ({ getEditorState, setEditorState, getReadOnly }) => {
       store.getEditorState = getEditorState;
       store.setEditorState = setEditorState;
+      getEditorReadOnly = getReadOnly;
     },
 
     onDownArrow: (keyboardEvent) => callbacks.onDownArrow && callbacks.onDownArrow(keyboardEvent),
@@ -198,8 +200,12 @@ export default (config = {}) => {
     handleReturn: (keyboardEvent) => callbacks.handleReturn && callbacks.handleReturn(keyboardEvent),
     onChange: (editorState) => {
       let newEditorState = attachImmutableEntitiesToEmojis(editorState);
+      const isEditorEditable = !getEditorReadOnly();
+      const isContentDifferent = !newEditorState.getCurrentContent().equals(
+        editorState.getCurrentContent()
+      );
 
-      if (!newEditorState.getCurrentContent().equals(editorState.getCurrentContent())) {
+      if (isContentDifferent && isEditorEditable) {
         // Forcing the current selection ensures that it will be at it's right place.
         // This solves the issue where inserting an Emoji on OSX with Apple's Emoji
         // selector led to the right selection the data, but wrong position in


### PR DESCRIPTION
Please check out Contributing Guidelines. By following this template you help us to review your code.
https://github.com/draft-js-plugins/draft-js-plugins/blob/master/CONTRIBUTING.md

## Checklist

- [ ] Fix any eslint errors that occur
- [ ] Update change-log for every plugin you touch
- [ ] Add/Update tests if you add/change new functionality
- [ ] Add/Update docs if you add/change functionality
- [ ] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

Whether you're fixing a bug or writing a new feature, please open an issue first and discuss with us. We're also reachable on [the draft js slack](https://draftjs.herokuapp.com/)

Briefly describe the use-case/problem you're solving, reference the issue for this bug/feature here

## Implementation

Briefly describe your solution

## Demo

If you're implementing or changing a feature, please add a gif to demo the change, thanks!
