### PR TITLE
Fixing plugins with stores outside of the create plugin functions

### DIFF
--- a/draft-js-alignment-plugin/CHANGELOG.md
+++ b/draft-js-alignment-plugin/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## 2.0.5
-- Fixed bug that would have shared stores between multiple editor instances. https://github.com/draft-js-plugins/draft-js-plugins/issues/1176
+- Fixed bug that would have shared stores between multiple editor instances. [#1176](https://github.com/draft-js-plugins/draft-js-plugins/issues/1176)
 
 ## 2.0.3 - 2.0.4
 - bumped find-with-regex

--- a/draft-js-alignment-plugin/CHANGELOG.md
+++ b/draft-js-alignment-plugin/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.0.5
+- Fixed bug that would have shared stores between multiple editor instances. https://github.com/draft-js-plugins/draft-js-plugins/issues/1176
+
 ## 2.0.3 - 2.0.4
 - bumped find-with-regex
 

--- a/draft-js-alignment-plugin/package.json
+++ b/draft-js-alignment-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "draft-js-alignment-plugin",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Alignment Plugin for DraftJS",
   "author": {
     "name": "Benjamin Kniffler",

--- a/draft-js-alignment-plugin/src/index.js
+++ b/draft-js-alignment-plugin/src/index.js
@@ -6,10 +6,6 @@ import createStore from './utils/createStore';
 import buttonStyles from './buttonStyles.css';
 import alignmentToolStyles from './alignmentToolStyles.css';
 
-const store = createStore({
-  isVisible: false,
-});
-
 const createSetAlignment = (contentBlock, { getEditorState, setEditorState }) => (data) => {
   const entityKey = contentBlock.getEntityAt(0);
   if (entityKey) {
@@ -21,6 +17,10 @@ const createSetAlignment = (contentBlock, { getEditorState, setEditorState }) =>
 };
 
 export default (config = {}) => {
+  const store = createStore({
+    isVisible: false,
+  });
+
   const defaultAlignmentToolTheme = {
     buttonStyles,
     alignmentToolStyles,

--- a/draft-js-resizeable-plugin/CHANGELOG.md
+++ b/draft-js-resizeable-plugin/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.0.7
+- fixed a potential bug with shared state [#1176](https://github.com/draft-js-plugins/draft-js-plugins/issues/1176)
+
 ## 2.0.5 - 2.0.6
 - bumped find-with-regex
 

--- a/draft-js-resizeable-plugin/package.json
+++ b/draft-js-resizeable-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "draft-js-resizeable-plugin",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Resizeable Plugin for DraftJS",
   "author": {
     "name": "Benjamin Kniffler",

--- a/draft-js-resizeable-plugin/src/index.js
+++ b/draft-js-resizeable-plugin/src/index.js
@@ -1,13 +1,6 @@
 import { EditorState } from 'draft-js';
 import createDecorator from './createDecorator';
 
-const store = {
-  getEditorRef: undefined,
-  getReadOnly: undefined,
-  getEditorState: undefined,
-  setEditorState: undefined,
-};
-
 const createSetResizeData = (contentBlock, { getEditorState, setEditorState }) => (data) => {
   const entityKey = contentBlock.getEntityAt(0);
   if (entityKey) {
@@ -18,23 +11,32 @@ const createSetResizeData = (contentBlock, { getEditorState, setEditorState }) =
   }
 };
 
-export default (config) => ({
-  initialize: ({ getEditorRef, getReadOnly, getEditorState, setEditorState }) => {
-    store.getReadOnly = getReadOnly;
-    store.getEditorRef = getEditorRef;
-    store.getEditorState = getEditorState;
-    store.setEditorState = setEditorState;
-  },
-  decorator: createDecorator({ config, store }),
-  blockRendererFn: (contentBlock, { getEditorState, setEditorState }) => {
-    const entityKey = contentBlock.getEntityAt(0);
-    const contentState = getEditorState().getCurrentContent();
-    const resizeData = entityKey ? contentState.getEntity(entityKey).data : {};
-    return {
-      props: {
-        resizeData,
-        setResizeData: createSetResizeData(contentBlock, { getEditorState, setEditorState }),
-      },
-    };
-  }
+export default (config) => (() => {
+  const store = {
+    getEditorRef: undefined,
+    getReadOnly: undefined,
+    getEditorState: undefined,
+    setEditorState: undefined,
+  };
+  return {
+    initialize: ({ getEditorRef, getReadOnly, getEditorState, setEditorState }) => {
+      store.getReadOnly = getReadOnly;
+      store.getEditorRef = getEditorRef;
+      store.getEditorState = getEditorState;
+      store.setEditorState = setEditorState;
+    },
+    decorator: createDecorator({ config, store }),
+    blockRendererFn: (contentBlock, { getEditorState, setEditorState }) => {
+      const entityKey = contentBlock.getEntityAt(0);
+      const contentState = getEditorState()
+        .getCurrentContent();
+      const resizeData = entityKey ? contentState.getEntity(entityKey).data : {};
+      return {
+        props: {
+          resizeData,
+          setResizeData: createSetResizeData(contentBlock, { getEditorState, setEditorState }),
+        },
+      };
+    }
+  };
 });


### PR DESCRIPTION
Please check out Contributing Guidelines. By following this template you help us to review your code.
https://github.com/draft-js-plugins/draft-js-plugins/blob/master/CONTRIBUTING.md

## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [ ] Add/Update tests if you add/change new functionality
- [ ] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

When using multiple alignment tools at the same time, even when I took care to create new instances of each plugin, I would see the alignment and focus be shared among the other editors. 
#1176 

## Implementation

I simply moved the store creation into the functions that create the plugins. 

## Demo

If you're implementing or changing a feature, please add a gif to demo the change, thanks!
