### PR TITLE
inline-toolbar: Try getting the relative parent window object first, …

### DIFF
--- a/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
+++ b/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
@@ -73,7 +73,8 @@ export default class Toolbar extends React.Component {
       }
       const editorRootRect = editorRoot.getBoundingClientRect();
 
-      const selectionRect = getVisibleSelectionRect(window);
+      const parentWindow = editorRoot.ownerDocument && editorRoot.ownerDocument.defaultView;
+      const selectionRect = getVisibleSelectionRect(parentWindow || window);
       if (!selectionRect) return;
 
       // The toolbar shouldn't be positioned directly on top of the selected text,


### PR DESCRIPTION
The toolbar isn't positioned according to the selected text because it should be using the iframe window object and not the main window.