### PR TITLE
Fixing warning on scrolling in emoji select #1635

### DIFF
--- a/packages/docs/pages/plugin/emoji/index.js
+++ b/packages/docs/pages/plugin/emoji/index.js
@@ -318,6 +318,12 @@ export default class App extends Component {
               </div>
               <div className={styles.subParam}>
                 <span className={styles.subParamName}>
+                  emojiSelectPopoverScrollbarOuter:
+                </span>
+                CSS class for the outer scrollbar box in the emoji select popup.
+              </div>
+              <div className={styles.subParam}>
+                <span className={styles.subParamName}>
                   emojiSelectPopoverScrollbar:
                 </span>
                 CSS class for scrollbar in the emoji select popup.

--- a/packages/emoji/CHANGELOG.md
+++ b/packages/emoji/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - use the setEditorState and getEditorState functions from props.store in EmojiSuggestionsPortal
 - update emojione to emoji-toolkit
 - remove defaultImagePath, defaultImageType and cacheBust to customize components
+- fixing warning on scrolling in emoji select [#1635](https://github.com/draft-js-plugins/draft-js-plugins/issues/1635)
 
 ## 2.1.3
 

--- a/packages/emoji/src/components/EmojiSelect/Popover/Groups/index.tsx
+++ b/packages/emoji/src/components/EmojiSelect/Popover/Groups/index.tsx
@@ -1,8 +1,17 @@
-import React, { Component, ComponentType, ReactElement, WheelEvent } from 'react';
+import React, {
+  Component,
+  ComponentType,
+  ReactElement,
+  WheelEvent,
+} from 'react';
 import PropTypes from 'prop-types';
 import { Scrollbars, positionValues } from 'react-custom-scrollbars';
 import Group from './Group';
-import { EmojiImageProps, EmojiPluginTheme, EmojiSelectGroup } from '../../../../index';
+import {
+  EmojiImageProps,
+  EmojiPluginTheme,
+  EmojiSelectGroup,
+} from '../../../../index';
 import { EmojiStrategy } from '../../../../utils/createEmojisFromStrategy';
 import Entry from '../Entry';
 
@@ -94,7 +103,7 @@ export default class Groups extends Component<GroupsProps> {
       const containerTop =
         this.container!.getBoundingClientRect().top - scrollTop;
 
-      groups.forEach(group => {
+      groups.forEach((group) => {
         const groupTop = group.instance!.container!.getBoundingClientRect().top;
         const listTop = group.instance!.list!.getBoundingClientRect().top;
         group.top = groupTop - containerTop; // eslint-disable-line no-param-reassign
@@ -124,22 +133,23 @@ export default class Groups extends Component<GroupsProps> {
       <div
         className={theme.emojiSelectPopoverGroups}
         onWheel={this.onWheel}
-        ref={element => {
+        ref={(element) => {
           this.container = element;
         }}
       >
         <Scrollbars
+          className={theme.emojiSelectPopoverScrollbarOuter}
           onScrollFrame={this.onScroll}
           renderTrackVertical={() => (
             <div className={theme.emojiSelectPopoverScrollbar} />
           )}
-          renderThumbVertical={props => (
+          renderThumbVertical={(props) => (
             <div
               {...props}
               className={theme.emojiSelectPopoverScrollbarThumb}
             />
           )}
-          ref={element => {
+          ref={(element) => {
             this.scrollbars = element;
           }}
         >
@@ -154,7 +164,7 @@ export default class Groups extends Component<GroupsProps> {
               checkMouseDown={checkMouseDown}
               onEmojiSelect={onEmojiSelect}
               onEmojiMouseDown={onEmojiMouseDown}
-              ref={element => {
+              ref={(element) => {
                 group.instance = element; // eslint-disable-line no-param-reassign
               }}
               emojiImage={emojiImage}

--- a/packages/emoji/src/components/EmojiSelect/Popover/index.tsx
+++ b/packages/emoji/src/components/EmojiSelect/Popover/index.tsx
@@ -1,9 +1,4 @@
-import React, {
-  Component,
-  ComponentType,
-  ReactElement,
-  WheelEvent,
-} from 'react';
+import React, { Component, ComponentType, ReactElement } from 'react';
 import PropTypes from 'prop-types';
 import addEmoji from '../../../modifiers/addEmoji';
 import Groups from './Groups';
@@ -81,8 +76,6 @@ export default class Popover extends Component<PopoverProps> {
       }
     }
   };
-
-  onWheel = (event: WheelEvent): void => event.preventDefault();
 
   onEmojiSelect = (emoji: string): void => {
     const newEditorState = addEmoji(this.props.store.getEditorState!(), emoji);
@@ -192,7 +185,6 @@ export default class Popover extends Component<PopoverProps> {
       <div
         className={className}
         onMouseDown={this.onMouseDown}
-        onWheel={this.onWheel}
         ref={(element) => {
           this.container = element;
         }}

--- a/packages/emoji/src/theme.ts
+++ b/packages/emoji/src/theme.ts
@@ -39,6 +39,7 @@ export interface EmojiPluginTheme {
   emojiSelectPopoverNavEntryActive?: string;
 
   emojiSelectPopoverScrollbar?: string;
+  emojiSelectPopoverScrollbarOuter?: string;
   emojiSelectPopoverScrollbarThumb?: string;
 }
 
@@ -209,6 +210,12 @@ export const defaultTheme: EmojiPluginTheme = {
   emojiSelectButtonPressed: css`
     ${selectButtonSharedStyle}
     background: #ededed;
+  `,
+
+  emojiSelectPopoverScrollbarOuter: css`
+    & > div {
+      overscroll-behavior: contain;
+    }
   `,
 
   emojiSelectPopover: css`


### PR DESCRIPTION
## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [ ] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

See Issue #1635

## Implementation

This PR removes the `onWheel` event listener and replaces it with the css property `overscroll-behavior: contain;`
