### PR TITLE
Add Static Toolbar Typing

### DIFF
--- a/draft-js-static-toolbar-plugin/package.json
+++ b/draft-js-static-toolbar-plugin/package.json
@@ -11,6 +11,7 @@
     "url": "https://github.com/draft-js-plugins/draft-js-plugins.git"
   },
   "main": "lib/index.cjs.js",
+  "types": "lib/index.d.ts",
   "module": "lib/index.esm.js",
   "files": [
     "lib"
@@ -27,8 +28,9 @@
   ],
   "scripts": {
     "clean": "../node_modules/.bin/rimraf lib",
-    "build": "yarn clean && yarn build:js && yarn build:css",
+    "build": "yarn clean && yarn build:js && yarn build:ts && yarn build:css",
     "build:js": "../node_modules/.bin/rollup --config ../rollup.config.js",
+    "build:ts": "../node_modules/.bin/cpx src/*.d.ts lib/",
     "build:css": "node ../scripts/build-css.js $(pwd)",
     "prepublish": "yarn build"
   },

--- a/draft-js-static-toolbar-plugin/src/index.d.ts
+++ b/draft-js-static-toolbar-plugin/src/index.d.ts
@@ -1,0 +1,36 @@
+import { EditorPlugin } from "draft-js-plugins-editor";
+import { ComponentType, ReactNode } from "react";
+import { DraftJsStyleButtonProps, DraftJsButtonTheme } from 'draft-js-buttons';
+
+export interface StaticToolbarPluginTheme {
+    buttonStyles: DraftJsButtonTheme;
+    toolbarStyles: {
+        toolbar: string;
+    };
+}
+
+export interface StaticToolbarPluginConfig {
+  theme: StaticToolbarPluginTheme;
+}
+
+export interface ToolbarProps {
+  children(externalProps: DraftJsStyleButtonProps): ReactNode;
+}
+
+export type StaticToolBarPlugin = EditorPlugin & {
+  Toolbar: ComponentType<ToolbarProps>;
+};
+
+declare const createStaticToolbarPlugin: (
+  config?: StaticToolbarPluginConfig
+) => StaticToolBarPlugin;
+
+export default createStaticToolbarPlugin;
+
+export interface SeparatorProps {
+  className?: string;
+}
+
+declare const Separator: (props: SeparatorProps) => JSX.Element;
+
+export { Separator };


### PR DESCRIPTION
Add typescript typing for the Static Toolbar plugin.

Ref. Inline Toolbar plugin. https://github.com/draft-js-plugins/draft-js-plugins/pull/1290