### PR TITLE
[emoji-plugin] lazy load emojis

### DIFF
--- a/draft-js-emoji-plugin/CHANGELOG.md
+++ b/draft-js-emoji-plugin/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+- Don't fetch all EmojiOne emoji as soon as the `<EmojiSelect />` is rendered. Fetch them on demand.
+
 ## 2.0.6
 - Added an `id` attribute on the listbox options so the `aria-activedescendant` value refers to the focused option.
 

--- a/draft-js-emoji-plugin/src/components/EmojiSelect/Popover/Groups/Group/index.js
+++ b/draft-js-emoji-plugin/src/components/EmojiSelect/Popover/Groups/Group/index.js
@@ -22,7 +22,7 @@ export default class Group extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.isActiveGroup) {
+    if (nextProps.isActive) {
       this.setState({ hasRenderedEmoji: true });
     }
   }

--- a/draft-js-emoji-plugin/src/components/EmojiSelect/Popover/Groups/Group/index.js
+++ b/draft-js-emoji-plugin/src/components/EmojiSelect/Popover/Groups/Group/index.js
@@ -14,9 +14,26 @@ export default class Group extends Component {
     onEmojiSelect: PropTypes.func.isRequired,
     onEmojiMouseDown: PropTypes.func.isRequired,
     useNativeArt: PropTypes.bool,
+    isActive: PropTypes.bool,
   };
 
