### PR TITLE
Improve issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,0 @@
-## Use-case/Problem
-
-- If you think a feature should be added to draft-js-plugins please provide a description of the use-case.
-- If you found a bug please reproduce it within a [codesandbox](codesandbox.io), this'll make it easier for us to help you. Here's an [example that uses the mentions plugin](https://codesandbox.io/s/MjG72jX2R) - this will help get you started
-
-Please note: The draft js plugins core team is very small and there's not that much time on our hands. If you can help fix this issue, please do, there's usually someone available in the draft-js-plugins channel [on slack](https://draftjs.herokuapp.com/) for pairing.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: '🐛 Report a bug'
+about: 'Report a reproducible bug or reproducible regression.'
+labels: 'bug'
+---
+
+## Environment
+
+<!--
+All necessary environmental info that will help triage this
+-->
+
+<!--
+Especially include:
+-->
+
+- @draft-js-plugins/editor version:
+- plugin name and version:
+
+## Description
+
+<!--
+Describe your issue in detail.
+Include screenshots if needed.
+If this is a regression, let us know.
+-->
+
+## Reproducible Demo
+
+<!--
+Please add a reproduce within [codesandbox](codesandbox.io), this'll make it easier for us to help you.
+Here's an [example that uses the mentions plugin](https://codesandbox.io/s/MjG72jX2R) - this will help get you started
+-->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 🤔 Questions and Help
+    url: https://draftjs.herokuapp.com/
+    about: Join the channel #draft-js-plugins after signing into the DraftJS Slack organization

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: '💬 Feature request'
+about: Suggest introduction of a new feature.
+labels: 'feature request'
+---
+
+## Describe the feature
+
+<!-- Describe what you would like to introduce -->
+
+## Motivation
+
+<!-- Describe what problem the feature solves -->
+
+## Possible implementations
+
+<!-- Describe how the feature could be implemented -->
+
+## Related Issues
+
+<!-- Link related issues here -->


### PR DESCRIPTION
## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [ ] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

Currently there is only one template for questions, feature requests and bugs. Also it would be better if questions are asked in the slack channel as it may be hard to find the link.

## Implementation

This PR add new templates which should also add tags. A link to Slack should be provided.
