### PR TITLE
fix lastSelection for Plugin that is inserted when it's selected

### DIFF
--- a/draft-js-focus-plugin/CHANGELOG.md
+++ b/draft-js-focus-plugin/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To Be Released
 
+- Fix focus stuck when add a plugin that is already selected
 - Migrate styles to linaria
 - Hide internals in single bundle
 - Add esm support

--- a/draft-js-focus-plugin/src/index.js
+++ b/draft-js-focus-plugin/src/index.js
@@ -70,6 +70,7 @@ export default (config = {}) => {
       // then the change was not a pure selection change
       const contentState = editorState.getCurrentContent();
       if (!contentState.equals(lastContentState)) {
+        lastSelection = editorState.getSelection();
         lastContentState = contentState;
         return editorState;
       }


### PR DESCRIPTION
Hey, if a focusable plugin is added when it's already selected, then the selection gets stuck. 
From what I see the plugin was designed for the case where a plugin is added and then selected by user interaction. 
In my tests, this one liner is all that's needed to fix this. 

You can see an example of this not working by going here https://rich-content-6-8-1.surge.sh/ and adding a divider. You will see that it isn't losing focus

![ezgif-3-d123054a6243](https://user-images.githubusercontent.com/2996028/73962268-c3203f00-4916-11ea-8b5a-14682ba41ed9.gif)
