### PR TITLE
Change UNSAFE_componentWillReceiveProps to componentDidUpdate; fix #warnings-for-some-updates-during-render

### DIFF
--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To be released
 
+- Change UNSAFE_componentWillReceiveProps to componentDidUpdate; fix https://reactjs.org/blog/2020/02/26/react-v16.13.0.html#warnings-for-some-updates-during-render
 - Replace legacy lifecycle hooks with UNSAFE aliases; the required react version is 16.3
 - Hide internals in single bundle
 - Add esm support

--- a/packages/editor/src/Editor/index.tsx
+++ b/packages/editor/src/Editor/index.tsx
@@ -108,9 +108,9 @@ class PluginEditor extends Component<PluginEditorProps> {
     this.onChange(moveSelectionToEnd(editorState));
   }
 
-  UNSAFE_componentWillReceiveProps(next: PluginEditorProps): void {
-    const curr = this.props;
-    const currDec = curr.editorState.getDecorator();
+  componentDidUpdate(prevProps: PluginEditorProps): void {
+    const next = this.props;
+    const currDec = prevProps.editorState.getDecorator();
     const nextDec = next.editorState.getDecorator();
 
     // If there is not current decorator, there's nothing to carry over to the next editor state


### PR DESCRIPTION
Please check out Contributing Guidelines. By following this template you help us to review your code.

## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [ ] Add/Update tests if you add/change new functionality
- [ ] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem
Fixes [#1393](https://github.com/draft-js-plugins/draft-js-plugins/issues/1393)
