### PR TITLE
[mention plugin] Fix getWordAt failure when mentionTrigger is set as empty

### DIFF
--- a/draft-js-emoji-plugin/CHANGELOG.md
+++ b/draft-js-emoji-plugin/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.0.7
+- Fixed getWordAt failure when mentionTrigger is empty.
+
 ## 2.0.6
 - Added an `id` attribute on the listbox options so the `aria-activedescendant` value refers to the focused option.
 

--- a/draft-js-mention-plugin/src/utils/__test__/getWordAt.js
+++ b/draft-js-mention-plugin/src/utils/__test__/getWordAt.js
@@ -11,13 +11,22 @@ describe('getWordAt', () => {
     expect(getWordAt('this is a test', 5)).to.deep.equal(expected);
   });
 
-  it('finds the first word', () => {
+  it('finds the first word from begin position of word', () => {
     const expected = {
       word: 'this',
       begin: 0,
       end: 4,
     };
     expect(getWordAt('this is a test', 0)).to.deep.equal(expected);
+  });
+
+  it('finds the first word from end position of word', () => {
+    const expected = {
+      word: 'this',
+      begin: 0,
+      end: 4,
+    };
+    expect(getWordAt('this is a test', 4)).to.deep.equal(expected);
   });
 
   it('finds the last word', () => {

--- a/draft-js-mention-plugin/src/utils/getWordAt.js
+++ b/draft-js-mention-plugin/src/utils/getWordAt.js
@@ -5,7 +5,8 @@ const getWordAt = (string, position) => {
   const pos = Number(position) >>> 0;
 
   // Search for the word's beginning and end.
-  const left = str.slice(0, pos + 1).search(/\S+$/);
+  // Do NOT adjust pos if it already at the end of word.(Happens when mentiontrigger is empty(''))
+  const left = str.slice(0, str.charAt(pos) === ' ' ? pos : pos + 1).search(/\S+$/);
   const right = str.slice(pos).search(/\s/);
 
   // The last word in the string is a special case.

--- a/draft-js-mention-plugin/src/utils/getWordAt.js
+++ b/draft-js-mention-plugin/src/utils/getWordAt.js
@@ -2,11 +2,16 @@ const getWordAt = (string, position) => {
   // Perform type conversions.
   const str = String(string);
   // eslint-disable-next-line no-bitwise
-  const pos = Number(position) >>> 0;
+  let pos = Number(position) >>> 0;
+
+  // Pos goes to end of word already when mentiontrigger is empty(''),
+  // so make sure adjusting pos ONLY when cursor pos is NOT at the end of word.
+  if (str.charAt(pos) !== ' ') {
+    pos += 1;
+  }
 
   // Search for the word's beginning and end.
-  // Do NOT adjust pos if it already at the end of word.(Happens when mentiontrigger is empty(''))
-  const left = str.slice(0, str.charAt(pos) === ' ' ? pos : pos + 1).search(/\S+$/);
+  const left = str.slice(0, pos).search(/\S+$/);
   const right = str.slice(pos).search(/\s/);
 
   // The last word in the string is a special case.

--- a/stories/Mention/MentionEditorWithoutMentionTrigger/editorStyles.css
+++ b/stories/Mention/MentionEditorWithoutMentionTrigger/editorStyles.css
@@ -1,0 +1,14 @@
+.editor {
+  box-sizing: border-box;
+  border: 1px solid #ddd;
+  cursor: text;
+  padding: 16px;
+  border-radius: 2px;
+  margin-bottom: 2em;
+  box-shadow: inset 0px 1px 8px -3px #ABABAB;
+  background: #fefefe;
+}
+
+.editor :global(.public-DraftEditor-content) {
+  min-height: 140px;
+}

--- a/stories/Mention/MentionEditorWithoutMentionTrigger/index.js
+++ b/stories/Mention/MentionEditorWithoutMentionTrigger/index.js
@@ -1,0 +1,111 @@
+import React, { Component } from 'react';
+import { EditorState } from 'draft-js';
+import Editor from 'draft-js-plugins-editor';
+import createMentionPlugin, { defaultSuggestionsFilter } from 'draft-js-mention-plugin';
+import editorStyles from './editorStyles.css';
+import mentionsStyles from './mentionsStyles.css';
+import mentions from './mentions';
+
+const positionSuggestions = ({ state, props }) => {
+  let transform;
+  let transition;
+
+  if (state.isActive && props.suggestions.length > 0) {
+    transform = 'scaleY(1)';
+    transition = 'all 0.25s cubic-bezier(.3,1.2,.2,1)';
+  } else if (state.isActive) {
+    transform = 'scaleY(0)';
+    transition = 'all 0.25s cubic-bezier(.3,1,.2,1)';
+  }
+
+  return {
+    transform,
+    transition,
+  };
+};
+
+const mentionPlugin = createMentionPlugin({
+  mentions,
+  entityMutability: 'IMMUTABLE',
+  theme: mentionsStyles,
+  positionSuggestions,
+  mentionPrefix: '',
+  mentionTrigger: '',
+});
+const { MentionSuggestions } = mentionPlugin;
+const plugins = [mentionPlugin];
+
+const Entry = (props) => {
+  const {
+    mention,
+    theme,
+    searchValue, // eslint-disable-line no-unused-vars
+    ...parentProps
+  } = props;
+
+  return (
+    <div {...parentProps}>
+      <div className={theme.mentionSuggestionsEntryContainer}>
+        <div className={theme.mentionSuggestionsEntryContainerLeft}>
+          <img
+            src={mention.avatar}
+            className={theme.mentionSuggestionsEntryAvatar}
+            role="presentation"
+          />
+        </div>
+
+        <div className={theme.mentionSuggestionsEntryContainerRight}>
+          <div className={theme.mentionSuggestionsEntryText}>
+            {mention.name}
+          </div>
+
+          <div className={theme.mentionSuggestionsEntryTitle}>
+            {mention.title}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default class CustomMentionEditor extends Component {
+
+  state = {
+    editorState: EditorState.createEmpty(),
+    suggestions: mentions,
+  };
+
+  onChange = (editorState) => {
+    this.setState({
+      editorState,
+    });
+  };
+
+  onSearchChange = ({ value }) => {
+    this.setState({
+      suggestions: defaultSuggestionsFilter(value, mentions),
+    });
+  };
+
+  focus = () => {
+    this.editor.focus();
+  };
+
+  render() {
+    return (
+      <div className={editorStyles.editor} onClick={this.focus}>
+        <Editor
+          editorState={this.state.editorState}
+          onChange={this.onChange}
+          plugins={plugins}
+          ref={(element) => { this.editor = element; }}
+        />
+        <MentionSuggestions
+          onSearchChange={this.onSearchChange}
+          suggestions={this.state.suggestions}
+          entryComponent={Entry}
+        />
+      </div>
+    );
+  }
+}

--- a/stories/Mention/MentionEditorWithoutMentionTrigger/mentions.js
+++ b/stories/Mention/MentionEditorWithoutMentionTrigger/mentions.js
@@ -1,0 +1,34 @@
+const mentions = [
+  {
+    name: 'matthew',
+    title: 'Senior Software Engineer',
+    avatar: 'https://pbs.twimg.com/profile_images/517863945/mattsailing_400x400.jpg',
+  },
+  {
+    name: 'julian',
+    title: 'United Kingdom',
+    avatar: 'https://avatars2.githubusercontent.com/u/1188186?v=3&s=400',
+  },
+  {
+    name: 'jyoti',
+    title: 'New Delhi, India',
+    avatar: 'https://avatars0.githubusercontent.com/u/2182307?v=3&s=400',
+  },
+  {
+    name: 'max',
+    title: 'Travels around the world, brews coffee, skis mountains and makes stuff on the web.',
+    avatar: 'https://pbs.twimg.com/profile_images/763033229993574400/6frGyDyA_400x400.jpg',
+  },
+  {
+    name: 'nik',
+    title: 'Passionate about Software Architecture, UX, Skiing & Triathlons',
+    avatar: 'https://avatars0.githubusercontent.com/u/223045?v=3&s=400',
+  },
+  {
+    name: 'pascal',
+    title: 'HeathIT hacker and researcher',
+    avatar: 'https://pbs.twimg.com/profile_images/688487813025640448/E6O6I011_400x400.png',
+  },
+];
+
+export default mentions;

--- a/stories/Mention/MentionEditorWithoutMentionTrigger/mentionsStyles.css
+++ b/stories/Mention/MentionEditorWithoutMentionTrigger/mentionsStyles.css
@@ -1,0 +1,71 @@
+.mention {
+  color: #4a85bb;
+  text-decoration: none;
+}
+
+.mentionSuggestions {
+  border-top: 1px solid #eee;
+  background: #fff;
+  border-radius: 2px;
+  cursor: pointer;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  display: flex;
+  flex-direction: column;
+  box-sizing: border-box;
+  transform-origin: 50% 0%;
+  transform: scaleY(0);
+  margin: -16px;
+}
+
+.mentionSuggestionsEntryContainer {
+  display: table;
+  width: 100%;
+}
+
+.mentionSuggestionsEntryContainerLeft,
+.mentionSuggestionsEntryContainerRight {
+  display: table-cell;
+  vertical-align: middle;
+}
+
+.mentionSuggestionsEntryContainerRight {
+  width: 100%;
+  padding-left: 8px;
+}
+
+.mentionSuggestionsEntry {
+  padding: 7px 10px 3px 10px;
+  transition: background-color 0.4s cubic-bezier(.27,1.27,.48,.56);
+}
+
+.mentionSuggestionsEntry:active {
+  background-color: #cce7ff;
+}
+
+.mentionSuggestionsEntryFocused {
+  composes: mentionSuggestionsEntry;
+  background-color: #e6f3ff;
+}
+
+.mentionSuggestionsEntryText,
+.mentionSuggestionsEntryTitle {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.mentionSuggestionsEntryText {
+}
+
+.mentionSuggestionsEntryTitle {
+  font-size: 80%;
+  color: #a7a7a7;
+}
+
+.mentionSuggestionsEntryAvatar {
+  display: block;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+}

--- a/stories/index.js
+++ b/stories/index.js
@@ -52,6 +52,7 @@ import RemoteMentionEditor from './Mention/RemoteMentionEditor';
 import CustomMentionEditor from './Mention/CustomMentionEditor';
 import CustomComponentMentionEditor from './Mention/CustomComponentMentionEditor';
 import MentionEditorWithCustomTrigger from './Mention/MentionEditorWithCustomTrigger';
+import MentionEditorWithoutMentionTrigger from './Mention/MentionEditorWithoutMentionTrigger';
 
 // SideToolbar
 import SimpleSideToolbarEditor from './SideToolbar/SimpleSideToolbarEditor';
@@ -125,7 +126,8 @@ storiesOf('Mention Plugin')
   .add('Editor with Mention Plugin and asynchronously loaded Suggestions', () => <RemoteMentionEditor />)
   .add('Editor with custom themed Mention Plugin', () => <CustomMentionEditor />)
   .add('Editor with Mention Plugin and custom themed Suggestions', () => <CustomComponentMentionEditor />)
-  .add('Editor with mention trigger which needs to be escaped', () => <MentionEditorWithCustomTrigger />);
+  .add('Editor with mention trigger which needs to be escaped', () => <MentionEditorWithCustomTrigger />)
+  .add('Editor with Mention Plugin without Mention Trigger', () => <MentionEditorWithoutMentionTrigger />);
 
 storiesOf('Side Toolbar Plugin')
   .add('Editor with SideToolbar Plugin', () => <SimpleSideToolbarEditor />)


### PR DESCRIPTION
## Checklist

- Fixed getWordAt failure when mentrionTrigger is empty
- Added unit test.

## Use-case/Problem

I am using mention plugin and set **‘mentionTrigger’ as empty**. By doing that, the mention pops up automatically as typing without keying in trigger letter, which works pretty good.
BUT some issues came up lately when I was adding mention **before existing mentions**:
1. First, the suggestions filtering did not work; the suggestions was not narrowed down as typing
2. Second, when I selected a suggestion, wrong portion of text got replaced as mention.
Note: Above scenario works when mentionTrigger is not empty.

## Implementation

Check if cursor is already pointing to end of word being typed, which is whitespace(' '). If Yes, do not move cursor right. If NO, move 1 position right (pos+1) as it is now.

## Demo of issue
This is example of custom mention. Set mentionTrigger as ''.
To Add mention '**julian**' before mention '**max**'

**1. Filtering not working when add mention before existing mention**
![mention-filtering-not-working](https://user-images.githubusercontent.com/1591917/44048911-926abb54-9ee7-11e8-88ca-cd812a849ae9.gif)


**2. Replace text not working when mention is selected.**
![mention-replace-not-working](https://user-images.githubusercontent.com/1591917/44048917-9717aa9a-9ee7-11e8-9c80-1fd21282006f.gif)

