### PR TITLE
Fixes occasional "this.props.getEditorState is not a function when tr…

### DIFF
--- a/packages/emoji/CHANGELOG.md
+++ b/packages/emoji/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add esm support
 - Use lodash-es in esm bundle
 - convert to typescript
+- use the setEditorState and getEditorState functions from props.store in EmojiSuggestionsPortal
 
 ## 2.1.3
 

--- a/packages/emoji/src/components/EmojiSuggestionsPortal/index.tsx
+++ b/packages/emoji/src/components/EmojiSuggestionsPortal/index.tsx
@@ -18,7 +18,7 @@ export default class EmojiSuggestionsPortal extends Component<
     this.updatePortalClientRect(this.props);
 
     // trigger a re-render so the EmojiSuggestions becomes active
-    this.props.setEditorState(this.props.getEditorState());
+    this.props.store.setEditorState!(this.props.store.getEditorState!());
   }
 
   UNSAFE_componentWillReceiveProps(


### PR DESCRIPTION
Please check out Contributing Guidelines. By following this template you help us to review your code.
https://github.com/draft-js-plugins/draft-js-plugins/blob/master/CONTRIBUTING.md

## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

Fixes https://github.com/draft-js-plugins/draft-js-plugins/issues/1234
The problem: The EmojiSuggestionsPortal component tries to access the setEditorState and getEditorState from `this.props`, but these functions are not reliably there.

## Implementation

These functions are always available in `this.props.store` of that component. So my fix is to take them from there. Analog to how the EmojiSuggestions component does it.