### PR TITLE
Return this.state.readOnly too in getReadOnly()

### DIFF
--- a/draft-js-plugins-editor/src/Editor/index.js
+++ b/draft-js-plugins-editor/src/Editor/index.js
@@ -130,7 +130,7 @@ class PluginEditor extends Component {
   getProps = () => ({ ...this.props });
 
   // TODO further down in render we use readOnly={this.props.readOnly || this.state.readOnly}. Ask Ben why readOnly is here just from the props? Why would plugins use this instead of just taking it from getProps?
-  getReadOnly = () => this.props.readOnly;
+  getReadOnly = () => this.props.readOnly || this.state.readOnly;
   setReadOnly = readOnly => {
     if (readOnly !== this.state.readOnly) this.setState({ readOnly });
   };


### PR DESCRIPTION
getReadOnly only returns props.readOnly and not the this.state.readOnly.

e.g. This updates the state and not props.readOnly
 setReadOnly = readOnly => {
    if (readOnly !== this.state.readOnly) this.setState({ readOnly });
  };

Please check out Contributing Guidelines. By following this template you help us to review your code.
https://github.com/draft-js-plugins/draft-js-plugins/blob/master/CONTRIBUTING.md

## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

Whether you're fixing a bug or writing a new feature, please open an issue first and discuss with us. We're also reachable on [the draft js slack](https://draftjs.herokuapp.com/)

Briefly describe the use-case/problem you're solving, reference the issue for this bug/feature here

## Implementation

Briefly describe your solution

## Demo

If you're implementing or changing a feature, please add a gif to demo the change, thanks!
