### PR TITLE
Update index.js

### DIFF
--- a/draft-js-image-plugin/src/Image/index.js
+++ b/draft-js-image-plugin/src/Image/index.js
@@ -31,6 +31,9 @@ export default class Image extends Component {
         src={src}
         role="presentation"
         className={combinedClassName}
+        style={{
+          maxWidth: "100%"
+        }}
       />
     );
   }


### PR DESCRIPTION
This styling fixing is about when the user input some image which over the width of the editor width.
![Screen Shot 2019-06-22 at 8 48 10 AM](https://user-images.githubusercontent.com/32106111/59957394-8a883e00-94ca-11e9-8717-fdebeb8f8401.png)
As you can see, when the image is oversized, the editor cannot fully display the image.
![Screen Shot 2019-06-22 at 8 48 24 AM](https://user-images.githubusercontent.com/32106111/59957409-b60b2880-94ca-11e9-9362-943c33df2d74.png)
After the fixes, the image now has the maxwitdth which equals to the size of the container.