### PR TITLE
Allow user to use a custom component for CustomCounter

### DIFF
--- a/docs/client/components/pages/Counter/SimpleCounterEditor/index.js
+++ b/docs/client/components/pages/Counter/SimpleCounterEditor/index.js
@@ -15,6 +15,8 @@ Note that the color changes when you pass one of the following limits:
 - 10 lines
 `;
 
+const CustomComponent = ({ count }) => <div>{count} words (custom function)</div>;
+
 export default class SimpleCounterEditor extends Component {
 
   state = {
@@ -48,10 +50,7 @@ export default class SimpleCounterEditor extends Component {
         <div><CharCounter limit={200} /> characters</div>
         <div><WordCounter limit={30} /> words</div>
         <div><LineCounter limit={10} /> lines</div>
-        <div>
-          <CustomCounter limit={40} countFunction={this.customCountFunction} />
-          <span> words (custom function)</span>
-        </div>
+        <CustomCounter limit={40} component={CustomComponent} countFunction={this.customCountFunction} />
         <br />
         <br />
       </div>

--- a/docs/client/components/pages/Counter/index.js
+++ b/docs/client/components/pages/Counter/index.js
@@ -44,7 +44,7 @@ export default class App extends Component {
             <li>Line Counter</li>
             <li>Custom Counter</li>
           </ul>
-          <p>The Custom Counter allows you to bring your own counting function. This will be a function that takes plain text (as a string) from the editor as input and returns a numerical value.</p>
+          <p>The Custom Counter allows you to bring your own counting function. This will be a function that takes plain text (as a string) from the editor as input and returns a numerical value. It also allows you to provide your own component for rendering.</p>
           <Heading level={3}>Supported Environment</Heading>
           <ul className={styles.list}>
             <li className={styles.listEntry}>
@@ -108,6 +108,10 @@ export default class App extends Component {
           <div className={styles.param}>
             <div className={styles.paramName}>limit</div>
             <div>A limit to indicate to the user that a threshold has passed.</div>
+          </div>
+          <div className={styles.param}>
+            <div className={styles.paramName}>component</div>
+            <div>A custom component for the Custom Counter. This component will be used to render the counter. It will accept classNames, count and limit as props.</div>
           </div>
           <div className={styles.param}>
             <div className={styles.paramName}>countFunction</div>

--- a/draft-js-counter-plugin/CHANGELOG.md
+++ b/draft-js-counter-plugin/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.0.2
+- Allow user to use a custom component for CustomCounter rendering.
+
 ## 2.0.1
 - New release
 

--- a/draft-js-counter-plugin/src/CustomCounter/__test__/index.js
+++ b/draft-js-counter-plugin/src/CustomCounter/__test__/index.js
@@ -55,4 +55,31 @@ describe('CounterPlugin Line Counter', () => {
     );
     expect(result).to.have.text('6');
   });
+
+
+  it('instantiates plugin with custom component', () => {
+    const text = 'Hello there, how are you?';
+    const editorState = createEditorStateFromText(text);
+    counterPlugin.initialize({
+      getEditorState: () => editorState
+    });
+    const { CustomCounter } = counterPlugin;
+
+    const countFunction = () => 10;
+
+    const component = (props) => (
+      <div className={props.className}>I count {props.count}/{props.limit} characters</div>
+    );
+    const result = mount(
+      <CustomCounter
+        className="my-counter"
+        component={component}
+        countFunction={countFunction}
+        limit={50}
+      />
+    );
+
+    expect(result.first().props().className).to.equal('my-counter');
+    expect(result).to.have.text('I count 10/50 characters');
+  });
 });

--- a/draft-js-counter-plugin/src/CustomCounter/index.js
+++ b/draft-js-counter-plugin/src/CustomCounter/index.js
@@ -5,6 +5,7 @@ import unionClassNames from 'union-class-names';
 class CustomCounter extends Component {
 
   static propTypes = {
+    component: PropTypes.func,
     theme: PropTypes.any,
     limit: PropTypes.number,
     countFunction: PropTypes.func.isRequired,
@@ -18,10 +19,14 @@ class CustomCounter extends Component {
   }
 
   render() {
-    const { store, limit, countFunction } = this.props;
+    const { store, limit, countFunction, component } = this.props;
     const plainText = store.getEditorState().getCurrentContent().getPlainText('');
     const count = countFunction(plainText);
     const classNames = this.getClassNames(count, limit);
+    if (component) {
+      const CustomComponent = component;
+      return <CustomComponent className={classNames} count={count} limit={limit} />;
+    }
 
     return <span className={classNames}>{count}</span>;
   }

--- a/stories/Counter/SimpleCounterEditor/index.js
+++ b/stories/Counter/SimpleCounterEditor/index.js
@@ -15,6 +15,8 @@ Note that the color changes when you pass one of the following limits:
 - 10 lines
 `;
 
+const CustomComponent = ({ count }) => <div>{count} words (custom function and component)</div>;
+
 export default class SimpleCounterEditor extends Component {
 
   state = {
@@ -48,10 +50,7 @@ export default class SimpleCounterEditor extends Component {
         <div><CharCounter limit={200} /> characters</div>
         <div><WordCounter limit={30} /> words</div>
         <div><LineCounter limit={10} /> lines</div>
-        <div>
-          <CustomCounter limit={40} countFunction={this.customCountFunction} />
-          <span> words (custom function)</span>
-        </div>
+        <CustomCounter limit={40} component={CustomComponent} countFunction={this.customCountFunction} />
         <br />
         <br />
       </div>


### PR DESCRIPTION
## Use-case/Problem

I would like to be able to use my own component for rendering when I use the CustomCounter. For example, I need to render an internationalized string that uses count as a param (Refs #1173 )

## Implementation

I added an optional `component` prop to the `CustomCounter` component. When it is defined, this component is rendered instead of the usual `<span>`.