### PR TITLE
Support old lower-case entity type `image` for backwards compatibility

### DIFF
--- a/draft-js-image-plugin/CHANGELOG.md
+++ b/draft-js-image-plugin/CHANGELOG.md
@@ -3,8 +3,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+
+## 2.0.6
+- accept saved images with "image" as the entity type from old saved data for backwards compatibility
+
 ## 2.0.4 - 2.0.5
-- use capitalised image entity type "IMAGE" instead of "image" - now works with convertFromHTML
+- use capitalised image entity type "IMAGE" for new images instead of "image" 
+- now works with convertFromHTML
 
 ## 2.0.3
 - bumped find-with-regex

--- a/draft-js-image-plugin/package.json
+++ b/draft-js-image-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "draft-js-image-plugin",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Image Plugin for DraftJS",
   "author": {
     "name": "Benjamin Kniffler",

--- a/draft-js-image-plugin/src/index.js
+++ b/draft-js-image-plugin/src/index.js
@@ -21,7 +21,7 @@ export default (config = {}) => {
         const entity = block.getEntityAt(0);
         if (!entity) return null;
         const type = contentState.getEntity(entity).getType();
-        if (type === 'IMAGE') {
+        if (type === 'IMAGE' || type === 'image') {
           return {
             component: ThemedImage,
             editable: false,


### PR DESCRIPTION
See https://github.com/draft-js-plugins/draft-js-plugins/issues/1171

## Implementation

This will match on both the old `image` and new `IMAGE` entity types.

