### PR TITLE
removes `blockKey` prop incorrectly applied on a DOM element

### DIFF
--- a/draft-js-hashtag-plugin/src/Hashtag/index.js
+++ b/draft-js-hashtag-plugin/src/Hashtag/index.js
@@ -13,6 +13,7 @@ export default class Hashtag extends Component {
       offsetKey, // eslint-disable-line no-unused-vars
       setEditorState, // eslint-disable-line no-unused-vars
       contentState, // eslint-disable-line no-unused-vars
+      blockKey, // eslint-disable-line no-unused-vars
       ...otherProps
     } = this.props; // eslint-disable-line no-use-before-define
     const combinedClassName = clsx(theme.hashtag, className);


### PR DESCRIPTION
Please check out Contributing Guidelines. By following this template you help us to review your code.
https://github.com/draft-js-plugins/draft-js-plugins/blob/master/CONTRIBUTING.md

## Checklist

- [ ] Fix any eslint errors that occur
- [ ] Update change-log for every plugin you touch
- [ ] Add/Update tests if you add/change new functionality
- [ ] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

fixes https://github.com/draft-js-plugins/draft-js-plugins/issues/1342

## Implementation

inside this file `draft-js-plugins/draft-js-hashtag-plugin/src/Hashtag/index.js`

I declared the "blockKey" property to make sure it does not compare inside the `otherProps` object, containing the undeclared component props.
This way the "blockKey" property will not be applied to a `span` element, thus avoid triggering the warning.
```
"React does not recognize the `blockKey` prop on a DOM element"
```

