### PR TITLE
Add support for multiple mentionTriggers

### DIFF
--- a/draft-js-mention-plugin/CHANGELOG.md
+++ b/draft-js-mention-plugin/CHANGELOG.md
@@ -16,6 +16,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Made suggestions prop required (pass empty array for async suggestions)
 - Remove prevState and state from positionSuggestions
 
+## to be released
+
+- added support for multiple triggers
+
 ## 3.1.5
 
 - removed deprecated draft-js hooks (onUpArrow, onDownArrow, onEscape, onTab) usage

--- a/draft-js-mention-plugin/src/MentionSuggestions/__test__/mentionSuggestionStrategy.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/__test__/mentionSuggestionStrategy.js
@@ -5,14 +5,14 @@ import mentionSuggestionsStrategy from '../../mentionSuggestionsStrategy';
 import defaultRegExp from '../../defaultRegExp';
 
 let callback;
-const trigger = '@';
+const triggers = ['@', '#'];
 const nonWhitespaceStrategy = mentionSuggestionsStrategy(
-  trigger,
+  triggers,
   false,
   defaultRegExp
 );
 const whitespaceStrategy = mentionSuggestionsStrategy(
-  trigger,
+  triggers,
   true,
   defaultRegExp
 );
@@ -64,6 +64,14 @@ describe('mentionSuggestionsStrategy', () => {
       expect(callback.secondCall.args).to.deep.equal([4, 13]);
       expect(callback.thirdCall.args).to.deep.equal([13, 19]);
     });
