### PR TITLE
percentage of width and height disappear

### DIFF
--- a/draft-js-resizeable-plugin/src/createDecorator.js
+++ b/draft-js-resizeable-plugin/src/createDecorator.js
@@ -151,7 +151,7 @@ export default ({ config, store }) => WrappedComponent =>
 
         const { width, height } = this.state;
         this.setState({ clicked: false });
-        this.setEntityData({ width, height });
+        this.setEntityData({ width: horizontal === 'relative' ? `${width}%` : width, height: vertical === 'relative' ? `${height}%` : height });
       };
 
       // TODO clean up event listeners


### PR DESCRIPTION
In editor, width and height are working fine. The percentage of width and height are kept, even though the width and height returned at line 152 are just number.  for instance, the width is returned as 75, but in editor, it is 75%. I have not figured out the reason.
however, if use draftToHtml component to convert draft to html,  the percentage of width and height are lost, which is correct because entitydata does not have percetage. so the changes just make sure the percentage is also set  with numbers.

Please check out Contributing Guidelines. By following this template you help us to review your code.
https://github.com/draft-js-plugins/draft-js-plugins/blob/master/CONTRIBUTING.md

## Checklist

- [ ] Fix any eslint errors that occur
- [ ] Update change-log for every plugin you touch
- [ ] Add/Update tests if you add/change new functionality
- [ ] Add/Update docs if you add/change functionality
- [ ] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

Whether you're fixing a bug or writing a new feature, please open an issue first and discuss with us. We're also reachable on [the draft js slack](https://draftjs.herokuapp.com/)

Briefly describe the use-case/problem you're solving, reference the issue for this bug/feature here

## Implementation

Briefly describe your solution

## Demo

If you're implementing or changing a feature, please add a gif to demo the change, thanks!
