### PR TITLE
use the setEditorState and getEditorState functions from props.store …

### DIFF
--- a/packages/mention/CHANGELOG.md
+++ b/packages/mention/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Remove prevState and state from positionSuggestions
 - add entryComponent to mention plugin
 - convert to typescript
+- use the setEditorState and getEditorState functions from props.store in EmojiSuggestionsPortal
 
 ## 3.1.5
 

--- a/packages/mention/src/MentionSuggestionsPortal.tsx
+++ b/packages/mention/src/MentionSuggestionsPortal.tsx
@@ -42,7 +42,7 @@ export default function MentionSuggestionsPortal(
     updatePortalClientRect(props);
 
     // trigger a re-render so the MentionSuggestions becomes active
-    props.setEditorState(props.getEditorState());
+    props.store.setEditorState!(props.store.getEditorState!());
 
     return () => {
       props.store.unregister(props.offsetKey);


### PR DESCRIPTION
Please check out Contributing Guidelines. By following this template you help us to review your code.
https://github.com/draft-js-plugins/draft-js-plugins/blob/master/CONTRIBUTING.md

## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

The problem addressed in https://github.com/draft-js-plugins/draft-js-plugins/issues/1234
also appears to happen in the mentions plugin.

## Implementation

This fix is the same as for the emoji plugin; use the setEditorState and getEditorState from the store where we're sure they're always available