### PR TITLE
Update to react icons 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "react": "^16.14.0",
     "react-custom-scrollbars": "^4.1.1",
     "react-dom": "^16.9.0",
-    "react-icons": "^2.2.3",
     "tlds": "^1.197.0",
     "to-style": "^1.3.3"
   },

--- a/packages/emoji/package.json
+++ b/packages/emoji/package.json
@@ -36,8 +36,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "clsx": "^1.0.4",
     "@draft-js-plugins/buttons": "^4.0.0-beta2",
+    "clsx": "^1.0.4",
     "emojione": "^2.2.7",
     "find-with-regex": "^1.1.3",
     "immutable": "~3.8.2",
@@ -45,7 +45,7 @@
     "lodash-es": "^4.17.15",
     "prop-types": "^15.5.8",
     "react-custom-scrollbars": "^4.2.0",
-    "react-icons": "^2.2.6",
+    "react-icons": "^3.11.0",
     "to-style": "^1.3.3"
   },
   "peerDependencies": {

--- a/packages/emoji/src/constants/defaultEmojiGroups.tsx
+++ b/packages/emoji/src/constants/defaultEmojiGroups.tsx
@@ -1,18 +1,21 @@
 import React from 'react';
-import FaSmileO from 'react-icons/lib/fa/smile-o';
-import FaPaw from 'react-icons/lib/fa/paw';
-import FaCutlery from 'react-icons/lib/fa/cutlery';
-import FaFutbolO from 'react-icons/lib/fa/futbol-o';
-import FaPlane from 'react-icons/lib/fa/plane';
-import FaBell from 'react-icons/lib/fa/bell';
-import FaHeart from 'react-icons/lib/fa/heart';
-import FaFlag from 'react-icons/lib/fa/flag';
+import {
+  FaSmile,
+  FaPaw,
+  FaUtensils,
+  FaFutbol,
+  FaPlane,
+  FaBell,
+  FaHeart,
+  FaFlag,
+} from 'react-icons/fa';
+
 import { EmojiSelectGroup } from '../index';
 
 const defaultEmojiGroups: EmojiSelectGroup[] = [
   {
     title: 'People',
-    icon: <FaSmileO style={{ verticalAlign: '' }} />,
+    icon: <FaSmile style={{ verticalAlign: '' }} />,
     categories: ['people'],
   },
   {
@@ -22,12 +25,12 @@ const defaultEmojiGroups: EmojiSelectGroup[] = [
   },
   {
     title: 'Food & Drink',
-    icon: <FaCutlery style={{ verticalAlign: '' }} />,
+    icon: <FaUtensils style={{ verticalAlign: '' }} />,
     categories: ['food'],
   },
   {
     title: 'Activity',
-    icon: <FaFutbolO style={{ verticalAlign: '' }} />,
+    icon: <FaFutbol style={{ verticalAlign: '' }} />,
     categories: ['activity'],
   },
   {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14107,24 +14107,12 @@ react-hotkeys@2.0.0:
   dependencies:
     prop-types "^15.6.1"
 
-react-icon-base@2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/react-icon-base/-/react-icon-base-2.1.0.tgz#a196e33fdf1e7aaa1fda3aefbb68bdad9e82a79d"
-  integrity sha1-oZbjP98eeqof2jrvu2i9rZ6Cp50=
-
-react-icons@*:
+react-icons@*, react-icons@^3.11.0:
   version "3.11.0"
   resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-3.11.0.tgz#2ca2903dfab8268ca18ebd8cc2e879921ec3b254"
   integrity sha512-JRgiI/vdF6uyBgyZhVyYJUZAop95Sy4XDe/jmT3R/bKliFWpO/uZBwvSjWEdxwzec7SYbEPNPck0Kff2tUGM2Q==
   dependencies:
     camelcase "^5.0.0"
-
-react-icons@^2.2.3, react-icons@^2.2.6:
-  version "2.2.7"
-  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-2.2.7.tgz#d7860826b258557510dac10680abea5ca23cf650"
-  integrity sha512-0n4lcGqzJFcIQLoQytLdJCE0DKSA9dkwEZRYoGrIDJZFvIT6Hbajx5mv9geqhqFiNjUgtxg8kPyDfjlhymbGFg==
-  dependencies:
-    react-icon-base "2.1.0"
 
 react-is@^16.12.0, react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.3, react-is@^16.8.6:
   version "16.13.1"


### PR DESCRIPTION
## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

Currently the type definition for `react-icons` are broken

## Implementation

This PR pushes `react-icons` to 3.11.0 to match the previous update `@types/react-icons`.
