### PR TITLE
Fix linaria classnames

### DIFF
--- a/scripts/build-css.js
+++ b/scripts/build-css.js
@@ -8,8 +8,8 @@ const root = process.argv[2];
 const libCss = path.join(root, 'lib-css');
 
 child_process.execSync(
-  `yarn linaria "${path.join(root, 'src/**/*.js')}" -o ${libCss} `,
-  { stdio: 'inherit' }
+  `yarn linaria "${path.join(root, 'src/**/*.js')}" -o ${libCss}`,
+  { cwd: path.resolve('..'), stdio: 'inherit' }
 );
 
 let content = '';


### PR DESCRIPTION
Classnames are generated from paths, index and displayName.
In this diff I fixed the problem of passing different paths by linaria
babel plugin and cli.