### PR TITLE
Restored default regexp to mentionSuggestionsStrategy.

### DIFF
--- a/docs/client/components/pages/Mention/CustomMentionEditor/mentions.js
+++ b/docs/client/components/pages/Mention/CustomMentionEditor/mentions.js
@@ -29,6 +29,11 @@ const mentions = [
     title: 'HeathIT hacker and researcher',
     avatar: 'https://pbs.twimg.com/profile_images/688487813025640448/E6O6I011_400x400.png',
   },
+  {
+    name: 'Łukasz Bąk',
+    title: 'Randomly Generated User',
+    avatar: 'https://randomuser.me/api/portraits/men/36.jpg',
+  },
 ];
 
 export default mentions;

--- a/draft-js-mention-plugin/src/mentionSuggestionsStrategy.js
+++ b/draft-js-mention-plugin/src/mentionSuggestionsStrategy.js
@@ -24,8 +24,8 @@ const findWithRegex = (regex, contentBlock, callback) => {
 
 export default (trigger: string, supportWhiteSpace: boolean, regExp: string) => { //eslint-disable-line
   const MENTION_REGEX = supportWhiteSpace ?
-    new RegExp(`${escapeRegExp(trigger)}[\\w\\s]{0,}`, 'g') :
-    new RegExp(`(\\s|^)${escapeRegExp(trigger)}[\\w]*`, 'g');
+    new RegExp(`${escapeRegExp(trigger)}(${regExp}|\\s){0,}`, 'g') :
+    new RegExp(`(\\s|^)${escapeRegExp(trigger)}${regExp}`, 'g');
 
   return (contentBlock: Object, callback: Function) => {
     findWithRegex(MENTION_REGEX, contentBlock, callback);


### PR DESCRIPTION
## Checklist

- [x] Fix any eslint errors that occur
- [ ] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

Fixes regression from 3.1.0. Allows to specify regexp to match mentions and fallbacks to default one if none specified. It restores the possibility of having special characters (like "ę", "ą", "ü" and such) in mention search

