### PR TITLE
keep inline toolbar inside viewport

### DIFF
--- a/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
+++ b/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
@@ -79,13 +79,25 @@ export default class Toolbar extends React.Component {
       // but rather with a small offset so the caret doesn't overlap with the text.
       const extraTopOffset = -5;
 
+      let left = (
+        editorRoot.offsetLeft
+        + (selectionRect.left - editorRootRect.left)
+        + (selectionRect.width / 2)
+      );
+
+      // Make sure toolbar fits inside viewport
+      const halfToolbarWidth = this.toolbar.offsetWidth / 2; // offsetWidth returns width before transform
+      const viewportOffset = 5;
+      const leftBound = (viewportOffset - editorRootRect.left) + halfToolbarWidth;
+      const rightBound = ((window.innerWidth - editorRootRect.left) - viewportOffset) - halfToolbarWidth;
+
+      left = Math.max(leftBound, Math.min(rightBound, left));
+
       const position = {
         top: (editorRoot.offsetTop - this.toolbar.offsetHeight)
           + (selectionRect.top - editorRootRect.top)
           + extraTopOffset,
-        left: editorRoot.offsetLeft
-          + (selectionRect.left - editorRootRect.left)
-          + (selectionRect.width / 2)
+        left
       };
       this.setState({ position });
     });


### PR DESCRIPTION
## Checklist

- [x] Fix any eslint errors that occur
- [ ] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

Fixed draft-js-inline-toolbar positioning to make sure it always fits inside viewport (#1111).

There's one downside. When toolbox stopped at the window's edge, arrow implemented via ::before/after remains at the center of the toolbox pointing at the wrong place. I don't see a way to fix that without adding another <div /> and splitting styles between them. And it will require a change in theming and will break current users styles. I'd like to keep this fix small and easily mergeable so I figured slightly mispositioned arrow is way better than non-usable toolbar anyway.

## Implementation

Calculate window bounds and don't let `left` go beyond them in `onSelectionChanged`.