### PR TITLE
Trigger rule

### DIFF
--- a/draft-js-mention-plugin/src/MentionSuggestions/index.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/index.js
@@ -122,7 +122,7 @@ export class MentionSuggestions extends Component {
               'g'
             ).test(plainText) &&
             anchorOffset <= end) || // @ is the first character
-          (anchorOffset > start + this.props.mentionTrigger.length &&
+          (anchorOffset >= start + this.props.mentionTrigger.length &&
             anchorOffset <= end) // @ is in the text or at the end
       );
 


### PR DESCRIPTION
When the input is 'trigger: @' anywhere, open should be triggered.
Because the user doesn't always know that a leading space is needed.