### PR TITLE
Fixing react warning from emoji plugin

### DIFF
--- a/packages/emoji/package.json
+++ b/packages/emoji/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draft-js-plugins/emoji",
-  "version": "4.0.0-beta3",
+  "version": "4.0.0-beta4",
   "description": "Emoji Plugin for DraftJS",
   "author": {
     "name": "Nik Graf",

--- a/packages/emoji/package.json
+++ b/packages/emoji/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draft-js-plugins/emoji",
-  "version": "4.0.0-beta2",
+  "version": "4.0.0-beta3",
   "description": "Emoji Plugin for DraftJS",
   "author": {
     "name": "Nik Graf",
@@ -50,7 +50,7 @@
   },
   "peerDependencies": {
     "draft-js": "^0.10.1 || ^0.11.0",
-    "react": "^16.3.0"
+    "react": "^16.8.0"
   },
   "devDependencies": {
     "@types/emojione": "^2.2.6",

--- a/packages/emoji/src/components/EmojiSuggestions/index.tsx
+++ b/packages/emoji/src/components/EmojiSuggestions/index.tsx
@@ -80,16 +80,18 @@ export default class EmojiSuggestions extends Component<
       const decoratorRect = this.props.store.getPortalClientRect(
         this.activeOffsetKey!
       );
-      const newStyles: CSSProperties = this.props.positionSuggestions({
-        decoratorRect,
-        props: this.props,
-        state: this.state,
-        filteredEmojis: this.filteredEmojis,
-        popover: this.popover,
-      });
-      for (const [key, value] of Object.entries(newStyles)) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (this.popover!.style as { [x: string]: any })[key] = value;
+      if (decoratorRect) {
+        const newStyles: CSSProperties = this.props.positionSuggestions({
+          decoratorRect,
+          props: this.props,
+          state: this.state,
+          filteredEmojis: this.filteredEmojis,
+          popover: this.popover,
+        });
+        for (const [key, value] of Object.entries(newStyles)) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (this.popover!.style as { [x: string]: any })[key] = value;
+        }
       }
     }
   }

--- a/packages/emoji/src/components/EmojiSuggestionsPortal/index.tsx
+++ b/packages/emoji/src/components/EmojiSuggestionsPortal/index.tsx
@@ -22,7 +22,7 @@ export default function EmojiSuggestionsPortal({
 
   const updatePortalClientRect = useCallback(() => {
     store.updatePortalClientRect(offsetKey, () =>
-      ref.current!.getBoundingClientRect()
+      ref.current?.getBoundingClientRect()
     );
   }, [store, offsetKey]);
 
@@ -34,7 +34,7 @@ export default function EmojiSuggestionsPortal({
     store.setEditorState!(store.getEditorState!());
 
     return () => {
-      store.register(offsetKey);
+      store.unregister(offsetKey);
     };
   }, [updatePortalClientRect, store]);
 

--- a/packages/emoji/src/index.tsx
+++ b/packages/emoji/src/index.tsx
@@ -72,13 +72,13 @@ export interface EmojiPluginConfig {
 }
 
 interface GetClientRectFn {
-  (): ClientRect;
+  (): ClientRect | undefined;
 }
 
 export interface EmojiPluginStore {
   getEditorState?(): EditorState;
   setEditorState?(state: EditorState): void;
-  getPortalClientRect(offsetKey: string): ClientRect;
+  getPortalClientRect(offsetKey: string): ClientRect | undefined;
   getAllSearches(): Map<string, string>;
   isEscaped(offsetKey: string): boolean;
   escapeSearch(offsetKey: string): void;


### PR DESCRIPTION
## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [ ] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

Currently I have the following warning on opening my page:

```
Warning: Cannot update a component from inside the function body of a different component.
    in EmojiSuggestionsPortal (created by DecoratedEmojiSuggestionsPortal)
    in DecoratedEmojiSuggestionsPortal (created by DecoratedComponent)
    in DecoratedComponent (created by DraftEditorBlock)
    in div (created by DraftEditorBlock)
    in DraftEditorBlock (created by DraftEditorContents)
    in div (created by DraftEditorContents)
    in div (created by DraftEditorContents)
    in DraftEditorContents (created by DraftEditor)
...
  | onChange | @ | Editor.tsx:113
  | PluginEditor._this.onChange | @ | index.esm.js:462
  | UNSAFE_componentWillMount | @ | index.esm.js:756
...
```
Where `UNSAFE_componentWillMount | @ | index.esm.js:756` resolves to: 
https://github.com/draft-js-plugins/draft-js-plugins/blob/8c467f47c2893f8fbc78dd508ab7a5cc115bb9ce/packages/emoji/src/components/EmojiSuggestionsPortal/index.tsx#L21

## Implementation

I changed the EmojiSuggestionsPortal to hooks which solved the issue and handle a case where the `ref.current` can be `undefined`.