-  shouldComponentUpdate = () => false;
+  state = {
+    hasRenderedEmoji: false,
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.isActiveGroup) {
+      this.setState({ hasRenderedEmoji: true });
+    }
+  }
+
+  shouldComponentUpdate = (nextProps) => {
+    if (this.state.hasRenderedEmoji) {
+      return false;
+    }
+
+    return nextProps.isActive;
+  };
 
   renderCategory = (category) => {
     const {
@@ -29,6 +46,7 @@ export default class Group extends Component {
       onEmojiSelect,
       onEmojiMouseDown,
       useNativeArt,
+      isActive,
     } = this.props;
 
     const categoryEmojis = emojis[category];
@@ -38,7 +56,7 @@ export default class Group extends Component {
         key={categoryEmojis[key][0]}
         className={theme.emojiSelectPopoverGroupItem}
       >
-        <Entry
+        {isActive && <Entry
           emoji={categoryEmojis[key][0]}
           theme={theme}
           imagePath={imagePath}
@@ -49,7 +67,7 @@ export default class Group extends Component {
           onEmojiSelect={onEmojiSelect}
           onEmojiMouseDown={onEmojiMouseDown}
           useNativeArt={useNativeArt}
-        />
+        />}
       </li>
     ));
   };

--- a/draft-js-emoji-plugin/src/components/EmojiSelect/Popover/Groups/Group/index.js
+++ b/draft-js-emoji-plugin/src/components/EmojiSelect/Popover/Groups/Group/index.js
@@ -21,12 +21,6 @@ export default class Group extends Component {
     hasRenderedEmoji: false,
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.isActive) {
-      this.setState({ hasRenderedEmoji: true });
-    }
-  }
-
   shouldComponentUpdate = (nextProps) => {
     if (this.state.hasRenderedEmoji) {
       return false;
@@ -34,6 +28,12 @@ export default class Group extends Component {
 
     return nextProps.isActive;
   };
+
+  componentDidUpdate() {
+    if (this.props.isActive) {
+      this.setState({ hasRenderedEmoji: true }); // eslint-disable-line
+    }
+  }
 
   renderCategory = (category) => {
     const {

--- a/draft-js-emoji-plugin/src/components/EmojiSelect/Popover/Groups/index.js
+++ b/draft-js-emoji-plugin/src/components/EmojiSelect/Popover/Groups/index.js
@@ -16,6 +16,7 @@ export default class Groups extends Component {
     onEmojiMouseDown: PropTypes.func.isRequired,
     onGroupScroll: PropTypes.func.isRequired,
     useNativeArt: PropTypes.bool,
+    isOpen: PropTypes.bool,
   };
 
   state = {
@@ -81,6 +82,14 @@ export default class Groups extends Component {
     }
   }
 
+
+  isRenderedGroupActive = (index) => {
+    const { activeGroup } = this.state;
+    const { isOpen } = this.props;
+    return activeGroup === index ||
+           (isOpen && activeGroup + 1 === index); // we also preload next group when popup is open
+  }
+
   render() {
     const {
       cacheBustParam,
@@ -95,7 +104,6 @@ export default class Groups extends Component {
       useNativeArt,
     } = this.props;
 
-    const { activeGroup } = this.state;
     return (
       <div
         className={theme.emojiSelectPopoverGroups}
@@ -130,7 +138,7 @@ export default class Groups extends Component {
                 group.instance = element; // eslint-disable-line no-param-reassign
               }}
               useNativeArt={useNativeArt}
-              isActive={activeGroup === index || activeGroup + 1 === index}
+              isActive={this.isRenderedGroupActive(index)}
             />
           ))}
         </Scrollbars>

--- a/draft-js-emoji-plugin/src/components/EmojiSelect/Popover/Groups/index.js
+++ b/draft-js-emoji-plugin/src/components/EmojiSelect/Popover/Groups/index.js
@@ -18,6 +18,10 @@ export default class Groups extends Component {
     useNativeArt: PropTypes.bool,
   };
 
+  state = {
+    activeGroup: 0,
+  }
+
   componentDidMount() {
     this.calculateBounds();
   }
@@ -32,6 +36,7 @@ export default class Groups extends Component {
     groups.forEach((group, index) => {
       if (values.scrollTop >= group.top) {
         activeGroup = index;
+        this.setState({ activeGroup });
       }
     });
     onGroupScroll(activeGroup);
@@ -90,6 +95,7 @@ export default class Groups extends Component {
       useNativeArt,
     } = this.props;
 
+    const { activeGroup } = this.state;
     return (
       <div
         className={theme.emojiSelectPopoverGroups}
@@ -124,6 +130,7 @@ export default class Groups extends Component {
                 group.instance = element; // eslint-disable-line no-param-reassign
               }}
               useNativeArt={useNativeArt}
+              isActive={activeGroup === index || activeGroup + 1 === index}
             />
           ))}
         </Scrollbars>

--- a/draft-js-emoji-plugin/src/components/EmojiSelect/Popover/index.js
+++ b/draft-js-emoji-plugin/src/components/EmojiSelect/Popover/index.js
@@ -198,6 +198,7 @@ export default class Popover extends Component {
           onGroupScroll={this.onGroupScroll}
           ref={(element) => { this.groups = element; }}
           useNativeArt={useNativeArt}
+          isOpen={isOpen}
         />
         <Nav
           theme={theme}


### PR DESCRIPTION
This is an update of https://github.com/draft-js-plugins/draft-js-plugins/pull/1030 PR which never got merged.

## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

So currently emoji plugin loads 1.3k emojis initially, which is just insane.

With this change it initially loads only 225 (first emoji group), then after the emoji popup is opened - second group of emojis loads. When user navigates to other groups it lazy loads current viewed group + next group to give best user experience. So if user doesn't scroll very fast his currently viewed group should be always loaded.

I know there was discussion in  https://github.com/draft-js-plugins/draft-js-plugins/pull/1030 about checking if image loaded with `onLoad` and only then preventing re-rendering of a group. But to me this seems not related to issue of lazy loading. Current implementation (as in production code) also doesn't handle case when image fails to load. This can be solved with separate PR. One solution would be to add `onError` handler to `<img>` and try to reload.

## Demo
![emoji-lazy-load](https://user-images.githubusercontent.com/6137511/43147201-2a3efd50-8f6b-11e8-9efc-b4083764a675.gif)


