### PR TITLE
feat(resizeable): options to define initial sizes

### DIFF
--- a/draft-js-resizeable-plugin/CHANGELOG.md
+++ b/draft-js-resizeable-plugin/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 3.0.0
+- BREAKING CHANGE: Removed the default initial size. Now it will by default use the default size of the image. You can use the new options `initialHeight` and `initialWidth` to set a fixed initial size to it. [#1166](https://github.com/draft-js-plugins/draft-js-plugins/issues/1166)
+
 ## 2.0.8
 - Fixed creator method.
 

--- a/draft-js-resizeable-plugin/src/createDecorator.js
+++ b/draft-js-resizeable-plugin/src/createDecorator.js
@@ -144,6 +144,8 @@ export default ({ config, store }) => (WrappedComponent) => class BlockResizeabl
       vertical,
       horizontal,
       style,
+      initialHeight,
+      initialWidth,
       // using destructuring to make sure unused props are not passed down to the block
       resizeSteps, // eslint-disable-line no-unused-vars
       ...elementProps
@@ -156,17 +158,17 @@ export default ({ config, store }) => (WrappedComponent) => class BlockResizeabl
     if (horizontal === 'auto') {
       styles.width = 'auto';
     } else if (horizontal === 'relative') {
-      styles.width = `${(width || blockProps.resizeData.width || 40)}%`;
+      styles.width = `${(width || blockProps.resizeData.width || initialWidth)}%`;
     } else if (horizontal === 'absolute') {
-      styles.width = `${(width || blockProps.resizeData.width || 40)}px`;
+      styles.width = `${(width || blockProps.resizeData.width || initialWidth)}px`;
     }
 
     if (vertical === 'auto') {
       styles.height = 'auto';
     } else if (vertical === 'relative') {
-      styles.height = `${(height || blockProps.resizeData.height || 40)}%`;
+      styles.height = `${(height || blockProps.resizeData.height || initialHeight)}%`;
     } else if (vertical === 'absolute') {
-      styles.height = `${(height || blockProps.resizeData.height || 40)}px`;
+      styles.height = `${(height || blockProps.resizeData.height || initialHeight)}px`;
     }
 
     // Handle cursor


### PR DESCRIPTION
Implements an option to set the initial height and initial width of the resized content.

Closes #1166.

BREAKING CHANGE: Removed the default initial size of 40. You can use the new options `initialHeight`
and `initialWidth` to configure it.

## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [ ] Add/Update tests if you add/change new functionality
- [ ] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

When using the option "horizontal" or "vertical" === 'absolute', the default value of the content to be resized will be 40px, which is too small.

Better described on #1166

## Implementation

This PR creates two new options to the resizeable plugin:

* initialWidth: sets the initial width of the resizeable content
* initialHeight: sets the initial height of the resizeable content

Also, on the issue #1166 , I raised the following question:
```
When working on the PR, one thing got me thinking, would it be a problem if we removed the default value, and made it an option, instead of always defaulting to 40? That way, the image size initially will always be the image's actual size, and then the user would resize it to be the size he want's it to be. If the default option is supplied, then the image size will initially use that, instead of the images default size.

What do you think?
```
This PR implements the behaviour above, but I can change, if that's not desireable.

Also, I couldn't find anywhere describing the options which the `createResizeablePlugin` function receives. If there is a place, I can add the new options there too.

Also², I was not able to locally run the tests, so I don't really know if that change breaks anything. Apparently this plugin doesn't have any tests, so it shouldn't (hopefully) break anything. The error I got is the following: 

```
[...]/draft-js-plugins/node_modules/jsdom/lib/jsdom/browser/Window.js:257
        throw new DOMException("localStorage is not available for opaque origins", "SecurityError");
        ^
SecurityError: localStorage is not available for opaque origins
    at get localStorage ([...]/draft-js-plugins/node_modules/jsdom/lib/jsdom/browser/Window.js:257:15)
    at [...]/draft-js-plugins/testHelper.js:36:14
```