### PR TITLE
Fixed: onMouseDown called onClick

### DIFF
--- a/draft-js-side-toolbar-plugin/src/components/BlockTypeSelect/index.js
+++ b/draft-js-side-toolbar-plugin/src/components/BlockTypeSelect/index.js
@@ -38,7 +38,7 @@ class BlockTypeSelect extends React.Component {
       <div
         onMouseEnter={this.onMouseEnter}
         onMouseLeave={this.onMouseLeave}
-        onMouseDown={this.onClick}
+        onMouseDown={this.onMouseDown}
       >
         <div className={theme.blockTypeSelectStyles.blockType}>
           <svg height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

Just discovered this; seems like a bug. If you click the button, the editor loses focus right now. This will be fixed after this PR.

## Implementation

I changed it into what seems to be the original intention of the file author.
