### PR TITLE
Fixed emoji select popover close issue on multiple instance case

### DIFF
--- a/draft-js-emoji-plugin/src/components/EmojiSelect/index.js
+++ b/draft-js-emoji-plugin/src/components/EmojiSelect/index.js
@@ -37,6 +37,8 @@ export default class EmojiSelect extends Component {
     toneSelectOpenDelay: 500,
   };
 
+  emojiSelectRef = React.createRef();
+
   // Start the selector closed
   state = {
     isOpen: false,
@@ -45,17 +47,18 @@ export default class EmojiSelect extends Component {
   // When the selector is open and users click anywhere on the page,
   // the selector should close
   componentDidMount() {
-    document.addEventListener('click', this.closePopover);
+    document.addEventListener('click', this.closeIfClickedOutside);
   }
 
   componentWillUnmount() {
-    document.removeEventListener('click', this.closePopover);
+    document.removeEventListener('click', this.closeIfClickedOutside);
   }
 
-  onClick = e => {
-    e.stopPropagation();
-    e.nativeEvent.stopImmediatePropagation();
-  };
+  closeIfClickedOutside = e => {
+    if (this.emojiSelectRef && !this.emojiSelectRef.contains(e.target)) {
+      this.closePopover();
+    }
+  }
 
   onButtonMouseUp = () =>
     this.state.isOpen ? this.closePopover() : this.openPopover();
@@ -95,7 +98,10 @@ export default class EmojiSelect extends Component {
       : theme.emojiSelectButton;
 
     return (
-      <div className={theme.emojiSelect} onClick={this.onClick}>
+      <div
+        ref={this.emojiSelectRef}
+        className={theme.emojiSelect}
+      >
         <button
           className={buttonClassName}
           onMouseUp={this.onButtonMouseUp}

--- a/draft-js-emoji-plugin/src/components/EmojiSelect/index.js
+++ b/draft-js-emoji-plugin/src/components/EmojiSelect/index.js
@@ -55,7 +55,7 @@ export default class EmojiSelect extends Component {
   }
 
   closeIfClickedOutside = e => {
-    if (this.emojiSelectRef && !this.emojiSelectRef.contains(e.target)) {
+    if (this.emojiSelectRef && !this.emojiSelectRef.current.contains(e.target)) {
       this.closePopover();
     }
   }


### PR DESCRIPTION
Please check out Contributing Guidelines. By following this template you help us to review your code.
https://github.com/draft-js-plugins/draft-js-plugins/blob/master/CONTRIBUTING.md

## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

When using multiple emoji picker plugins on one page (imagine a list of posts like fb timeline that each have its own comment input and emoji picker button) there is an issue that already open emoji picker popover want close if you click on another instances popover trigger button. 
The issue can be seen on demo page of emoji plugin https://www.draft-js-plugins.com/plugin/emoji

<img src="https://user-images.githubusercontent.com/3504419/80152072-676a6700-8591-11ea-9c60-c2348207c013.gif" width="200"/>
## Implementation

As can be seen, in the change I have updated the event listener on the document to call a specific function `closeIfClickedOutside` which is simply checking if the click target element is something inside emoji popover component or no. And if no then it calls a function to close the popover and doing nothing otherwise.

```
  closeIfClickedOutside = e => {
    if (this.emojiSelectRef && !this.emojiSelectRef.contains(e.target)) {
      this.closePopover();
    }
  }
```

## Demo

After fix the one popover instance will always close when opening another popover.

<img src="https://user-images.githubusercontent.com/3504419/80152781-a9e07380-8592-11ea-8c62-7ca858e343b8.gif" width="200"/>
