### PR TITLE
Update uses of mergeEntityData to use returned ContentState object

### DIFF
--- a/draft-js-alignment-plugin/CHANGELOG.md
+++ b/draft-js-alignment-plugin/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Migrate styles to linaria
 - Hide internals in single bundle
 - Add esm support
+- Update entity editing for compatibility with [planned removal of `DraftEntity` from draft-js](https://draftjs.org/docs/v0-10-api-migration)
 
 ## 2.0.6
 

--- a/draft-js-alignment-plugin/src/AlignmentTool/index.js
+++ b/draft-js-alignment-plugin/src/AlignmentTool/index.js
@@ -56,9 +56,10 @@ export default class AlignmentTool extends React.Component {
           left: boundingRect.left - relativeRect.left + boundingRect.width / 2,
           transform: 'translate(-50%) scale(1)',
           transition: 'transform 0.15s cubic-bezier(.3,1.2,.2,1)',
+	  visibility: 'hidden',
         };
       } else {
-        position = { transform: 'translate(-50%) scale(0)' };
+        position = { transform: 'translate(-50%) scale(0)', visibility: 'visible' };
       }
       const alignment = this.props.store.getItem('alignment') || 'default';
       this.setState({
@@ -86,6 +87,7 @@ export default class AlignmentTool extends React.Component {
 
     return (
       <div
+	      tabIndex={-1}
         className={theme.alignmentToolStyles.alignmentTool}
         style={this.state.position}
         ref={toolbar => {
@@ -96,6 +98,7 @@ export default class AlignmentTool extends React.Component {
           <Button
             /* the index can be used here as the buttons list won't change */
             key={index}
+	    tabIndex={-1}
             alignment={this.state.alignment}
             setAlignment={this.props.store.getItem('setAlignment')}
             theme={theme.buttonStyles}

--- a/draft-js-alignment-plugin/src/index.js
+++ b/draft-js-alignment-plugin/src/index.js
@@ -13,9 +13,12 @@ const createSetAlignment = (
   if (entityKey) {
     const editorState = getEditorState();
     const contentState = editorState.getCurrentContent();
-    contentState.mergeEntityData(entityKey, { ...data });
+    const newContentState = contentState.mergeEntityData(entityKey, data);
     setEditorState(
-      EditorState.forceSelection(editorState, editorState.getSelection())
+      EditorState.forceSelection(
+        EditorState.push(editorState, newContentState, 'apply-entity'),
+        editorState.getSelection()
+      )
     );
   }
 };

--- a/draft-js-drag-n-drop-upload-plugin/CHANGELOG.md
+++ b/draft-js-drag-n-drop-upload-plugin/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Hide internals in single bundle
 - Add esm support
+- Update entity editing for compatibility with [planned removal of `DraftEntity` from draft-js](https://draftjs.org/docs/v0-10-api-migration)
 
 ## 2.0.4
 

--- a/draft-js-drag-n-drop-upload-plugin/src/modifiers/modifyBlockData.js
+++ b/draft-js-drag-n-drop-upload-plugin/src/modifiers/modifyBlockData.js
@@ -5,10 +5,9 @@ export default function(editorState, key, data) {
 
   const block = currentContentState.getBlockForKey(key);
   const entityKey = block.getEntityAt(0);
-  currentContentState.mergeEntityData(entityKey, data);
-
+  const newContentState = currentContentState.mergeEntityData(entityKey, data);
   return EditorState.forceSelection(
-    editorState,
+    EditorState.push(editorState, newContentState, 'apply-entity'),
     editorState.getCurrentContent().getSelectionAfter()
   );
 }

--- a/draft-js-resizeable-plugin/CHANGELOG.md
+++ b/draft-js-resizeable-plugin/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Hide internals in single bundle
 - Add esm support
+- Update entity editing for compatibility with [planned removal of `DraftEntity` from draft-js](https://draftjs.org/docs/v0-10-api-migration)
 
 ## 2.0.9
 

--- a/draft-js-resizeable-plugin/src/index.js
+++ b/draft-js-resizeable-plugin/src/index.js
@@ -9,9 +9,12 @@ const createSetResizeData = (
   if (entityKey) {
     const editorState = getEditorState();
     const contentState = editorState.getCurrentContent();
-    contentState.mergeEntityData(entityKey, { ...data });
+    const newContentState = contentState.mergeEntityData(entityKey, data);
     setEditorState(
-      EditorState.forceSelection(editorState, editorState.getSelection())
+      EditorState.forceSelection(
+        EditorState.push(editorState, newContentState, 'apply-entity'),
+        editorState.getSelection()
+      )
     );
   }
 };


### PR DESCRIPTION
## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

Filed as issue #1380 

## Implementation

When using `ContentState::mergeEntityData` the `ContentState` object returned is now updated in the `EditorState` object.
