### PR TITLE
[draft-js-mention-plugin] add support for vietnamese characters

### DIFF
--- a/draft-js-mention-plugin/src/defaultRegExp.js
+++ b/draft-js-mention-plugin/src/defaultRegExp.js
@@ -22,4 +22,6 @@ export default '[' +
   '\u4e00-\u9eff' +
   // Arabic https://en.wikipedia.org/wiki/Arabic_(Unicode_block)
   '\u0600-\u06ff' +
+  // Vietnamese http://vietunicode.sourceforge.net/charset/
+  '\u00C0-\u1EF9' +
   ']*';


### PR DESCRIPTION
add vietnamese trigger for mention plugin.
Characters are listed in here: http://vietunicode.sourceforge.net/charset/

Thank you :)