### PR TITLE
Remove deprecated draft-js hooks usage

### DIFF
--- a/HOW_TO_CREATE_A_PLUGIN.md
+++ b/HOW_TO_CREATE_A_PLUGIN.md
@@ -58,12 +58,6 @@ A plugin accepts all standard props the Draft.js Editor Component uses. [See det
 - [handlePastedFiles](https://facebook.github.io/draft-js/docs/api-reference-editor.html#handlepastedfiles)
 - [handleDroppedFiles](https://facebook.github.io/draft-js/docs/api-reference-editor.html#handledroppedfiles)
 - [handleDrop](https://facebook.github.io/draft-js/docs/api-reference-editor.html#handledrop)
-- [onEscape](https://facebook.github.io/draft-js/docs/api-reference-editor.html#onescape)
-- [onTab](https://facebook.github.io/draft-js/docs/api-reference-editor.html#ontab)
-- [onUpArrow](https://facebook.github.io/draft-js/docs/api-reference-editor.html#onuparrow)
-- [onRightArrow](https://draftjs.org/docs/api-reference-editor.html#onrightarrow)
-- [onDownArrow](https://facebook.github.io/draft-js/docs/api-reference-editor.html#ondownarrow)
-- [onLeftArrow](https://draftjs.org/docs/api-reference-editor.html#onleftarrow)
 - [onFocus](https://draftjs.org/docs/api-reference-editor.html#onfocus)
 - [onBlur](https://draftjs.org/docs/api-reference-editor.html#onblur)
 

--- a/draft-js-emoji-plugin/CHANGELOG.md
+++ b/draft-js-emoji-plugin/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## to be released
+
+- removed deprecated draft-js hooks (onUpArrow, onDownArrow, onEscape, onTab) usage
+
 ## 2.1.2
 
 - Allow draft-js v0.11

--- a/draft-js-emoji-plugin/src/components/EmojiSuggestions/index.js
+++ b/draft-js-emoji-plugin/src/components/EmojiSuggestions/index.js
@@ -241,11 +241,25 @@ export default class EmojiSuggestions extends Component {
     // It assumes that the keyFunctions object will not loose its reference and
     // by this we can replace inner parameters spread over different modules.
     // This better be some registering & unregistering logic. PRs are welcome :)
-    this.props.callbacks.onDownArrow = this.onDownArrow;
-    this.props.callbacks.onUpArrow = this.onUpArrow;
-    this.props.callbacks.onEscape = this.onEscape;
     this.props.callbacks.handleReturn = this.commitSelection;
-    this.props.callbacks.onTab = this.onTab;
+    this.props.callbacks.keyBindingFn = keyboardEvent => {
+      // arrow down
+      if (keyboardEvent.keyCode === 40) {
+        this.onDownArrow(keyboardEvent);
+      }
+      // arrow up
+      if (keyboardEvent.keyCode === 38) {
+        this.onUpArrow(keyboardEvent);
+      }
+      // escape
+      if (keyboardEvent.keyCode === 27) {
+        this.onEscape(keyboardEvent);
+      }
+      // tab
+      if (keyboardEvent.keyCode === 9) {
+        this.onTab(keyboardEvent);
+      }
+    };
 
     const descendant = `emoji-option-${this.key}-${this.state.focusedOptionIndex}`;
     this.props.ariaProps.ariaActiveDescendantID = descendant;
@@ -263,10 +277,7 @@ export default class EmojiSuggestions extends Component {
 
   closeDropdown = () => {
     // make sure none of these callbacks are triggered
-    this.props.callbacks.onDownArrow = undefined;
-    this.props.callbacks.onUpArrow = undefined;
-    this.props.callbacks.onTab = undefined;
-    this.props.callbacks.onEscape = undefined;
+    this.props.callbacks.keyBindingFn = undefined;
     this.props.callbacks.handleReturn = undefined;
     this.props.ariaProps.ariaHasPopup = 'false';
     this.props.ariaProps.ariaExpanded = false;

--- a/draft-js-emoji-plugin/src/index.js
+++ b/draft-js-emoji-plugin/src/index.js
@@ -78,10 +78,6 @@ export default (config = {}) => {
   const callbacks = {
     keyBindingFn: undefined,
     handleKeyCommand: undefined,
-    onDownArrow: undefined,
-    onUpArrow: undefined,
-    onTab: undefined,
-    onEscape: undefined,
     handleReturn: undefined,
     onChange: undefined,
   };
@@ -217,13 +213,8 @@ export default (config = {}) => {
       store.setEditorState = setEditorState;
     },
 
-    onDownArrow: keyboardEvent =>
-      callbacks.onDownArrow && callbacks.onDownArrow(keyboardEvent),
-    onTab: keyboardEvent => callbacks.onTab && callbacks.onTab(keyboardEvent),
-    onUpArrow: keyboardEvent =>
-      callbacks.onUpArrow && callbacks.onUpArrow(keyboardEvent),
-    onEscape: keyboardEvent =>
-      callbacks.onEscape && callbacks.onEscape(keyboardEvent),
+    keyBindingFn: keyboardEvent =>
+      callbacks.keyBindingFn && callbacks.keyBindingFn(keyboardEvent),
     handleReturn: keyboardEvent =>
       callbacks.handleReturn && callbacks.handleReturn(keyboardEvent),
     onChange: editorState => {

--- a/draft-js-focus-plugin/CHANGELOG.md
+++ b/draft-js-focus-plugin/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## to be released
+
+- removed deprecated draft-js hooks (onUpArrow, onDownArrow) usage
+
 ## 3.0.0
 
 - Upgrade to draft-js v0.11; the new version is incompatible with v0.10

--- a/draft-js-mention-plugin/CHANGELOG.md
+++ b/draft-js-mention-plugin/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## to be released 
+
+- removed deprecated draft-js hooks (onUpArrow, onDownArrow, onEscape, onTab) usage
+
 ## 3.1.4
 
 - Allow draft-js v0.11

--- a/draft-js-mention-plugin/src/MentionSuggestions/__test__/index.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/__test__/index.js
@@ -45,10 +45,7 @@ function defaultProps() {
   return {
     suggestions: mentions,
     callbacks: {
-      onDownArrow: sinon.spy(),
-      onUpArrow: sinon.spy(),
-      onTab: sinon.spy(),
-      onEscape: sinon.spy(),
+      keyBindingFn: sinon.spy(),
       handleReturn: sinon.spy(),
     },
     store: {

--- a/draft-js-mention-plugin/src/MentionSuggestions/index.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/index.js
@@ -292,11 +292,25 @@ export class MentionSuggestions extends Component {
     // It assumes that the keyFunctions object will not loose its reference and
     // by this we can replace inner parameters spread over different modules.
     // This better be some registering & unregistering logic. PRs are welcome :)
-    this.props.callbacks.onDownArrow = this.onDownArrow;
-    this.props.callbacks.onUpArrow = this.onUpArrow;
-    this.props.callbacks.onEscape = this.onEscape;
     this.props.callbacks.handleReturn = this.commitSelection;
-    this.props.callbacks.onTab = this.onTab;
+    this.props.callbacks.keyBindingFn = keyboardEvent => {
+      // arrow down
+      if (keyboardEvent.keyCode === 40) {
+        this.onDownArrow(keyboardEvent);
+      }
+      // arrow up
+      if (keyboardEvent.keyCode === 38) {
+        this.onUpArrow(keyboardEvent);
+      }
+      // escape
+      if (keyboardEvent.keyCode === 27) {
+        this.onEscape(keyboardEvent);
+      }
+      // tab
+      if (keyboardEvent.keyCode === 9) {
+        this.onTab(keyboardEvent);
+      }
+    };
 
     const descendant = `mention-option-${this.key}-${this.state.focusedOptionIndex}`;
     this.props.ariaProps.ariaActiveDescendantID = descendant;
@@ -314,11 +328,8 @@ export class MentionSuggestions extends Component {
 
   closeDropdown = () => {
     // make sure none of these callbacks are triggered
-    this.props.callbacks.onDownArrow = undefined;
-    this.props.callbacks.onUpArrow = undefined;
-    this.props.callbacks.onTab = undefined;
-    this.props.callbacks.onEscape = undefined;
     this.props.callbacks.handleReturn = undefined;
+    this.props.callbacks.keyBindingFn = undefined;
     this.props.ariaProps.ariaHasPopup = 'false';
     this.props.ariaProps.ariaExpanded = false;
     this.props.ariaProps.ariaActiveDescendantID = undefined;

--- a/draft-js-mention-plugin/src/index.js
+++ b/draft-js-mention-plugin/src/index.js
@@ -34,10 +34,6 @@ export default (config = {}) => {
   const callbacks = {
     keyBindingFn: undefined,
     handleKeyCommand: undefined,
-    onDownArrow: undefined,
-    onUpArrow: undefined,
-    onTab: undefined,
-    onEscape: undefined,
     handleReturn: undefined,
     onChange: undefined,
   };
@@ -153,13 +149,8 @@ export default (config = {}) => {
       store.setEditorState = setEditorState;
     },
 
-    onDownArrow: keyboardEvent =>
-      callbacks.onDownArrow && callbacks.onDownArrow(keyboardEvent),
-    onTab: keyboardEvent => callbacks.onTab && callbacks.onTab(keyboardEvent),
-    onUpArrow: keyboardEvent =>
-      callbacks.onUpArrow && callbacks.onUpArrow(keyboardEvent),
-    onEscape: keyboardEvent =>
-      callbacks.onEscape && callbacks.onEscape(keyboardEvent),
+    keyBindingFn: keyboardEvent =>
+      callbacks.keyBindingFn && callbacks.keyBindingFn(keyboardEvent),
     handleReturn: keyboardEvent =>
       callbacks.handleReturn && callbacks.handleReturn(keyboardEvent),
     onChange: editorState => {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
   "lint-staged": {
     "*.js": [
       "prettier --write",
-      "git add"
+      "git add",
+      "eslint"
     ]
   },
   "prettier": {


### PR DESCRIPTION
All onDownArrow, onUpArrow, onLeftArrow, onRightArrow, onEscape, onTab
usages are replaced with keyBindingFn.

Their mentions are dropped from HOW_TO_CREATE_A_PLUGIN tut.