### PR TITLE
SideToolbar: Add scroll support

### DIFF
--- a/docs/client/components/pages/SideToolbar/SimpleSideToolbarEditorWithScroll/editorStyles.css
+++ b/docs/client/components/pages/SideToolbar/SimpleSideToolbarEditorWithScroll/editorStyles.css
@@ -1,0 +1,19 @@
+.editor {
+  box-sizing: border-box;
+  border: 1px solid #ddd;
+  cursor: text;
+  padding: 16px;
+  border-radius: 2px;
+  margin-bottom: 2em;
+  box-shadow: inset 0px 1px 8px -3px #ABABAB;
+  background: #fefefe;
+}
+
+.editor :global(.public-DraftEditor-content) {
+  min-height: 140px;
+}
+
+.scroll-container {
+  height: 50px;
+  overflow-y: auto;
+}

--- a/docs/client/components/pages/SideToolbar/SimpleSideToolbarEditorWithScroll/index.js
+++ b/docs/client/components/pages/SideToolbar/SimpleSideToolbarEditorWithScroll/index.js
@@ -1,0 +1,42 @@
+import React, { Component } from 'react';
+import Editor, { createEditorStateWithText } from 'draft-js-plugins-editor';
+import createSideToolbarPlugin from 'draft-js-side-toolbar-plugin';
+import editorStyles from './editorStyles.css';
+
+const sideToolbarPlugin = createSideToolbarPlugin();
+const { SideToolbar } = sideToolbarPlugin;
+const plugins = [sideToolbarPlugin];
+const text = 'Once you click into the text field the sidebar plugin will show up …';
+
+export default class SimpleSideToolbarEditor extends Component {
+
+  state = {
+    editorState: createEditorStateWithText(text),
+  };
+
+  onChange = (editorState) => {
+    this.setState({
+      editorState,
+    });
+  };
+
+  focus = () => {
+    this.editor.focus();
+  };
+
+  render() {
+    return (
+      <div className={editorStyles.editor} onClick={this.focus}>
+        <div className="scroll-container">
+          <Editor
+            editorState={this.state.editorState}
+            onChange={this.onChange}
+            plugins={plugins}
+            ref={(element) => { this.editor = element; }}
+          />
+          <SideToolbar scrollParent={editorStyles.editor} />
+        </div>
+      </div>
+    );
+  }
+}

--- a/docs/client/components/pages/SideToolbar/index.js
+++ b/docs/client/components/pages/SideToolbar/index.js
@@ -4,6 +4,10 @@ import simpleExampleCode from '!!../../../loaders/prism-loader?language=javascri
 // eslint-disable-next-line import/no-unresolved
 import simpleExampleEditorStylesCode from '!!../../../loaders/prism-loader?language=css!./SimpleSideToolbarEditor/editorStyles.css';
 // eslint-disable-next-line import/no-unresolved
+import simpleExampleCodeWithScroll from '!!../../../loaders/prism-loader?language=javascript!./SimpleSideToolbarEditorWithScroll';
+// eslint-disable-next-line import/no-unresolved
+import simpleExampleEditorWithScrollStylesCode from '!!../../../loaders/prism-loader?language=css!./SimpleSideToolbarEditorWithScroll/editorStyles.css';
+// eslint-disable-next-line import/no-unresolved
 import customExampleCode from '!!../../../loaders/prism-loader?language=javascript!./CustomSideToolbarEditor';
 // eslint-disable-next-line import/no-unresolved
 import customExampleEditorStylesCode from '!!../../../loaders/prism-loader?language=css!./CustomSideToolbarEditor/editorStyles.css';
@@ -26,6 +30,7 @@ import styles from './styles.css';
 import Code from '../../shared/Code';
 import InlineCode from '../../shared/InlineCode';
 import SimpleSideToolbarEditor from './SimpleSideToolbarEditor';
+import SimpleSideToolbarEditorWithScroll from './SimpleSideToolbarEditorWithScroll';
 import CustomSideToolbarEditor from './CustomSideToolbarEditor';
 import SocialBar from '../../shared/SocialBar';
 import NavBar from '../../shared/NavBar';
@@ -115,6 +120,19 @@ export default class App extends Component {
           <SimpleSideToolbarEditor />
           <Code code={simpleExampleCode} name="SimpleSideToolbarEditor.js" />
           <Code code={simpleExampleEditorStylesCode} name="editorStyles.css" />
+        </Container>
+        <Container>
+          <Heading level={2}>Simple Side Toolbar Example With Scroll Support</Heading>
+          <SimpleSideToolbarEditorWithScroll />
+          <Code code={simpleExampleCodeWithScroll} name="SimpleSideToolbarEditorWithScroll.js" />
+          <Code code={simpleExampleEditorWithScrollStylesCode} name="editorStyles.css" />
+        </Container>
+        <Container>
+          <Heading level={2}>Configuration Parameters</Heading>
+          <div className={styles.paramBig}>
+            <span className={styles.paramName}>scrollParent</span>
+            <span>String, query selector, that is the parent of scrolled element.(If none is provided, scroll will not be taken into account for positioning.)</span>
+          </div>
         </Container>
         <Container>
           <Heading level={2}>Custom Side Toolbar Example</Heading>

--- a/draft-js-side-toolbar-plugin/CHANGELOG.md
+++ b/draft-js-side-toolbar-plugin/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+### 3.1.0
+- Add `scrollParent` prop to help support scroll
+- Add scroll support
+
 ### 3.0.0
 - Swap structure prop in side toolbar for render prop
 - Add `position` configuration for positioning left side or right side.

--- a/draft-js-side-toolbar-plugin/src/components/Toolbar/index.js
+++ b/draft-js-side-toolbar-plugin/src/components/Toolbar/index.js
@@ -75,8 +75,21 @@ class Toolbar extends React.Component {
         editorRoot = editorRoot.parentNode;
       }
 
+      const topWithNoScroll = node.offsetTop + editorRoot.offsetTop;
+
+      let valueTop = 0;
+      if (this.props.scrollParent) {
+        const scrollParent = document.querySelectorAll(this.props.scrollParent)[0];
+
+        let element = node;
+        do {
+          valueTop += element.scrollTop || 0;
+          element = element.parentNode;
+        } while (element && element !== scrollParent);
+      }
+
       const position = {
-        top: node.offsetTop + editorRoot.offsetTop,
+        top: topWithNoScroll - valueTop,
         transform: 'scale(1)',
         transition: 'transform 0.15s cubic-bezier(.3,1.2,.2,1)',
       };


### PR DESCRIPTION
## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [ ] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem
Plugin is ignoring scroll value when editor is in scroll container.

## Implementation
Sum the scrollTop values of all nodes in editor and remove it from original value.

## Demo

![http://prikachi.com/images/501/9397501o.gif](http://prikachi.com/images/501/9397501o.gif)
