### PR TITLE
Move searchPortal ref function to constructor

### DIFF
--- a/draft-js-emoji-plugin/src/components/EmojiSuggestionsPortal/index.js
+++ b/draft-js-emoji-plugin/src/components/EmojiSuggestionsPortal/index.js
@@ -2,6 +2,11 @@ import React, { Component } from 'react';
 
 export default class EmojiSuggestionsPortal extends Component {
 
+  constructor(props) {
+  	super(props);
+    this.searchPortalRef = (element) => { this.searchPortal = element; };
+  }
+
   componentWillMount() {
     this.props.store.register(this.props.offsetKey);
     this.updatePortalClientRect(this.props);
@@ -31,7 +36,7 @@ export default class EmojiSuggestionsPortal extends Component {
     return (
       <span
         className={this.key}
-        ref={(element) => { this.searchPortal = element; }}
+        ref={this.searchPortalRef}
       >
         {this.props.children}
       </span>

--- a/draft-js-emoji-plugin/src/components/EmojiSuggestionsPortal/index.js
+++ b/draft-js-emoji-plugin/src/components/EmojiSuggestionsPortal/index.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 export default class EmojiSuggestionsPortal extends Component {
 
   constructor(props) {
-  	super(props);
+    super(props);
     this.searchPortalRef = (element) => { this.searchPortal = element; };
   }
 


### PR DESCRIPTION
## Checklist

- [x] Fix any eslint errors that occur
- [ ] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

Fixes issue #666. #667 fixed this issue in mentions plugin. As emoji plugin shares almost the same code, We still need to fix it here.

## Implementation

Moving searchPortal ref function to constructor fixed this issue.
