### PR TITLE
Added typescript definitions for SideToolbar plugin

### DIFF
--- a/draft-js-side-toolbar-plugin/CHANGELOG.md
+++ b/draft-js-side-toolbar-plugin/CHANGELOG.md
@@ -8,8 +8,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Migrate styles to linaria
 - Hide internals in single bundle
 - Add esm support
-
-## 3.0.3
 - Added TS definitions
 
 ## 3.0.2

--- a/draft-js-side-toolbar-plugin/CHANGELOG.md
+++ b/draft-js-side-toolbar-plugin/CHANGELOG.md
@@ -9,6 +9,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Hide internals in single bundle
 - Add esm support
 
+## 3.0.3
+- Added TS definitions
+
 ## 3.0.2
 
 - Allow draft-js v0.11

--- a/draft-js-side-toolbar-plugin/package.json
+++ b/draft-js-side-toolbar-plugin/package.json
@@ -12,6 +12,7 @@
   },
   "main": "lib/index.cjs.js",
   "module": "lib/index.esm.js",
+  "types": "lib/index.d.ts",
   "files": [
     "lib"
   ],

--- a/draft-js-side-toolbar-plugin/package.json
+++ b/draft-js-side-toolbar-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "draft-js-side-toolbar-plugin",
-  "version": "3.0.3",
+  "version": "3.0.2",
   "description": "Toolbar Plugin for DraftJS",
   "author": {
     "name": "Benjamin Kniffler",

--- a/draft-js-side-toolbar-plugin/package.json
+++ b/draft-js-side-toolbar-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "draft-js-side-toolbar-plugin",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Toolbar Plugin for DraftJS",
   "author": {
     "name": "Benjamin Kniffler",

--- a/draft-js-side-toolbar-plugin/src/index.d.ts
+++ b/draft-js-side-toolbar-plugin/src/index.d.ts
@@ -35,7 +35,7 @@ export interface SideToolbarChildrenProps {
 }
 
 export interface SideToolbarProps {
-    children?: ComponentType<SideToolbarChildrenProps>;
+    children?: (externalProps: SideToolbarChildrenProps) => ReactNode;
 }
 
 export type SideToolbarPlugin = EditorPlugin & {

--- a/draft-js-side-toolbar-plugin/src/index.d.ts
+++ b/draft-js-side-toolbar-plugin/src/index.d.ts
@@ -1,0 +1,47 @@
+
+import { EditorPlugin } from "draft-js-plugins-editor";
+import { ComponentType, ReactNode } from "react";
+import { EditorState } from "draft-js";
+
+export interface SideToolbarPluginTheme {
+    buttonStyles?: {
+        buttonWrapper?: string;
+        button?: string;
+        active?: string;
+        separator?: string;
+    };
+    blockTypeSelectStyles?: {
+        blockType?: string;
+        spacer?: string;
+        popup?: string;
+    };
+    toolbarStyles?: {
+        wrapper?: string;
+    };
+}
+
+type SideToolbarPosition = "left" | "right";
+
+export interface SideToolbarPluginConfig {
+    theme?: SideToolbarPluginTheme;
+    position?: SideToolbarPosition;
+}
+
+export interface SideToolbarChildrenProps {
+    theme: SideToolbarPluginTheme["buttonStyles"];
+    getEditorState: () => EditorState;
+    setEditorState: (editorState: EditorState) => void;
+    onOverrideContent: (content: ComponentType<SideToolbarChildrenProps>) => void;
+}
+
+export interface SideToolbarProps {
+    children?: ComponentType<SideToolbarChildrenProps>;
+}
+
+export type SideToolbarPlugin = EditorPlugin & {
+    SideToolbar: ComponentType<SideToolbarProps>;
+};
+
+export const createSideToolbarPlugin: (config?: SideToolbarPluginConfig) => SideToolbarPlugin;
+
+export default createSideToolbarPlugin;


### PR DESCRIPTION
Please check out Contributing Guidelines. By following this template you help us to review your code.
https://github.com/draft-js-plugins/draft-js-plugins/blob/master/CONTRIBUTING.md

## Checklist
- [X] Fix any eslint errors that occur
- [X] Update change-log for every plugin you touch
- [X] Add/Update tests if you add/change new functionality
- [X] Add/Update docs if you add/change functionality
- [X] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem
Not able to use this plugin within a TypeScript project

## Implementation
Added `index.d.ts` file with a definition of each part of the plugin
