### PR TITLE
Update index.d.ts

### DIFF
--- a/draft-js-plugins-editor/src/index.d.ts
+++ b/draft-js-plugins-editor/src/index.d.ts
@@ -47,7 +47,7 @@ export interface EditorPlugin {
   keyBindingFn?(
     e: KeyboardEvent,
     pluginFunctions: PluginFunctions
-  ): DraftEditorCommand | null;
+  ): DraftEditorCommand | null | undefined;
   handleReturn?(
     e: KeyboardEvent,
     editorState: EditorState,

--- a/draft-js-plugins-editor/src/index.d.ts
+++ b/draft-js-plugins-editor/src/index.d.ts
@@ -105,6 +105,8 @@ export interface PluginEditorProps extends EditorProps {
   defaultKeyBindings?: boolean;
   defaultKeyCommands?: boolean;
   defaultBlockRenderMap?: boolean;
+  
+  keyBindingFn?(e: SyntheticKeyboardEvent): EditorCommand | null | undefined;
 
   // eslint-disable-next-line react/no-unused-prop-types
   decorators?: DraftDecorator[];


### PR DESCRIPTION
Adding undefined as an acceptable return from a keyBindingFn to signify it has not been handled

Please check out Contributing Guidelines. By following this template you help us to review your code.
https://github.com/draft-js-plugins/draft-js-plugins/blob/master/CONTRIBUTING.md

## Checklist

- [x] Fix any eslint errors that occur
- [ ] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

It appears in line 321 of Editor/index.js that undefined is an acceptable return from a plugin[methodName]. As the keyBindingFn is automatically added to the plugins list, at the moment there is a ts lint error when passing in a function that can return undefined

## Implementation

Overriding the type def from draft-js for keyBindingFn

