### PR TITLE
draft-js-undo-plugin: fix issue about button not working when it have the same parent container with editor

### DIFF
--- a/draft-js-undo-plugin/CHANGELOG.md
+++ b/draft-js-undo-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To Be Released
 
+### 2.0.2
+
+- button not working while it's in the same container with editor [#1139](https://github.com/draft-js-plugins/draft-js-plugins/issues/1139)
+
 ### Fixed
 
 - Fixed an issue during initialization [#740](https://github.com/draft-js-plugins/draft-js-plugins/pull/740). Thanks to @terryoy

--- a/draft-js-undo-plugin/package.json
+++ b/draft-js-undo-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "draft-js-undo-plugin",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Undo Plugin for DraftJS",
   "author": {
     "name": "Nik Graf",

--- a/draft-js-undo-plugin/src/RedoButton/__test__/index.js
+++ b/draft-js-undo-plugin/src/RedoButton/__test__/index.js
@@ -97,7 +97,7 @@ describe('RedoButton', () => {
         children="redo"
       />
     );
-    result.find('button').simulate('click');
+    result.find('button').simulate('click', { stopPropagation: ()=> undefined });
     expect(onChange).to.have.been.calledOnce;
   });
 });

--- a/draft-js-undo-plugin/src/RedoButton/__test__/index.js
+++ b/draft-js-undo-plugin/src/RedoButton/__test__/index.js
@@ -97,7 +97,7 @@ describe('RedoButton', () => {
         children="redo"
       />
     );
-    result.find('button').simulate('click', { stopPropagation: ()=> undefined });
+    result.find('button').simulate('click', { stopPropagation: () => undefined });
     expect(onChange).to.have.been.calledOnce;
   });
 });

--- a/draft-js-undo-plugin/src/RedoButton/index.js
+++ b/draft-js-undo-plugin/src/RedoButton/index.js
@@ -10,7 +10,8 @@ class RedoButton extends Component {
     theme: PropTypes.any,
   };
 
-  onClick = () => {
+  onClick = (event) => {
+    event.stopPropagation();
     this.props.store.setEditorState(EditorState.redo(this.props.store.getEditorState()));
   };
 

--- a/draft-js-undo-plugin/src/UndoButton/__test__/index.js
+++ b/draft-js-undo-plugin/src/UndoButton/__test__/index.js
@@ -96,7 +96,7 @@ describe('UndoButton', () => {
         children="redo"
       />
     );
-    result.find('button').simulate('click');
+    result.find('button').simulate('click', { stopPropagation: ()=> undefined });
     expect(onChange).to.have.been.calledOnce;
   });
 });

--- a/draft-js-undo-plugin/src/UndoButton/__test__/index.js
+++ b/draft-js-undo-plugin/src/UndoButton/__test__/index.js
@@ -96,7 +96,7 @@ describe('UndoButton', () => {
         children="redo"
       />
     );
-    result.find('button').simulate('click', { stopPropagation: ()=> undefined });
+    result.find('button').simulate('click', { stopPropagation: () => undefined });
     expect(onChange).to.have.been.calledOnce;
   });
 });

--- a/draft-js-undo-plugin/src/UndoButton/index.js
+++ b/draft-js-undo-plugin/src/UndoButton/index.js
@@ -10,7 +10,8 @@ class UndoButton extends Component {
     theme: PropTypes.any,
   };
 
-  onClick = () => {
+  onClick = (event) => {
+    event.stopPropagation();
     this.props.store.setEditorState(EditorState.undo(this.props.store.getEditorState()));
   };
 


### PR DESCRIPTION
## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

the redo/undo button not working #1139 

## Implementation

use `stopPropagation` to avoid trigger focus 

## Demo


![2018-08-04 15 30 13](https://user-images.githubusercontent.com/11409069/43673794-502623fc-97fb-11e8-887d-a4fc0ca84dbb.gif)
