### PR TITLE
use getEditorState and setEditorState from the store in the EmojiSuggestionsPortal component

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,0 @@
-## Use-case/Problem
-
-- If you think a feature should be added to draft-js-plugins please provide a description of the use-case.
-- If you found a bug please reproduce it within a [codesandbox](codesandbox.io), this'll make it easier for us to help you. Here's an [example that uses the mentions plugin](https://codesandbox.io/s/MjG72jX2R) - this will help get you started
-
-Please note: The draft js plugins core team is very small and there's not that much time on our hands. If you can help fix this issue, please do, there's usually someone available in the draft-js-plugins channel [on slack](https://draftjs.herokuapp.com/) for pairing.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: '🐛 Report a bug'
+about: 'Report a reproducible bug or reproducible regression.'
+labels: 'bug'
+---
+
+## Environment
+
+<!--
+All necessary environmental info that will help triage this
+-->
+
+<!--
+Especially include:
+-->
+
+- @draft-js-plugins/editor version:
+- plugin name and version:
+
+## Description
+
+<!--
+Describe your issue in detail.
+Include screenshots if needed.
+If this is a regression, let us know.
+-->
+
+## Reproducible Demo
+
+<!--
+Please add a reproduce within [codesandbox](codesandbox.io), this'll make it easier for us to help you.
+Here's an [example that uses the mentions plugin](https://codesandbox.io/s/MjG72jX2R) - this will help get you started
+-->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,4 +2,4 @@ blank_issues_enabled: false
 contact_links:
   - name: 🤔 Questions and Help
     url: https://draftjs.herokuapp.com/
-    about: Join the channel #draft-js-plugins after signing into the DraftJS Slack organization
+    about: "Join the channel #draft-js-plugins after signing into the DraftJS Slack organization"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 🤔 Questions and Help
+    url: https://draftjs.herokuapp.com/
+    about: Join the channel #draft-js-plugins after signing into the DraftJS Slack organization

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: '💬 Feature request'
+about: Suggest introduction of a new feature.
+labels: 'feature request'
+---
+
+## Describe the feature
+
+<!-- Describe what you would like to introduce -->
+
+## Motivation
+
+<!-- Describe what problem the feature solves -->
+
+## Possible implementations
+
+<!-- Describe how the feature could be implemented -->
+
+## Related Issues
+
+<!-- Link related issues here -->

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "react": "^16.14.0",
     "react-custom-scrollbars": "^4.1.1",
     "react-dom": "^16.9.0",
-    "tlds": "^1.197.0",
+    "tlds": "^1.212.0",
     "to-style": "^1.3.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "react": "^16.14.0",
     "react-custom-scrollbars": "^4.1.1",
     "react-dom": "^16.9.0",
-    "react-icons": "^2.2.3",
     "tlds": "^1.197.0",
     "to-style": "^1.3.3"
   },

--- a/packages/anchor/package.json
+++ b/packages/anchor/package.json
@@ -41,7 +41,7 @@
     "@draft-js-plugins/utils": "^4.0.0-beta2",
     "prepend-http": "3",
     "prop-types": "^15.5.8",
-    "tlds": "^1.197.0"
+    "tlds": "^1.212.0"
   },
   "peerDependencies": {
     "draft-js": "^0.10.1 || ^0.11.0",

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To be released
 
+- Change UNSAFE_componentWillReceiveProps to componentDidUpdate; fix https://reactjs.org/blog/2020/02/26/react-v16.13.0.html#warnings-for-some-updates-during-render
 - Replace legacy lifecycle hooks with UNSAFE aliases; the required react version is 16.3
 - Hide internals in single bundle
 - Add esm support

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draft-js-plugins/editor",
-  "version": "4.0.0-beta2",
+  "version": "4.0.0-beta3",
   "description": "Editor for DraftJS Plugins",
   "author": {
     "name": "Nik Graf",

--- a/packages/editor/src/Editor/index.tsx
+++ b/packages/editor/src/Editor/index.tsx
@@ -108,9 +108,9 @@ class PluginEditor extends Component<PluginEditorProps> {
     this.onChange(moveSelectionToEnd(editorState));
   }
 
-  UNSAFE_componentWillReceiveProps(next: PluginEditorProps): void {
-    const curr = this.props;
-    const currDec = curr.editorState.getDecorator();
+  componentDidUpdate(prevProps: PluginEditorProps): void {
+    const next = this.props;
+    const currDec = prevProps.editorState.getDecorator();
     const nextDec = next.editorState.getDecorator();
 
     // If there is not current decorator, there's nothing to carry over to the next editor state

--- a/packages/emoji/CHANGELOG.md
+++ b/packages/emoji/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add esm support
 - Use lodash-es in esm bundle
 - convert to typescript
+- use the setEditorState and getEditorState functions from props.store in EmojiSuggestionsPortal
 
 ## 2.1.3
 

--- a/packages/emoji/package.json
+++ b/packages/emoji/package.json
@@ -36,8 +36,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "clsx": "^1.0.4",
     "@draft-js-plugins/buttons": "^4.0.0-beta2",
+    "clsx": "^1.0.4",
     "emojione": "^2.2.7",
     "find-with-regex": "^1.1.3",
     "immutable": "~3.8.2",
@@ -45,7 +45,7 @@
     "lodash-es": "^4.17.15",
     "prop-types": "^15.5.8",
     "react-custom-scrollbars": "^4.2.0",
-    "react-icons": "^2.2.6",
+    "react-icons": "^3.11.0",
     "to-style": "^1.3.3"
   },
   "peerDependencies": {

--- a/packages/emoji/package.json
+++ b/packages/emoji/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draft-js-plugins/emoji",
-  "version": "4.0.0-beta2",
+  "version": "4.0.0-beta3",
   "description": "Emoji Plugin for DraftJS",
   "author": {
     "name": "Nik Graf",
@@ -37,6 +37,7 @@
   "license": "MIT",
   "dependencies": {
     "@draft-js-plugins/buttons": "^4.0.0-beta2",
+    "@draft-js-plugins/utils": "^4.0.0-beta2",
     "clsx": "^1.0.4",
     "emojione": "^2.2.7",
     "find-with-regex": "^1.1.3",

--- a/packages/emoji/src/components/EmojiSuggestions/index.tsx
+++ b/packages/emoji/src/components/EmojiSuggestions/index.tsx
@@ -21,12 +21,11 @@ import { PositionSuggestionsParams } from '../../utils/positionSuggestions';
 import { EmojiPluginTheme } from '../../theme';
 
 export interface EmojiSuggestionsPubParams {
-  isActive: boolean;
-  focusedOptionIndex: number;
-  suggestions: unknown[];
-  onClose(): void;
-  onOpen(): void;
-  onSearchChange(change: { value: string }): void;
+  isActive?: boolean;
+  focusedOptionIndex?: number;
+  onClose?(): void;
+  onOpen?(): void;
+  onSearchChange?(change: { value: string }): void;
 }
 
 interface EmojiSuggestionsParams extends EmojiSuggestionsPubParams {

--- a/packages/emoji/src/components/EmojiSuggestionsPortal/index.tsx
+++ b/packages/emoji/src/components/EmojiSuggestionsPortal/index.tsx
@@ -18,7 +18,7 @@ export default class EmojiSuggestionsPortal extends Component<
     this.updatePortalClientRect(this.props);
 
     // trigger a re-render so the EmojiSuggestions becomes active
-    this.props.setEditorState(this.props.getEditorState());
+    this.props.store.setEditorState(this.props.store.getEditorState());
   }
 
   UNSAFE_componentWillReceiveProps(

--- a/packages/emoji/src/components/EmojiSuggestionsPortal/index.tsx
+++ b/packages/emoji/src/components/EmojiSuggestionsPortal/index.tsx
@@ -18,7 +18,7 @@ export default class EmojiSuggestionsPortal extends Component<
     this.updatePortalClientRect(this.props);
 
     // trigger a re-render so the EmojiSuggestions becomes active
-    this.props.store.setEditorState(this.props.store.getEditorState());
+    this.props.store.setEditorState!(this.props.store.getEditorState!());
   }
 
   UNSAFE_componentWillReceiveProps(

--- a/packages/emoji/src/constants/defaultEmojiGroups.tsx
+++ b/packages/emoji/src/constants/defaultEmojiGroups.tsx
@@ -1,18 +1,21 @@
 import React from 'react';
-import FaSmileO from 'react-icons/lib/fa/smile-o';
-import FaPaw from 'react-icons/lib/fa/paw';
-import FaCutlery from 'react-icons/lib/fa/cutlery';
-import FaFutbolO from 'react-icons/lib/fa/futbol-o';
-import FaPlane from 'react-icons/lib/fa/plane';
-import FaBell from 'react-icons/lib/fa/bell';
-import FaHeart from 'react-icons/lib/fa/heart';
-import FaFlag from 'react-icons/lib/fa/flag';
+import {
+  FaSmile,
+  FaPaw,
+  FaUtensils,
+  FaFutbol,
+  FaPlane,
+  FaBell,
+  FaHeart,
+  FaFlag,
+} from 'react-icons/fa';
+
 import { EmojiSelectGroup } from '../index';
 
 const defaultEmojiGroups: EmojiSelectGroup[] = [
   {
     title: 'People',
-    icon: <FaSmileO style={{ verticalAlign: '' }} />,
+    icon: <FaSmile style={{ verticalAlign: '' }} />,
     categories: ['people'],
   },
   {
@@ -22,12 +25,12 @@ const defaultEmojiGroups: EmojiSelectGroup[] = [
   },
   {
     title: 'Food & Drink',
-    icon: <FaCutlery style={{ verticalAlign: '' }} />,
+    icon: <FaUtensils style={{ verticalAlign: '' }} />,
     categories: ['food'],
   },
   {
     title: 'Activity',
-    icon: <FaFutbolO style={{ verticalAlign: '' }} />,
+    icon: <FaFutbol style={{ verticalAlign: '' }} />,
     categories: ['activity'],
   },
   {

--- a/packages/linkify/package.json
+++ b/packages/linkify/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "clsx": "^1.0.4",
     "linkify-it": "^2.0.3",
-    "tlds": "^1.189.0"
+    "tlds": "^1.212.0"
   },
   "peerDependencies": {
     "draft-js": "^0.10.1 || ^0.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14107,24 +14107,12 @@ react-hotkeys@2.0.0:
   dependencies:
     prop-types "^15.6.1"
 
-react-icon-base@2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/react-icon-base/-/react-icon-base-2.1.0.tgz#a196e33fdf1e7aaa1fda3aefbb68bdad9e82a79d"
-  integrity sha1-oZbjP98eeqof2jrvu2i9rZ6Cp50=
-
-react-icons@*:
+react-icons@*, react-icons@^3.11.0:
   version "3.11.0"
   resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-3.11.0.tgz#2ca2903dfab8268ca18ebd8cc2e879921ec3b254"
   integrity sha512-JRgiI/vdF6uyBgyZhVyYJUZAop95Sy4XDe/jmT3R/bKliFWpO/uZBwvSjWEdxwzec7SYbEPNPck0Kff2tUGM2Q==
   dependencies:
     camelcase "^5.0.0"
-
-react-icons@^2.2.3, react-icons@^2.2.6:
-  version "2.2.7"
-  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-2.2.7.tgz#d7860826b258557510dac10680abea5ca23cf650"
-  integrity sha512-0n4lcGqzJFcIQLoQytLdJCE0DKSA9dkwEZRYoGrIDJZFvIT6Hbajx5mv9geqhqFiNjUgtxg8kPyDfjlhymbGFg==
-  dependencies:
-    react-icon-base "2.1.0"
 
 react-is@^16.12.0, react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.3, react-is@^16.8.6:
   version "16.13.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16179,10 +16179,10 @@ tinycolor2@^1.4.1:
   resolved "https://registry.yarnpkg.com/tinycolor2/-/tinycolor2-1.4.1.tgz#f4fad333447bc0b07d4dc8e9209d8f39a8ac77e8"
   integrity sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g=
 
-tlds@^1.189.0, tlds@^1.197.0:
-  version "1.209.0"
-  resolved "https://registry.yarnpkg.com/tlds/-/tlds-1.209.0.tgz#13cfdc039331d49730ca7bfa9526fc9b319e2cec"
-  integrity sha512-KVsZ1NSpBodpo42/JIwTyau7SqUxV/qQMp2epSDPa99885LpHWLaVCCt8CWzGe4X5YIVNr+b6bUys9e9eEb5OA==
+tlds@^1.212.0:
+  version "1.212.0"
+  resolved "https://registry.yarnpkg.com/tlds/-/tlds-1.212.0.tgz#f3f29bd5d10d0fd9a6f171a5f9d57d58b71eccf7"
+  integrity sha512-03rYYO1rGhOYpdYB+wlLY2d0xza6hdN/S67ol2ZpaH+CtFedMVAVhj8ft0rwxEkr90zatou8opBv7Xp6X4cK6g==
 
 tmp@^0.0.33:
   version "0.0.33"


### PR DESCRIPTION
Please check out Contributing Guidelines. By following this template you help us to review your code.
https://github.com/draft-js-plugins/draft-js-plugins/blob/master/CONTRIBUTING.md

## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

Fixes https://github.com/draft-js-plugins/draft-js-plugins/issues/1234
The problem: The EmojiSuggestionsPortal component tries to access the setEditorState and getEditorState from `this.props`, but these functions are not reliably there.

## Implementation

These functions are always available in `this.props.store` of that component. So my fix is to take them from there. Analog to how the EmojiSuggestions component does it.