### PR TITLE
Allow for Custom Key Commands in Types

### DIFF
--- a/draft-js-plugins-editor/src/index.d.ts
+++ b/draft-js-plugins-editor/src/index.d.ts
@@ -9,9 +9,9 @@ import {
   Editor,
   EditorProps,
   EditorState,
-  SelectionState
-} from "draft-js";
-import { Component, Ref, SyntheticEvent, KeyboardEvent } from "react";
+  SelectionState,
+} from 'draft-js';
+import { Component, KeyboardEvent, Ref, SyntheticEvent } from 'react';
 
 export interface PluginFunctions {
   getPlugins(): EditorPlugin[]; // a function returning a list of all the plugins
@@ -47,14 +47,14 @@ export interface EditorPlugin {
   keyBindingFn?(
     e: KeyboardEvent,
     pluginFunctions: PluginFunctions
-  ): DraftEditorCommand | null | undefined;
+  ): DraftEditorCommand | string | null;
   handleReturn?(
     e: KeyboardEvent,
     editorState: EditorState,
     pluginFunctions: PluginFunctions
   ): DraftHandleValue;
   handleKeyCommand?(
-    command: DraftEditorCommand,
+    command: DraftEditorCommand | string,
     editorState: EditorState,
     eventTimeStamp: number,
     pluginFunctions: PluginFunctions
@@ -105,7 +105,7 @@ export interface PluginEditorProps extends EditorProps {
   defaultKeyBindings?: boolean;
   defaultKeyCommands?: boolean;
   defaultBlockRenderMap?: boolean;
-  
+
   keyBindingFn?(e: SyntheticKeyboardEvent): EditorCommand | null | undefined;
 
   // eslint-disable-next-line react/no-unused-prop-types

--- a/draft-js-plugins-editor/src/index.d.ts
+++ b/draft-js-plugins-editor/src/index.d.ts
@@ -10,8 +10,11 @@ import {
   EditorProps,
   EditorState,
   SelectionState,
-} from 'draft-js';
-import { Component, KeyboardEvent, Ref, SyntheticEvent } from 'react';
+  DraftBlockRenderMap
+} from "draft-js";
+import { Component, Ref, SyntheticEvent, KeyboardEvent } from "react";
+
+type EditorCommand = DraftEditorCommand | string;
 
 export interface PluginFunctions {
   getPlugins(): EditorPlugin[]; // a function returning a list of all the plugins
@@ -38,6 +41,7 @@ export interface EditorPlugin {
 
   // Events passed from the draft-js editor back to all plugins
   blockRendererFn?(block: ContentBlock, pluginFunctions: PluginFunctions): any;
+  blockRenderMap?: DraftBlockRenderMap;
   blockStyleFn?(block: ContentBlock, pluginFunctions: PluginFunctions): string;
   customStyleFn?: (
     style: DraftInlineStyle,
@@ -47,14 +51,14 @@ export interface EditorPlugin {
   keyBindingFn?(
     e: KeyboardEvent,
     pluginFunctions: PluginFunctions
-  ): DraftEditorCommand | string | null;
+  ): EditorCommand | null;
   handleReturn?(
     e: KeyboardEvent,
     editorState: EditorState,
     pluginFunctions: PluginFunctions
   ): DraftHandleValue;
   handleKeyCommand?(
-    command: DraftEditorCommand | string,
+    command: EditorCommand,
     editorState: EditorState,
     eventTimeStamp: number,
     pluginFunctions: PluginFunctions


### PR DESCRIPTION
Please check out Contributing Guidelines. By following this template you help us to review your code.
https://github.com/draft-js-plugins/draft-js-plugins/blob/master/CONTRIBUTING.md

## Checklist

- [ ] Fix any eslint errors that occur
- [ ] Update change-log for every plugin you touch
- [ ] Add/Update tests if you add/change new functionality
- [ ] Add/Update docs if you add/change functionality
- [ ] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

Whether you're fixing a bug or writing a new feature, please open an issue first and discuss with us. We're also reachable on [the draft js slack](https://draftjs.herokuapp.com/)

Briefly describe the use-case/problem you're solving, reference the issue for this bug/feature here

Currently users cannot extend the editor with custom key commands if they are using typescript. 

## Implementation

This change adds a  union with string to the DraftEditorCommand. So users can do things like return a command 'save' for `cmd/ctrl + s`.

An alternative implementation is to declare an EditorCommand type. `type EditorCommand = DraftEditorCommand | string;` and return that type from the functions.

