### PR TITLE
Modify RegEx to match trigger without leading space

### DIFF
--- a/draft-js-mention-plugin/src/mentionSuggestionsStrategy.js
+++ b/draft-js-mention-plugin/src/mentionSuggestionsStrategy.js
@@ -31,7 +31,7 @@ const findWithRegex = (regex, contentBlock, callback) => {
 export default (trigger: string, supportWhiteSpace: boolean, regExp: string) => { //eslint-disable-line
   const MENTION_REGEX = supportWhiteSpace ?
     new RegExp(`${escapeRegExp(trigger)}(${regExp}|\\s){0,}`, 'g') :
-    new RegExp(`(\\s|^)${escapeRegExp(trigger)}${regExp}`, 'g');
+    new RegExp(`(.|^)${escapeRegExp(trigger)}${regExp}`, 'g');
 
   return (contentBlock: Object, callback: Function) => {
     findWithRegex(MENTION_REGEX, contentBlock, callback);


### PR DESCRIPTION
Simple fix for https://github.com/draft-js-plugins/draft-js-plugins/issues/973

Ideally, there should be a boolean prop for "requiresLeadingSpace"