### PR TITLE
add support of initialWidth & initialHeight

### DIFF
--- a/draft-js-resizeable-plugin/CHANGELOG.md
+++ b/draft-js-resizeable-plugin/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Hide internals in single bundle
 - Add esm support
+- Add support of optional initialWidth and initialHeight parameters when creating decorator [#1166](https://github.com/draft-js-plugins/draft-js-plugins/issues/1166)
+- Add typescript type for createResizeablePlugin optional parameter
 
 ## 2.0.9
 

--- a/draft-js-resizeable-plugin/README.md
+++ b/draft-js-resizeable-plugin/README.md
@@ -11,3 +11,25 @@ const resizePlugin = createResizeablePlugin();
 ```
 
 This plugin does not require, but work better in combination with the `draft-js-focus-plugin`.
+
+------
+
+You can pass optional parameter to `createResizeablePlugin`;
+
+| Props                                          | Type         | Description | Required
+|-----------------------------------------------|:------------:|--------|--------|
+| horizontal                                     | "auto" or "relative" or "absolute" | "relative" measures the width of image in percentages,  while "absolute" measures in pixels | no
+| vertical                                       | "auto" or "relative" or "absolute" | same as horizontal, but for height | no
+| initialWidth                                   | string | initial width of image. If not passed, the default value is 40 (either % or px, depending on type of horizontal) unless horizontal is set to "auto". In case of "auto" is has no effect. You can pass any valid css value for property width. For example, "100px", "60%" or "auto" | no
+| initialHeight                                  | string | same as initialWidth, but for height | no
+
+
+### Example
+```js
+import createResizeablePlugin from 'draft-js-resizeable-plugin';
+
+const resizePlugin = createResizeablePlugin({
+    horizontal: "absolute",
+    initialWidth: "auto"
+});
+```

--- a/draft-js-resizeable-plugin/src/createDecorator.js
+++ b/draft-js-resizeable-plugin/src/createDecorator.js
@@ -166,6 +166,8 @@ export default ({ config, store }) => WrappedComponent =>
         blockProps,
         vertical,
         horizontal,
+        initialWidth,
+        initialHeight,
         style,
         // using destructuring to make sure unused props are not passed down to the block
         resizeSteps, // eslint-disable-line no-unused-vars
@@ -179,17 +181,37 @@ export default ({ config, store }) => WrappedComponent =>
       if (horizontal === 'auto') {
         styles.width = 'auto';
       } else if (horizontal === 'relative') {
-        styles.width = `${width || blockProps.resizeData.width || 40}%`;
+        const value = width || blockProps.resizeData.width;
+        if (!value && initialWidth) {
+          styles.width = initialWidth;
+        } else {
+          styles.width = `${value || 40}%`;
+        }
       } else if (horizontal === 'absolute') {
-        styles.width = `${width || blockProps.resizeData.width || 40}px`;
+        const value = width || blockProps.resizeData.width;
+        if (!value && initialWidth) {
+          styles.width = initialWidth;
+        } else {
+          styles.width = `${value || 40}px`;
+        }
       }
 
       if (vertical === 'auto') {
         styles.height = 'auto';
       } else if (vertical === 'relative') {
-        styles.height = `${height || blockProps.resizeData.height || 40}%`;
+        const value = height || blockProps.resizeData.height;
+        if (!value && initialHeight) {
+          styles.height = initialHeight;
+        } else {
+          styles.height = `${value || 40}%`;
+        }
       } else if (vertical === 'absolute') {
-        styles.height = `${height || blockProps.resizeData.height || 40}px`;
+        const value = height || blockProps.resizeData.height;
+        if (!value && initialHeight) {
+          styles.height = initialHeight;
+        } else {
+          styles.height = `${value || 40}%`;
+        }
       }
 
       // Handle cursor

--- a/draft-js-resizeable-plugin/src/index.d.ts
+++ b/draft-js-resizeable-plugin/src/index.d.ts
@@ -3,6 +3,15 @@ import { EditorPlugin } from "draft-js-plugins-editor";
 
 type ResizeableEditorPlugin = EditorPlugin & { decorator: DraftDecorator };
 
-declare const createResizeablePlugin: () => ResizeableEditorPlugin;
+type ScaleType = "auto" | "relative" | "absolute";
+interface InitializeArguments {
+	blockProps?: any;
+	horizontal?: ScaleType;
+	vertical?: ScaleType;
+	initialWidth?: string;
+	initialHeight?: string;
+}
+
+declare const createResizeablePlugin: (args?: InitializeArguments) => ResizeableEditorPlugin;
 
 export default createResizeablePlugin;


### PR DESCRIPTION

Implements an option to set the initial height and initial width of the resized content **without breaking changes**.
Closes [#1166](https://github.com/draft-js-plugins/draft-js-plugins/issues/1166).

## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [ ] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

When horizontal or vertical properties are "relative" or "absolute", the default value is 40 (40% or 40px, depending whether "relative" or "absolute" is set). Currently, it is not possible to change default value. For example, if I want the block width to be absolute, without affecting initial width, it is not possible to do so.

## Implementation

You can pass optional two parameters: `initialWidth` and `initialHeight` to the first argument of `createResizeablePlugin` and change the default style of width and/or height. Typescript declaration is also updated.

## Example
```js
const resizePlugin = createResizeablePlugin({
    horizontal: "absolute",
    initialWidth: "auto"
});
```