### PR TITLE
fix getreadonly problem

### DIFF
--- a/draft-js-plugins-editor/src/Editor/index.js
+++ b/draft-js-plugins-editor/src/Editor/index.js
@@ -130,7 +130,7 @@ class PluginEditor extends Component {
   getProps = () => ({ ...this.props });
 
   // TODO further down in render we use readOnly={this.props.readOnly || this.state.readOnly}. Ask Ben why readOnly is here just from the props? Why would plugins use this instead of just taking it from getProps?
-  getReadOnly = () => this.props.readOnly;
+  getReadOnly = () => this.props.readOnly || this.state.readOnly;
   setReadOnly = readOnly => {
     if (readOnly !== this.state.readOnly) this.setState({ readOnly });
   };


### PR DESCRIPTION
## Checklist

- [x] Fix any eslint errors that occur
- [ ] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

I'm trying read whether the editor is in readOnly mode or not (from my plugin). But I can't do it since all I can read is whether I've given a `readOnly` prop or not. But readOnly is a state field. I can't reach it this way. 

## Implementation 

This way to do it is just fine: 

```js
  getReadOnly = () => this.props.readOnly || this.state.readOnly;
```