### PR TITLE
Updating documentation plugin order

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ const hashtagPlugin = createHashtagPlugin();
 const linkifyPlugin = createLinkifyPlugin();
 
 const plugins = [
-  hashtagPlugin,
   linkifyPlugin,
+  hashtagPlugin,
 ];
 
 export default class UnicornEditor extends Component {


### PR DESCRIPTION
Accordingly the documentation for the hashtag plugin, the linkifyPlugin should be listed before the hashtag to avoid problems.

Please check out Contributing Guidelines. By following this template you help us to review your code.
https://github.com/draft-js-plugins/draft-js-plugins/blob/master/CONTRIBUTING.md

## Checklist

- [ ] Fix any eslint errors that occur
- [ ] Update change-log for every plugin you touch
- [ ] Add/Update tests if you add/change new functionality
- [ ] Add/Update docs if you add/change functionality
- [ ] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

Whether you're fixing a bug or writing a new feature, please open an issue first and discuss with us. We're also reachable on [the draft js slack](https://draftjs.herokuapp.com/)

Briefly describe the use-case/problem you're solving, reference the issue for this bug/feature here

## Implementation

Briefly describe your solution

## Demo

If you're implementing or changing a feature, please add a gif to demo the change, thanks!
