### PR TITLE
Remove build in prepublish

### DIFF
--- a/packages/alignment/package.json
+++ b/packages/alignment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draft-js-plugins/alignment",
-  "version": "4.0.0-beta1",
+  "version": "4.0.0-beta2",
   "description": "Alignment Plugin for DraftJS",
   "author": {
     "name": "Benjamin Kniffler",
@@ -31,13 +31,12 @@
     "build": "yarn build:js && yarn build:dts && yarn build:css",
     "build:js": "yarn rollup --config ../../rollup.config.js",
     "build:dts": "tsc -d",
-    "build:css": "node ../../scripts/build-css.js $(pwd)",
-    "prepublish": "yarn build"
+    "build:css": "node ../../scripts/build-css.js $(pwd)"
   },
   "license": "MIT",
   "dependencies": {
-    "@draft-js-plugins/buttons": "^4.0.0-beta1",
-    "@draft-js-plugins/utils": "^4.0.0-beta1"
+    "@draft-js-plugins/buttons": "^4.0.0-beta2",
+    "@draft-js-plugins/utils": "^4.0.0-beta2"
   },
   "peerDependencies": {
     "draft-js": "^0.10.1 || ^0.11.0",

--- a/packages/anchor/package.json
+++ b/packages/anchor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draft-js-plugins/anchor",
-  "version": "4.0.0-beta1",
+  "version": "4.0.0-beta2",
   "description": "Link Plugin for DraftJS",
   "author": {
     "name": "Jan Amann",
@@ -33,13 +33,12 @@
     "build": "yarn build:js && yarn build:dts && yarn build:css",
     "build:js": "yarn rollup --config ../../rollup.config.js",
     "build:dts": "tsc -d",
-    "build:css": "node ../../scripts/build-css.js $(pwd)",
-    "prepublish": "yarn build"
+    "build:css": "node ../../scripts/build-css.js $(pwd)"
   },
   "license": "MIT",
   "dependencies": {
     "clsx": "^1.0.4",
-    "@draft-js-plugins/utils": "^4.0.0-beta1",
+    "@draft-js-plugins/utils": "^4.0.0-beta2",
     "prepend-http": "3",
     "prop-types": "^15.5.8",
     "tlds": "^1.197.0"

--- a/packages/buttons/package.json
+++ b/packages/buttons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draft-js-plugins/buttons",
-  "version": "4.0.0-beta1",
+  "version": "4.0.0-beta2",
   "description": "Buttons for DraftJS",
   "author": {
     "name": "Nik Graf",
@@ -30,8 +30,7 @@
     "clean": "yarn rimraf lib",
     "build": "yarn build:js && yarn build:dts",
     "build:js": "yarn rollup --config ../../rollup.config.js",
-    "build:dts": "tsc -d",
-    "prepublish": "yarn build"
+    "build:dts": "tsc -d"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/counter/package.json
+++ b/packages/counter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draft-js-plugins/counter",
-  "version": "4.0.0-beta1",
+  "version": "4.0.0-beta2",
   "description": "Counter Plugin for DraftJS",
   "author": {
     "name": "Adrian Li",
@@ -32,8 +32,7 @@
     "build": "yarn build:js && yarn build:dts && yarn build:css",
     "build:js": "yarn rollup --config ../../rollup.config.js",
     "build:dts": "tsc -d --emitDeclarationOnly --declarationDir lib",
-    "build:css": "node ../../scripts/build-css.js $(pwd)",
-    "prepublish": "yarn build"
+    "build:css": "node ../../scripts/build-css.js $(pwd)"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/divider/package.json
+++ b/packages/divider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draft-js-plugins/divider",
-  "version": "4.0.0-beta1",
+  "version": "4.0.0-beta2",
   "description": "Divider Plugin for DraftJS",
   "author": {
     "name": "Ilkwon Sim",
@@ -32,8 +32,7 @@
     "build": "yarn build:js && yarn build:dts && yarn build:css",
     "build:js": "yarn rollup --config ../../rollup.config.js",
     "build:dts": "tsc -d",
-    "build:css": "node ../../scripts/build-css.js $(pwd)",
-    "prepublish": "yarn build"
+    "build:css": "node ../../scripts/build-css.js $(pwd)"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/drag-n-drop-upload/package.json
+++ b/packages/drag-n-drop-upload/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draft-js-plugins/drag-n-drop-upload",
-  "version": "4.0.0-beta1",
+  "version": "4.0.0-beta2",
   "description": "Dropping & uploading files with DraftJS",
   "author": {
     "name": "Benjamin Kniffler",
@@ -30,8 +30,7 @@
     "clean": "yarn rimraf lib",
     "build": "yarn build:js && yarn build:dts",
     "build:js": "yarn rollup --config ../../rollup.config.js",
-    "build:dts": "tsc -d",
-    "prepublish": "yarn build"
+    "build:dts": "tsc -d"
   },
   "license": "MIT",
   "peerDependencies": {

--- a/packages/drag-n-drop/package.json
+++ b/packages/drag-n-drop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draft-js-plugins/drag-n-drop",
-  "version": "4.0.0-beta1",
+  "version": "4.0.0-beta2",
   "description": "Block Drag & Drop Plugin for DraftJS",
   "author": {
     "name": "Benjamin Kniffler",
@@ -30,8 +30,7 @@
     "clean": "yarn rimraf lib",
     "build": "yarn build:js && yarn build:dts",
     "build:js": "yarn rollup --config ../../rollup.config.js",
-    "build:dts": "tsc -d",
-    "prepublish": "yarn build"
+    "build:dts": "tsc -d"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draft-js-plugins/editor",
-  "version": "4.0.0-beta1",
+  "version": "4.0.0-beta2",
   "description": "Editor for DraftJS Plugins",
   "author": {
     "name": "Nik Graf",
@@ -31,8 +31,7 @@
     "clean": "yarn rimraf lib",
     "build": "yarn build:js && yarn build:dts",
     "build:js": "yarn rollup --config ../../rollup.config.js",
-    "build:dts": "tsc -d",
-    "prepublish": "yarn build"
+    "build:dts": "tsc -d"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/emoji/package.json
+++ b/packages/emoji/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draft-js-plugins/emoji",
-  "version": "4.0.0-beta1",
+  "version": "4.0.0-beta2",
   "description": "Emoji Plugin for DraftJS",
   "author": {
     "name": "Nik Graf",
@@ -32,13 +32,12 @@
     "build": "yarn build:js && yarn build:dts && yarn build:css",
     "build:js": "yarn rollup --config ../../rollup.config.js",
     "build:dts": "tsc -d --emitDeclarationOnly --declarationDir lib",
-    "build:css": "node ../../scripts/build-css.js $(pwd)",
-    "prepublish": "yarn build"
+    "build:css": "node ../../scripts/build-css.js $(pwd)"
   },
   "license": "MIT",
   "dependencies": {
     "clsx": "^1.0.4",
-    "@draft-js-plugins/buttons": "^4.0.0-beta1",
+    "@draft-js-plugins/buttons": "^4.0.0-beta2",
     "emojione": "^2.2.7",
     "find-with-regex": "^1.1.3",
     "immutable": "~3.7.4",

--- a/packages/focus/package.json
+++ b/packages/focus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draft-js-plugins/focus",
-  "version": "4.0.0-beta1",
+  "version": "4.0.0-beta2",
   "description": "Focus Plugin for DraftJS",
   "author": {
     "name": "Benjamin Kniffler",
@@ -31,8 +31,7 @@
     "build": "yarn build:js && yarn build:dts && yarn build:css",
     "build:js": "yarn rollup --config ../../rollup.config.js",
     "build:dts": "tsc -d --emitDeclarationOnly --declarationDir lib",
-    "build:css": "node ../../scripts/build-css.js $(pwd)",
-    "prepublish": "yarn build"
+    "build:css": "node ../../scripts/build-css.js $(pwd)"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/hashtag/package.json
+++ b/packages/hashtag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draft-js-plugins/hashtag",
-  "version": "4.0.0-beta1",
+  "version": "4.0.0-beta2",
   "description": "Hashtag Plugin for DraftJS",
   "author": {
     "name": "Nik Graf",
@@ -32,8 +32,7 @@
     "build": "yarn build:js && yarn build:dts && yarn build:css",
     "build:js": "yarn rollup --config ../../rollup.config.js",
     "build:dts": "tsc -d --emitDeclarationOnly --declarationDir lib",
-    "build:css": "node ../../scripts/build-css.js $(pwd)",
-    "prepublish": "yarn build"
+    "build:css": "node ../../scripts/build-css.js $(pwd)"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draft-js-plugins/image",
-  "version": "4.0.0-beta1",
+  "version": "4.0.0-beta2",
   "description": "Image Plugin for DraftJS",
   "author": {
     "name": "Benjamin Kniffler",
@@ -31,8 +31,7 @@
     "build": "yarn build:js && yarn build:dts && yarn build:css",
     "build:js": "yarn rollup --config ../../rollup.config.js",
     "build:dts": "tsc -d --emitDeclarationOnly --declarationDir lib",
-    "build:css": "node ../../scripts/build-css.js $(pwd)",
-    "prepublish": "yarn build"
+    "build:css": "node ../../scripts/build-css.js $(pwd)"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/inline-toolbar/package.json
+++ b/packages/inline-toolbar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draft-js-plugins/inline-toolbar",
-  "version": "4.0.0-beta1",
+  "version": "4.0.0-beta2",
   "description": "Toolbar Plugin for DraftJS",
   "author": {
     "name": "Benjamin Kniffler",
@@ -31,13 +31,12 @@
     "build": "yarn build:js && yarn build:dts && yarn build:css",
     "build:js": "yarn rollup --config ../../rollup.config.js",
     "build:dts": "tsc -d --emitDeclarationOnly --declarationDir lib",
-    "build:css": "node ../../scripts/build-css.js $(pwd)",
-    "prepublish": "yarn build"
+    "build:css": "node ../../scripts/build-css.js $(pwd)"
   },
   "license": "MIT",
   "dependencies": {
-    "@draft-js-plugins/buttons": "^4.0.0-beta1",
-    "@draft-js-plugins/utils": "^4.0.0-beta1"
+    "@draft-js-plugins/buttons": "^4.0.0-beta2",
+    "@draft-js-plugins/utils": "^4.0.0-beta2"
   },
   "peerDependencies": {
     "draft-js": "^0.10.1 || ^0.11.0",

--- a/packages/linkify/package.json
+++ b/packages/linkify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draft-js-plugins/linkify",
-  "version": "4.0.0-beta1",
+  "version": "4.0.0-beta2",
   "description": "Linkify Plugin for DraftJS",
   "author": {
     "name": "Nik Graf",
@@ -32,8 +32,7 @@
     "build": "yarn build:js && yarn build:dts && yarn build:css",
     "build:js": "yarn rollup --config ../../rollup.config.js",
     "build:dts": "tsc -d",
-    "build:css": "node ../../scripts/build-css.js $(pwd)",
-    "prepublish": "yarn build"
+    "build:css": "node ../../scripts/build-css.js $(pwd)"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/mention/package.json
+++ b/packages/mention/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draft-js-plugins/mention",
-  "version": "4.0.0-beta1",
+  "version": "4.0.0-beta2",
   "description": "Mention Plugin for DraftJS",
   "author": {
     "name": "Nik Graf",
@@ -32,8 +32,7 @@
     "build": "yarn build:js && yarn build:dts && yarn build:css",
     "build:js": "yarn rollup --config ../../rollup.config.js",
     "build:dts": "tsc -d",
-    "build:css": "node ../../scripts/build-css.js $(pwd)",
-    "prepublish": "yarn build"
+    "build:css": "node ../../scripts/build-css.js $(pwd)"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/resizeable/package.json
+++ b/packages/resizeable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draft-js-plugins/resizeable",
-  "version": "4.0.0-beta1",
+  "version": "4.0.0-beta2",
   "description": "Resizeable Plugin for DraftJS",
   "author": {
     "name": "Benjamin Kniffler",
@@ -30,8 +30,7 @@
     "clean": "yarn rimraf lib",
     "build": "yarn build:js && yarn build:dts",
     "build:js": "yarn rollup --config ../../rollup.config.js",
-    "build:dts": "tsc -d",
-    "prepublish": "yarn build"
+    "build:dts": "tsc -d"
   },
   "license": "MIT",
   "peerDependencies": {

--- a/packages/side-toolbar/package.json
+++ b/packages/side-toolbar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draft-js-plugins/side-toolbar",
-  "version": "4.0.0-beta1",
+  "version": "4.0.0-beta2",
   "description": "Toolbar Plugin for DraftJS",
   "author": {
     "name": "Benjamin Kniffler",
@@ -31,13 +31,12 @@
     "build": "yarn build:js && yarn build:dts && yarn build:css",
     "build:js": "yarn rollup --config ../../rollup.config.js",
     "build:dts": "tsc -d",
-    "build:css": "node ../../scripts/build-css.js $(pwd)",
-    "prepublish": "yarn build"
+    "build:css": "node ../../scripts/build-css.js $(pwd)"
   },
   "license": "MIT",
   "dependencies": {
-    "@draft-js-plugins/buttons": "^4.0.0-beta1",
-    "@draft-js-plugins/utils": "^4.0.0-beta1",
+    "@draft-js-plugins/buttons": "^4.0.0-beta2",
+    "@draft-js-plugins/utils": "^4.0.0-beta2",
     "prop-types": "^15.5.8"
   },
   "peerDependencies": {

--- a/packages/static-toolbar/package.json
+++ b/packages/static-toolbar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draft-js-plugins/static-toolbar",
-  "version": "4.0.0-beta1",
+  "version": "4.0.0-beta2",
   "description": "Static Toolbar Plugin for DraftJS",
   "author": {
     "name": "Julian Krispel",
@@ -31,13 +31,12 @@
     "build": "yarn build:js && yarn build:dts && yarn build:css",
     "build:js": "yarn rollup --config ../../rollup.config.js",
     "build:dts": "tsc -d",
-    "build:css": "node ../../scripts/build-css.js $(pwd)",
-    "prepublish": "yarn build"
+    "build:css": "node ../../scripts/build-css.js $(pwd)"
   },
   "license": "MIT",
   "dependencies": {
-    "@draft-js-plugins/buttons": "^4.0.0-beta1",
-    "@draft-js-plugins/utils": "^4.0.0-beta1",
+    "@draft-js-plugins/buttons": "^4.0.0-beta2",
+    "@draft-js-plugins/utils": "^4.0.0-beta2",
     "prop-types": "^15.5.8"
   },
   "peerDependencies": {

--- a/packages/sticker/package.json
+++ b/packages/sticker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draft-js-plugins/sticker",
-  "version": "4.0.0-beta1",
+  "version": "4.0.0-beta2",
   "description": "Sticker Plugin for DraftJS",
   "author": {
     "name": "Nik Graf",
@@ -32,8 +32,7 @@
     "build": "yarn build:js && yarn build:dts && yarn build:css",
     "build:js": "yarn rollup --config ../../rollup.config.js",
     "build:dts": "tsc -d",
-    "build:css": "node ../../scripts/build-css.js $(pwd)",
-    "prepublish": "yarn build"
+    "build:css": "node ../../scripts/build-css.js $(pwd)"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/undo/package.json
+++ b/packages/undo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draft-js-plugins/undo",
-  "version": "4.0.0-beta1",
+  "version": "4.0.0-beta2",
   "description": "Undo Plugin for DraftJS",
   "author": {
     "name": "Nik Graf",
@@ -32,8 +32,7 @@
     "build": "yarn build:js && yarn build:dts && yarn build:css",
     "build:js": "yarn rollup --config ../../rollup.config.js",
     "build:dts": "tsc -d",
-    "build:css": "node ../../scripts/build-css.js $(pwd)",
-    "prepublish": "yarn build"
+    "build:css": "node ../../scripts/build-css.js $(pwd)"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draft-js-plugins/utils",
-  "version": "4.0.0-beta1",
+  "version": "4.0.0-beta2",
   "description": "Plugin utilities for draft js",
   "author": {
     "name": "Julian Krispel-Smasel",
@@ -30,8 +30,7 @@
     "clean": "yarn rimraf lib",
     "build": "yarn build:js && yarn build:dts",
     "build:js": "yarn rollup --config ../../rollup.config.js",
-    "build:dts": "tsc -d --emitDeclarationOnly --declarationDir lib",
-    "prepublish": "yarn build"
+    "build:dts": "tsc -d --emitDeclarationOnly --declarationDir lib"
   },
   "license": "MIT",
   "peerDependencies": {

--- a/packages/video/package.json
+++ b/packages/video/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draft-js-plugins/video",
-  "version": "4.0.0-beta1",
+  "version": "4.0.0-beta2",
   "description": "Video Plugin for DraftJS",
   "author": {
     "name": "Anchen li"
@@ -31,8 +31,7 @@
     "build": "yarn build:js && yarn build:dts && yarn build:css",
     "build:js": "yarn rollup --config ../../rollup.config.js",
     "build:dts": "tsc -d",
-    "build:css": "node ../../scripts/build-css.js $(pwd)",
-    "prepublish": "yarn build"
+    "build:css": "node ../../scripts/build-css.js $(pwd)"
   },
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

A new release currently exit with the following error

```
error parsing json: {ts,tsx}' -o /home/runner/work/draft-js-plugins/draft-js-plugins/packages/mention/lib-css
Successfully extracted 1 CSS files.
{
```

## Implementation

I removed the build step in prebuild as there is already a full build.
