### PR TITLE
fix(mention-plugin): avoid infinite loop while mentionTrigger is empty with supportWhiteSpace

### DIFF
--- a/draft-js-mention-plugin/CHANGELOG.md
+++ b/draft-js-mention-plugin/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 3.1.3
+- Force update regex's `lastIndex` to avoid infinite loop
+- Fixed replace issue while `mentionTrigger` is empty
+
 ## 3.1.2
 - Allow empty `mentionTrigger` with `supportWhitespace: true` #1182
 

--- a/draft-js-mention-plugin/package.json
+++ b/draft-js-mention-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "draft-js-mention-plugin",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Mention Plugin for DraftJS",
   "author": {
     "name": "Nik Graf",

--- a/draft-js-mention-plugin/src/mentionSuggestionsStrategy.js
+++ b/draft-js-mention-plugin/src/mentionSuggestionsStrategy.js
@@ -18,7 +18,7 @@ const findWithRegex = (regex, contentBlock, callback) => {
       // Force update regex's lastIndex to avoid Infinite loop
       while ((matchArr = regex.exec(text)) !== null) { // eslint-disable-line
         if (regex.lastIndex === prevLastIndex) {
-          regex.lastIndex += 1;
+          regex.lastIndex += 1; // eslint-disable-line no-param-reassign
         }
         prevLastIndex = regex.lastIndex;
         start = nonEntityStart + matchArr.index;

--- a/draft-js-mention-plugin/src/mentionSuggestionsStrategy.js
+++ b/draft-js-mention-plugin/src/mentionSuggestionsStrategy.js
@@ -15,10 +15,10 @@ const findWithRegex = (regex, contentBlock, callback) => {
       let prevLastIndex = regex.lastIndex;
 
       // Go through all matches in the text and return the indices to the callback
-      // Force update regex's lastIndex to avoid Infinite loop
+      // Break the loop if lastIndex is not changed
       while ((matchArr = regex.exec(text)) !== null) { // eslint-disable-line
         if (regex.lastIndex === prevLastIndex) {
-          regex.lastIndex += 1; // eslint-disable-line no-param-reassign
+          break;
         }
         prevLastIndex = regex.lastIndex;
         start = nonEntityStart + matchArr.index;

--- a/draft-js-mention-plugin/src/mentionSuggestionsStrategy.js
+++ b/draft-js-mention-plugin/src/mentionSuggestionsStrategy.js
@@ -12,9 +12,15 @@ const findWithRegex = (regex, contentBlock, callback) => {
       const text = contentBlockText.slice(nonEntityStart, nonEntityEnd);
       let matchArr;
       let start;
+      let prevLastIndex = regex.lastIndex;
 
       // Go through all matches in the text and return the indices to the callback
+      // Force update regex's lastIndex to avoid Infinite loop
       while ((matchArr = regex.exec(text)) !== null) { // eslint-disable-line
+        if (regex.lastIndex === prevLastIndex) {
+          regex.lastIndex += 1;
+        }
+        prevLastIndex = regex.lastIndex;
         start = nonEntityStart + matchArr.index;
         callback(start, start + matchArr[0].length);
       }

--- a/draft-js-mention-plugin/src/utils/__test__/getSearchTextAt.js
+++ b/draft-js-mention-plugin/src/utils/__test__/getSearchTextAt.js
@@ -25,9 +25,9 @@ describe('getSearchTextAt', () => {
   it('finds the matching string following empty trigger', () => {
     const expected = {
       matchingString: 'Max',
-      begin: -1,
+      begin: 0,
       end: 3,
     };
-    expect(getSearchTextAt('Max', 3, trigger)).to.deep.equal(expected);
+    expect(getSearchTextAt('Max', 3, '')).to.deep.equal(expected);
   });
 });

--- a/draft-js-mention-plugin/src/utils/getSearchTextAt.js
+++ b/draft-js-mention-plugin/src/utils/getSearchTextAt.js
@@ -5,7 +5,7 @@
  */
 export default (blockText: string, position: number, trigger: string) => {
   const str = blockText.substr(0, position);
-  const begin = str.lastIndexOf(trigger);
+  const begin = trigger.length === 0 ? 0 : str.lastIndexOf(trigger);
   const matchingString = trigger.length === 0 ? str : str.slice(begin + trigger.length);
   const end = str.length;
 


### PR DESCRIPTION
## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

1. replacing behavior is wrong while mentionTrigger is empty
2. page got infinite loop when mentionTrigger is empty and supportWhiteSpace is true

## Implementation

The infinite loop was cause by the update issue about regex's lastIndex, i just add a force update in it.

## Demo

![2018-09-10 21 08 10](https://user-images.githubusercontent.com/11409069/45299284-ade68b80-b53d-11e8-83d5-c3758af79ece.gif)

