### PR TITLE
check whether getReadOnly is undefined

### DIFF
--- a/draft-js-resizeable-plugin/src/createDecorator.js
+++ b/draft-js-resizeable-plugin/src/createDecorator.js
@@ -205,13 +205,14 @@ export default ({ config, store }) => WrappedComponent =>
         styles.cursor = 'default';
       }
 
-      const interactionProps = store.getReadOnly()
-        ? {}
-        : {
-            onMouseDown: this.mouseDown,
-            onMouseMove: this.mouseMove,
-            onMouseLeave: this.mouseLeave,
-          };
+      const interactionProps = 
+        !store.getReadOnly || store.getReadOnly()
+          ? {}
+          : {
+              onMouseDown: this.mouseDown,
+              onMouseMove: this.mouseMove,
+              onMouseLeave: this.mouseLeave,
+            };
 
       return (
         <WrappedComponent


### PR DESCRIPTION
Please check out Contributing Guidelines. By following this template you help us to review your code.
https://github.com/draft-js-plugins/draft-js-plugins/blob/master/CONTRIBUTING.md

## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

The same issue that was described in [#926](https://github.com/draft-js-plugins/draft-js-plugins/issues/926), but in a different plugin. In some cases a re-render happens earlier than initialization, which causes store.getReadOnly to be undefined, so calling it results in an error.

## Implementation

Check whether store.getReadOnly is defined first, and only call it if it is.
If it isn't defined, assume that it's read only.