### PR TITLE
Fixed ts definition in order to be able to include the component with…

### DIFF
--- a/draft-js-inline-toolbar-plugin/CHANGELOG.md
+++ b/draft-js-inline-toolbar-plugin/CHANGELOG.md
@@ -10,6 +10,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Hide internals in single bundle
 - Add esm support
 
+## 3.0.2
+- Fixed ts definition in order to be able to include the component without childs
+
 ## 3.0.1
 
 - Allow draft-js v0.11

--- a/draft-js-inline-toolbar-plugin/CHANGELOG.md
+++ b/draft-js-inline-toolbar-plugin/CHANGELOG.md
@@ -9,8 +9,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Migrate styles to linaria
 - Hide internals in single bundle
 - Add esm support
-
-## 3.0.2
 - Fixed ts definition in order to be able to include the component without childs
 
 ## 3.0.1

--- a/draft-js-inline-toolbar-plugin/package.json
+++ b/draft-js-inline-toolbar-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "draft-js-inline-toolbar-plugin",
-  "version": "3.0.2",
+  "version": "3.0.1",
   "description": "Toolbar Plugin for DraftJS",
   "author": {
     "name": "Benjamin Kniffler",

--- a/draft-js-inline-toolbar-plugin/package.json
+++ b/draft-js-inline-toolbar-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "draft-js-inline-toolbar-plugin",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Toolbar Plugin for DraftJS",
   "author": {
     "name": "Benjamin Kniffler",

--- a/draft-js-inline-toolbar-plugin/src/index.d.ts
+++ b/draft-js-inline-toolbar-plugin/src/index.d.ts
@@ -28,7 +28,7 @@ export interface ToolbarChildrenProps {
 }
 
 export interface ToolbarProps {
-  children(externalProps: ToolbarChildrenProps): ReactNode;
+  children?: ComponentType<ToolbarChildrenProps>;
 }
 
 export type InlineToolBarPlugin = EditorPlugin & {

--- a/draft-js-inline-toolbar-plugin/src/index.d.ts
+++ b/draft-js-inline-toolbar-plugin/src/index.d.ts
@@ -28,7 +28,7 @@ export interface ToolbarChildrenProps {
 }
 
 export interface ToolbarProps {
-  children?: ComponentType<ToolbarChildrenProps>;
+  children?: (externalProps: ToolbarChildrenProps) => ReactNode;
 }
 
 export type InlineToolBarPlugin = EditorPlugin & {


### PR DESCRIPTION
…out childs

Please check out Contributing Guidelines. By following this template you help us to review your code.
https://github.com/draft-js-plugins/draft-js-plugins/blob/master/CONTRIBUTING.md

## Checklist

- [X] Fix any eslint errors that occur
- [X] Update change-log for every plugin you touch
- [X] Add/Update tests if you add/change new functionality
- [X] Add/Update docs if you add/change functionality
- [X] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

When you try to reproduce the example fo this plugin in a TS project, the definition does not allow you to include the component without chid

## Implementation

Fixed `index.d.ts` definition in order to be able to include the component without childs