### PR TITLE
chore: expose createBlockAlignmentButton in buttons package

### DIFF
--- a/packages/buttons/CHANGELOG.md
+++ b/packages/buttons/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To be released
 
+- Expose createBlockAlignmentButton util
+
 ## 4.0.0
 
 - Hide internals in single bundle

--- a/packages/buttons/src/index.ts
+++ b/packages/buttons/src/index.ts
@@ -2,6 +2,7 @@ import { ComponentType } from 'react';
 import { EditorState } from 'draft-js';
 import createBlockStyleButton from './utils/createBlockStyleButton';
 import createInlineStyleButton from './utils/createInlineStyleButton';
+import createBlockAlignmentButton from './utils/createBlockAlignmentButton';
 import ItalicButton from './components/ItalicButton';
 import BoldButton from './components/BoldButton';
 import CodeButton from './components/CodeButton';
@@ -47,6 +48,7 @@ export type DraftJsBlockAlignmentButtonType = ComponentType<
 export type DraftJsStyleButtonType = ComponentType<DraftJsStyleButtonProps>;
 
 export {
+  createBlockAlignmentButton,
   createBlockStyleButton,
   createInlineStyleButton,
   ItalicButton,


### PR DESCRIPTION

## Use-case/Problem

in v3, I use to be able to access the `createBlockAlignmentButton` util even though it wasn't publicly exposed, but now it is written in typescript thus this is now necessary

```js
// before
import createBlockAlignmentButton from 'draft-js-buttons/lib/utils/createBlockAlignmentButton';
```

## Implementation

exposing util to make it public

```js
// now
import { createBlockAlignmentButton } from '@draft-js-plugins/buttons'
```

