### PR TITLE
Fixing keyBindingFn in mention plugin

### DIFF
--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draft-js-plugins/editor",
-  "version": "4.0.0-beta4",
+  "version": "4.0.0-beta5",
   "description": "Editor for DraftJS Plugins",
   "author": {
     "name": "Nik Graf",

--- a/packages/editor/src/Editor/index.tsx
+++ b/packages/editor/src/Editor/index.tsx
@@ -20,13 +20,15 @@ import { handleKeyCommand } from './defaultKeyCommands';
 import { AriaProps, EditorPlugin, PluginFunctions, EditorRef } from '..';
 import { createPluginHooks } from './PluginHooks';
 
-export interface PluginEditorProps extends EditorProps {
+export interface PluginEditorProps extends Omit<EditorProps, 'keyBindingFn'> {
   plugins?: EditorPlugin[];
   defaultKeyBindings?: boolean;
   defaultKeyCommands?: boolean;
   defaultBlockRenderMap?: boolean;
 
-  keyBindingFn?(event: KeyboardEvent): DraftEditorCommand | null;
+  keyBindingFn?(
+    event: KeyboardEvent
+  ): DraftEditorCommand | string | null | undefined;
   decorators?: Array<CompositeDecorator | DraftDecorator>;
 }
 
@@ -275,9 +277,14 @@ class PluginEditor extends Component<PluginEditorProps> {
     const customStyleMap = this.resolveCustomStyleMap();
     const accessibilityProps = this.resolveAccessibilityProps();
     const blockRenderMap = this.resolveblockRenderMap();
+    const {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-shadow
+      keyBindingFn, //removed as it will be overwritten by pluginHooks
+      ...editorProps
+    } = this.props;
     return (
       <Editor
-        {...this.props}
+        {...editorProps}
         {...accessibilityProps}
         {...pluginHooks}
         readOnly={this.props.readOnly || this.state.readOnly}

--- a/packages/mention/package.json
+++ b/packages/mention/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draft-js-plugins/mention",
-  "version": "4.0.0-beta3",
+  "version": "4.0.0-beta4",
   "description": "Mention Plugin for DraftJS",
   "author": {
     "name": "Nik Graf",

--- a/packages/mention/src/index.tsx
+++ b/packages/mention/src/index.tsx
@@ -196,7 +196,7 @@ export default (
     },
 
     keyBindingFn: (keyboardEvent) =>
-      (callbacks.keyBindingFn && callbacks.keyBindingFn(keyboardEvent)) || null,
+      callbacks.keyBindingFn && callbacks.keyBindingFn(keyboardEvent),
     handleReturn: (keyboardEvent) =>
       callbacks.handleReturn && callbacks.handleReturn(keyboardEvent),
     onChange: (editorState) => {


### PR DESCRIPTION
## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [ ] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

`@draft-js-plugins/mention`  `keyBindingFn` returns `null` if `callbacks.keyBindingFn` is not defined which breaks the chain of the `keyBindingFn` of other plugins. See also #1601.

## Implementation

`@draft-js-plugins/mention`  `keyBindingFn` returns now undefined if `callbacks.keyBindingFn` is not defined. Also fixed the type definition for `@draft-js-plugins/editor` `keyBindingFn` as mentioned in #1651
