### PR TITLE
Update index.tsx

### DIFF
--- a/packages/editor/src/Editor/index.tsx
+++ b/packages/editor/src/Editor/index.tsx
@@ -108,9 +108,9 @@ class PluginEditor extends Component<PluginEditorProps> {
     this.onChange(moveSelectionToEnd(editorState));
   }
 
-  UNSAFE_componentWillReceiveProps(next: PluginEditorProps): void {
-    const curr = this.props;
-    const currDec = curr.editorState.getDecorator();
+  componentDidUpdate(prevProps: PluginEditorProps): void {
+    const next = this.props;
+    const currDec = prevProps.editorState.getDecorator();
     const nextDec = next.editorState.getDecorator();
 
     // If there is not current decorator, there's nothing to carry over to the next editor state


### PR DESCRIPTION
-Warning: https://reactjs.org/blog/2020/02/26/react-v16.13.0.html#warnings-for-some-updates-during-render
- Switch to using componentDidUpdate to avoid warnings when calling onChange + using decorator.

## Checklist

- [x] Fix any eslint errors that occur
- [ ] Update change-log for every plugin you touch
- [ ] Add/Update tests if you add/change new functionality
- [ ] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

const decorator = new CompositeDecorator([...emojiPlugin.decorators]);
const [editorState, setEditorState] = useState(
  EditorState.createEmpty(decorator),
);

const sendMessage = () => {
    // ... do something
    setEditorState(createEditorStateWithText(''));
  }
};
