### PR TITLE
#1393 Apply decorators and set the selection after rendering

### DIFF
--- a/draft-js-plugins-editor/CHANGELOG.md
+++ b/draft-js-plugins-editor/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Replace legacy lifecycle hooks with UNSAFE aliases; the required react version is 16.3
 - Hide internals in single bundle
 - Add esm support
+- Apply decorators and set selection after initial rendering to prevent `onChange` to trigger during the render cycle
 
 ## 3.0.0
 

--- a/draft-js-plugins-editor/src/Editor/index.js
+++ b/draft-js-plugins-editor/src/Editor/index.js
@@ -63,7 +63,7 @@ class PluginEditor extends Component {
     this.state = {}; // TODO for Nik: ask ben why this is relevent
   }
 
-  UNSAFE_componentWillMount() {
+  componentDidMount() {
     const decorator = resolveDecorators(
       this.props,
       this.getEditorState,


### PR DESCRIPTION
Apply decorators and set selection after initial rendering to prevent `onChange` to trigger during the render cycle, as this now results in ["Warning: Cannot update a component from inside the function body of a different component."](https://reactjs.org/blog/2020/02/26/react-v16.13.0.html#warnings-for-some-updates-during-render). 

**The problem**

Many people will have the `onChange` callback hooked up to some state setter on the editor, i.e.

```javascript
const [editorState, setEditorState] = useState(..);

return <Editor onChange={(newEditorState) => setEditorState(newEditorState)} editorState={editorState} />
```

As `onChange` is called during rendering [in the Editor](https://github.com/draft-js-plugins/draft-js-plugins/blob/master/draft-js-plugins-editor/src/Editor/index.js#L74), when it is hooked up to a state setter, this will result in the console warning:

> ["Warning: Cannot update a component from inside the function body of a different component."](https://reactjs.org/blog/2020/02/26/react-v16.13.0.html#warnings-for-some-updates-during-render)

To prevent this, I moved these lines to `componentDidMount`. 

Todo:

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [ ] Add/Update tests if you add/change new functionality
- [ ] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

Help is wanted, as at this point I don't even get `pre-commit` hooks and testing working locally..