### PR TITLE
Revert "chore(deps): bump immutable from 3.7.6 to 3.8.2"

### DIFF
--- a/packages/drag-n-drop/package.json
+++ b/packages/drag-n-drop/package.json
@@ -34,7 +34,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "immutable": "~3.8.2"
+    "immutable": "~3.7.4"
   },
   "peerDependencies": {
     "draft-js": "^0.10.1 || ^0.11.0",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -35,7 +35,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "immutable": "~3.8.2",
+    "immutable": "~3.7.4",
     "prop-types": "^15.5.8"
   },
   "peerDependencies": {

--- a/packages/emoji/package.json
+++ b/packages/emoji/package.json
@@ -43,7 +43,7 @@
     "emojibase": "^5.1.0",
     "emojibase-data": "^6.1.0",
     "find-with-regex": "^1.1.3",
-    "immutable": "~3.8.2",
+    "immutable": "~3.7.4",
     "lodash": "^4.17.19",
     "lodash-es": "^4.17.20",
     "prop-types": "^15.5.8",

--- a/packages/focus/package.json
+++ b/packages/focus/package.json
@@ -36,7 +36,7 @@
   "license": "MIT",
   "dependencies": {
     "clsx": "^1.0.4",
-    "immutable": "~3.8.2"
+    "immutable": "~3.7.4"
   },
   "peerDependencies": {
     "draft-js": "^0.11.0",

--- a/packages/mention/package.json
+++ b/packages/mention/package.json
@@ -37,7 +37,7 @@
   "license": "MIT",
   "dependencies": {
     "clsx": "^1.0.4",
-    "immutable": "~3.8.2",
+    "immutable": "~3.7.4",
     "lodash": "^4.17.19",
     "lodash-es": "^4.17.20",
     "prop-types": "^15.5.8"

--- a/packages/sticker/package.json
+++ b/packages/sticker/package.json
@@ -36,7 +36,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "immutable": "~3.8.2"
+    "immutable": "~3.7.4"
   },
   "peerDependencies": {
     "draft-js": "^0.10.1 || ^0.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7528,11 +7528,6 @@ immutable@~3.7.4:
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.7.6.tgz#13b4d3cb12befa15482a26fe1b2ebae640071e4b"
   integrity sha1-E7TTyxK++hVIKib+Gy665kAHHks=
 
-immutable@~3.8.2:
-  version "3.8.2"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"
-  integrity sha1-wkOZUUVbs5kT2vKBN28VMOEErfM=
-
 import-cwd@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/import-cwd/-/import-cwd-2.1.0.tgz#aa6cf36e722761285cb371ec6519f53e2435b0a9"


### PR DESCRIPTION
Reverts draft-js-plugins/draft-js-plugins#1531

Draft-js still depends on "~3.7.4" which makes production bundle quite bloated with immutable.js instances. Only yarn resolution would help.