### PR TITLE
Update createEditorStateWithText.js

### DIFF
--- a/draft-js-plugins-editor/src/utils/createEditorStateWithText.js
+++ b/draft-js-plugins-editor/src/utils/createEditorStateWithText.js
@@ -4,5 +4,6 @@
 
 import { ContentState, EditorState } from 'draft-js';
 
-export default text =>
-  EditorState.createWithContent(ContentState.createFromText(text));
+export default text => EditorState.createWithText
+  ? EditorState.createWithText(text)
+  : EditorState.createWithContent(ContentState.createFromText(text));


### PR DESCRIPTION
## Checklist

- [N/A] Fix any eslint errors that occur
- [N/A] Update change-log for every plugin you touch
- [N/A] Add/Update tests if you add/change new functionality
- [N/A] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem
`draft-js` introduced a built-in way to create `EditorState` by text in https://github.com/facebook/draft-js/commit/fc9395f.

## Implementation
Since it's only available since `draft-js@0.11.7` and the `peerDependencies` allow `0.11.x`, I did a check before using the new one.

Whenever it's decided to upgrade the `peerDependencies`, this check can be removed