+
+    it('should match multiple triggers', () => {
+      nonWhitespaceStrategy(getBlock('@the #walking @dead'), callback);
+      expect(callback.callCount).to.equal(3);
+      expect(callback.firstCall.args).to.deep.equal([0, 4]);
+      expect(callback.secondCall.args).to.deep.equal([4, 13]);
+      expect(callback.thirdCall.args).to.deep.equal([13, 19]);
+    });
   });
 
   context('when whitespace support is enabled', () => {
@@ -94,6 +102,16 @@ describe('mentionSuggestionsStrategy', () => {
       expect(callback.callCount).to.equal(2);
       expect(callback.firstCall.args).to.deep.equal([0, 15]);
       expect(callback.secondCall.args).to.deep.equal([15, 27]);
+    });
+
+    it('should match multiple triggers with spaces', () => {
+      whitespaceStrategy(
+        getBlock('@the walking dead tv #the white house'),
+        callback
+      );
+      expect(callback.callCount).to.equal(2);
+      expect(callback.firstCall.args).to.deep.equal([0, 21]);
+      expect(callback.secondCall.args).to.deep.equal([21, 37]);
     });
 
     it('should not match entities', () => {

--- a/draft-js-mention-plugin/src/index.js
+++ b/draft-js-mention-plugin/src/index.js
@@ -84,6 +84,10 @@ export default (config = {}) => {
     mentionRegExp = defaultRegExp,
     supportWhitespace = false,
   } = config;
+  let { mentionTriggers } = config;
+  if (!mentionTriggers) {
+    mentionTriggers = [mentionTrigger];
+  }
   const mentionSearchProps = {
     ariaProps,
     callbacks,
@@ -91,7 +95,7 @@ export default (config = {}) => {
     store,
     entityMutability,
     positionSuggestions,
-    mentionTrigger,
+    mentionTriggers,
     mentionPrefix,
   };
   const DecoratedMentionSuggestionsComponent = props => (
@@ -107,12 +111,12 @@ export default (config = {}) => {
     MentionSuggestions: DecoratedMentionSuggestionsComponent,
     decorators: [
       {
-        strategy: mentionStrategy(mentionTrigger),
+        strategy: mentionStrategy(mentionTriggers),
         component: DecoratedMention,
       },
       {
         strategy: mentionSuggestionsStrategy(
-          mentionTrigger,
+          mentionTriggers,
           supportWhitespace,
           mentionRegExp
         ),

--- a/draft-js-mention-plugin/src/mentionStrategy.js
+++ b/draft-js-mention-plugin/src/mentionStrategy.js
@@ -1,6 +1,6 @@
 import getTypeByTrigger from './utils/getTypeByTrigger';
 
-const findMentionEntities = trigger => (
+const findMentionEntities = triggers => (
   contentBlock,
   callback,
   contentState
@@ -9,7 +9,11 @@ const findMentionEntities = trigger => (
     const entityKey = character.getEntity();
     return (
       entityKey !== null &&
-      contentState.getEntity(entityKey).getType() === getTypeByTrigger(trigger)
+      triggers.some(
+        trigger =>
+          contentState.getEntity(entityKey).getType() ===
+          getTypeByTrigger(trigger)
+      )
     );
   }, callback);
 };

--- a/draft-js-mention-plugin/src/mentionSuggestionsStrategy.js
+++ b/draft-js-mention-plugin/src/mentionSuggestionsStrategy.js
@@ -30,14 +30,17 @@ const findWithRegex = (regex, contentBlock, callback) => {
 };
 
 export default (
-  trigger: string,
+  triggers: Array<string>,
   supportWhiteSpace: boolean,
   regExp: string
 ) => {
+  const triggerPattern = `[${triggers
+    .map(trigger => escapeRegExp(trigger))
+    .join('')}]`;
   //eslint-disable-line
   const MENTION_REGEX = supportWhiteSpace
-    ? new RegExp(`${escapeRegExp(trigger)}(${regExp}|\\s){0,}`, 'g')
-    : new RegExp(`(\\s|^)${escapeRegExp(trigger)}${regExp}`, 'g');
+    ? new RegExp(`${triggerPattern}(${regExp}|\\s){0,}`, 'g')
+    : new RegExp(`(\\s|^)${triggerPattern}${regExp}`, 'g');
 
   return (contentBlock: Object, callback: Function) => {
     findWithRegex(MENTION_REGEX, contentBlock, callback);

--- a/draft-js-mention-plugin/src/modifiers/addMention.js
+++ b/draft-js-mention-plugin/src/modifiers/addMention.js
@@ -17,11 +17,9 @@ const addMention = (
   const entityKey = contentStateWithEntity.getLastCreatedEntityKey();
 
   const currentSelectionState = editorState.getSelection();
-  const { begin, end } = getSearchText(
-    editorState,
-    currentSelectionState,
-    mentionTrigger
-  );
+  const { begin, end } = getSearchText(editorState, currentSelectionState, [
+    mentionTrigger,
+  ]);
 
   // get selection of the @mention search text
   const mentionTextSelection = currentSelectionState.merge({

--- a/draft-js-mention-plugin/src/utils/__test__/getSearchTextAt.js
+++ b/draft-js-mention-plugin/src/utils/__test__/getSearchTextAt.js
@@ -1,37 +1,38 @@
 import { expect } from 'chai';
 import getSearchTextAt from '../getSearchTextAt';
 
-const trigger = '@';
-
 describe('getSearchTextAt', () => {
   it('finds the matching string following trigger', () => {
-    const expected = {
+    expect(getSearchTextAt('hi @The Walking Dead', 20, ['@'])).to.deep.equal({
       matchingString: 'The Walking Dead',
       begin: 3,
       end: 20,
-    };
-    expect(getSearchTextAt('hi @The Walking Dead', 20, trigger)).to.deep.equal(
-      expected
-    );
+    });
   });
 
   it('finds the matching string following trigger upto the position only', () => {
-    const expected = {
+    expect(getSearchTextAt('hi @The Walking Dead', 15, ['@'])).to.deep.equal({
       matchingString: 'The Walking',
       begin: 3,
       end: 15,
-    };
-    expect(getSearchTextAt('hi @The Walking Dead', 15, trigger)).to.deep.equal(
-      expected
-    );
+    });
   });
 
   it('finds the matching string following empty trigger', () => {
-    const expected = {
+    expect(getSearchTextAt('Max', 3, [''])).to.deep.equal({
       matchingString: 'Max',
       begin: 0,
       end: 3,
-    };
-    expect(getSearchTextAt('Max', 3, '')).to.deep.equal(expected);
+    });
+  });
+
+  it('finds the appropriate matching string despite multiple triggers', () => {
+    expect(
+      getSearchTextAt('one @two three #four five', 20, ['@', '#'])
+    ).to.deep.equal({
+      matchingString: 'four',
+      begin: 15,
+      end: 20,
+    });
   });
 });

--- a/draft-js-mention-plugin/src/utils/getSearchText.js
+++ b/draft-js-mention-plugin/src/utils/getSearchText.js
@@ -1,10 +1,10 @@
 import getSearchTextAt from './getSearchTextAt';
 
-export default (editorState, selection, trigger) => {
+export default (editorState, selection, triggers) => {
   const anchorKey = selection.getAnchorKey();
   const anchorOffset = selection.getAnchorOffset();
   const currentContent = editorState.getCurrentContent();
   const currentBlock = currentContent.getBlockForKey(anchorKey);
   const blockText = currentBlock.getText();
-  return getSearchTextAt(blockText, anchorOffset, trigger);
+  return getSearchTextAt(blockText, anchorOffset, triggers);
 };

--- a/draft-js-mention-plugin/src/utils/getSearchTextAt.js
+++ b/draft-js-mention-plugin/src/utils/getSearchTextAt.js
@@ -3,11 +3,19 @@
 /**
  * Return tail end of the string matching trigger upto the position.
  */
-export default (blockText: string, position: number, trigger: string) => {
+export default (blockText: string, position: number, triggers: Array<string>) => {
   const str = blockText.substr(0, position);
-  const begin = trigger.length === 0 ? 0 : str.lastIndexOf(trigger);
+
+  const { begin, index } = triggers
+    .map((trigger, triggerIndex) => ({
+      begin: trigger.length === 0 ? 0 : str.lastIndexOf(trigger),
+      index: triggerIndex,
+    }))
+    .reduce((left, right) => (left.begin >= right.begin ? left : right));
   const matchingString =
-    trigger.length === 0 ? str : str.slice(begin + trigger.length);
+    triggers[index].length === 0
+      ? str
+      : str.slice(begin + triggers[index].length);
   const end = str.length;
 
   return {

--- a/stories/mentions-custom-trigger/src/App.js
+++ b/stories/mentions-custom-trigger/src/App.js
@@ -7,7 +7,7 @@ import createMentionPlugin, {
 import editorStyles from './editorStyles.css';
 import mentions from './mentions';
 
-const mentionPlugin = createMentionPlugin({ mentionTrigger: '(' });
+const mentionPlugin = createMentionPlugin({ mentionTriggers: ['@', '#'] });
 const { MentionSuggestions } = mentionPlugin;
 const plugins = [mentionPlugin];
 
@@ -15,7 +15,9 @@ export default class SimpleMentionEditor extends Component {
   state = {
     open: false,
     editorState: EditorState.createWithContent(
-      ContentState.createFromText('Type ( to make the mention dropdown appear')
+      ContentState.createFromText(
+        'Type @ or # to make the mention dropdown appear'
+      )
     ),
     suggestions: mentions,
   };


### PR DESCRIPTION
## Checklist

- [✓] Fix any eslint errors that occur
- [✓] Update change-log for every plugin you touch
- [✓] Add/Update tests if you add/change new functionality
- [?] Add/Update docs if you add/change functionality
- [✓] Enable "Allow edits from maintainers" for this PR

^ There aren't any docs for this plugin, but it is fairly straightforward (see the implementation section below).

## Use-case

Issue = #1418 

I'm working on a personal app that requires a rich text editor, for which I'm using DraftJS and plugins. In addition to be able to @mention people (which provides that nice typeahead experience), I also want the same for #hashtags and additional entities like $documents or something.

## Implementation

* MentionSuggestionsPortal (`draft-js-mention-plugin/src/mentionStrategy.js`) is a decorator that marks already-created or potential mention entities. I modified the regex it uses to handle a list of triggers, instead of a single one.
* The MentionSuggestions component (`draft-js-mention-plugin/src/MentionSuggestions/index.js`) goes through each "marked" item, checks to see if the current selection (aka text cursor position) is inside the appropriate range, and if yes, shows the dropdown. Since it already stores the active "marked" item, I modified it to also store the active trigger. This is provided to the `onSearchChange` (surfaces to the application) and the `addMention` method, which uses it to figure out the entity type to use in the editorState.
* I also modified the other decorator (`draft-js-mention-plugin/src/mentionSuggestionsStrategy.js`), which is used for styling mention entities, to recognize the addition triggers.
* Those were the major changes, rest of the updates were mostly signature changes to support a `Array<string>` instead of a plain `string`. I also updated the storybook example that I was using for testing.

## Demo

![Demo](https://i.imgur.com/YbMQ8pE.gif)