### PR TITLE
Suggestions trigger rule

### DIFF
--- a/draft-js-mention-plugin/src/MentionSuggestions/MentionSuggestions.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/MentionSuggestions.js
@@ -122,7 +122,7 @@ export class MentionSuggestions extends Component {
               'g'
             ).test(plainText) &&
             anchorOffset <= end) || // @ is the first character
-          (anchorOffset > start + this.props.mentionTrigger.length &&
+          (anchorOffset >= start + this.props.mentionTrigger.length &&
             anchorOffset <= end) // @ is in the text or at the end
       );
 


### PR DESCRIPTION
Open suggestions without leading space or character after mention trigger (when support for whitespace is enabled).
Change duplicated with: https://github.com/draft-js-plugins/draft-js-plugins/pull/1374