### PR TITLE
Should import lodash.escapeRegExp

### DIFF
--- a/draft-js-mention-plugin/src/mentionSuggestionsStrategy.js
+++ b/draft-js-mention-plugin/src/mentionSuggestionsStrategy.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import escapeRegExp from 'lodash/escapeRegExp';
+import escapeRegExp from 'lodash.escapeRegExp';
 
 const findWithRegex = (regex, contentBlock, callback) => {
   const contentBlockText = contentBlock.getText();


### PR DESCRIPTION
Import `escapeRegExp` from a seperate lodash package instead of the lodash.

Please check out Contributing Guidelines. By following this template you help us to review your code.
https://github.com/draft-js-plugins/draft-js-plugins/blob/master/CONTRIBUTING.md

## Checklist

- [ ] Fix any eslint errors that occur
- [ ] Update change-log for every plugin you touch
- [ ] Add/Update tests if you add/change new functionality
- [ ] Add/Update docs if you add/change functionality
- [ ] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

Whether you're fixing a bug or writing a new feature, please open an issue first and discuss with us. We're also reachable on [the draft js slack](https://draftjs.herokuapp.com/)

Briefly describe the use-case/problem you're solving, reference the issue for this bug/feature here

## Implementation

Briefly describe your solution

## Demo

If you're implementing or changing a feature, please add a gif to demo the change, thanks!
