### PR TITLE
Make plugins side effect free

### DIFF
--- a/packages/alignment/CHANGELOG.md
+++ b/packages/alignment/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To be released
 
+## 4.1.0
+
+- add "sideEffects": false for tree shaking
+
 ## 4.0.0
 
 - Replace legacy lifecycle hooks with UNSAFE aliases; the required react version is 16.3

--- a/packages/alignment/package.json
+++ b/packages/alignment/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@draft-js-plugins/alignment",
-  "version": "4.0.0",
+  "version": "4.1.0",
+  "sideEffects": false,
   "description": "Alignment Plugin for DraftJS",
   "author": {
     "name": "Benjamin Kniffler",

--- a/packages/anchor/CHANGELOG.md
+++ b/packages/anchor/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To be released
 
+## 4.1.0
+
+- add "sideEffects": false for tree shaking
+
 ## 4.0.1
 
 - fixing getEditorState can be undefined [#1704](https://github.com/draft-js-plugins/draft-js-plugins/issues/1704)

--- a/packages/anchor/package.json
+++ b/packages/anchor/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@draft-js-plugins/anchor",
-  "version": "4.0.1",
+  "version": "4.1.0",
+  "sideEffects": false,
   "description": "Link Plugin for DraftJS",
   "author": {
     "name": "Jan Amann",

--- a/packages/buttons/CHANGELOG.md
+++ b/packages/buttons/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To be released
 
+## 4.1.0
+
+- add "sideEffects": false for tree shaking
 - Expose createBlockAlignmentButton util
 
 ## 4.0.0

--- a/packages/buttons/package.json
+++ b/packages/buttons/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@draft-js-plugins/buttons",
-  "version": "4.0.0",
+  "version": "4.1.0",
+  "sideEffects": false,
   "description": "Buttons for DraftJS",
   "author": {
     "name": "Nik Graf",

--- a/packages/counter/CHANGELOG.md
+++ b/packages/counter/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To Be Released
 
+## 4.1.0
+
+- add "sideEffects": false for tree shaking
+
 ## 4.0.0
 
 - Migrate styles to linaria

--- a/packages/counter/package.json
+++ b/packages/counter/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@draft-js-plugins/counter",
-  "version": "4.0.0",
+  "version": "4.1.0",
+  "sideEffects": false,
   "description": "Counter Plugin for DraftJS",
   "author": {
     "name": "Adrian Li",

--- a/packages/divider/CHANGELOG.md
+++ b/packages/divider/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To Be Released
 
+## 4.1.0
+
+- add "sideEffects": false for tree shaking
+
 ## 4.0.0
 
 - Migrate styles to linaria

--- a/packages/divider/package.json
+++ b/packages/divider/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@draft-js-plugins/divider",
-  "version": "4.0.0",
+  "version": "4.1.0",
+  "sideEffects": false,
   "description": "Divider Plugin for DraftJS",
   "author": {
     "name": "Ilkwon Sim",

--- a/packages/drag-n-drop-upload/CHANGELOG.md
+++ b/packages/drag-n-drop-upload/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To be released
 
+## 4.1.0
+
+- add "sideEffects": false for tree shaking
+
 ## 4.0.0
 
 - Hide internals in single bundle

--- a/packages/drag-n-drop-upload/package.json
+++ b/packages/drag-n-drop-upload/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@draft-js-plugins/drag-n-drop-upload",
-  "version": "4.0.0",
+  "version": "4.1.0",
+  "sideEffects": false,
   "description": "Dropping & uploading files with DraftJS",
   "author": {
     "name": "Benjamin Kniffler",

--- a/packages/drag-n-drop/CHANGELOG.md
+++ b/packages/drag-n-drop/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To be released
 
+## 4.1.0
+
+- add "sideEffects": false for tree shaking
+
 ## 4.0.0
 
 - Hide internals in single bundle

--- a/packages/drag-n-drop/package.json
+++ b/packages/drag-n-drop/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@draft-js-plugins/drag-n-drop",
-  "version": "4.0.0",
+  "version": "4.1.0",
+  "sideEffects": false,
   "description": "Block Drag & Drop Plugin for DraftJS",
   "author": {
     "name": "Benjamin Kniffler",

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To be released
 
+## 4.1.0
+
+- add "sideEffects": false for tree shaking
+
 ## 4.0.0
 
 - Change UNSAFE_componentWillReceiveProps to componentDidUpdate; fix https://reactjs.org/blog/2020/02/26/react-v16.13.0.html#warnings-for-some-updates-during-render

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@draft-js-plugins/editor",
-  "version": "4.0.0",
+  "version": "4.1.0",
+  "sideEffects": false,
   "description": "Editor for DraftJS Plugins",
   "author": {
     "name": "Nik Graf",

--- a/packages/emoji/CHANGELOG.md
+++ b/packages/emoji/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To be released
 
+## 4.1.0
+
+- add "sideEffects": false for tree shaking
+
 ## 4.0.2
 
 - fixing issue Failed to execute 'removeChild' on 'Node' [#1697](https://github.com/draft-js-plugins/draft-js-plugins/issues/1697)

--- a/packages/emoji/package.json
+++ b/packages/emoji/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@draft-js-plugins/emoji",
-  "version": "4.0.2",
+  "version": "4.1.0",
+  "sideEffects": false,
   "description": "Emoji Plugin for DraftJS",
   "author": {
     "name": "Nik Graf",

--- a/packages/focus/CHANGELOG.md
+++ b/packages/focus/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To Be Released
 
+## 4.1.0
+
+- add "sideEffects": false for tree shaking
+
 ## 4.0.0
 
 - Migrate styles to linaria

--- a/packages/focus/package.json
+++ b/packages/focus/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@draft-js-plugins/focus",
-  "version": "4.0.0",
+  "version": "4.1.0",
+  "sideEffects": false,
   "description": "Focus Plugin for DraftJS",
   "author": {
     "name": "Benjamin Kniffler",

--- a/packages/hashtag/CHANGELOG.md
+++ b/packages/hashtag/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To Be Released
 
+## 4.1.0
+
+- add "sideEffects": false for tree shaking
+
 ## 4.0.0
 
 - Migrate styles to linaria

--- a/packages/hashtag/package.json
+++ b/packages/hashtag/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@draft-js-plugins/hashtag",
-  "version": "4.0.0",
+  "version": "4.1.0",
+  "sideEffects": false,
   "description": "Hashtag Plugin for DraftJS",
   "author": {
     "name": "Nik Graf",

--- a/packages/image/CHANGELOG.md
+++ b/packages/image/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To be released
 
+## 4.1.0
+
+- add "sideEffects": false for tree shaking
+
 ## 4.0.0
 
 - Migrate styles to linaria

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@draft-js-plugins/image",
-  "version": "4.0.0",
+  "version": "4.1.0",
+  "sideEffects": false,
   "description": "Image Plugin for DraftJS",
   "author": {
     "name": "Benjamin Kniffler",

--- a/packages/inline-toolbar/CHANGELOG.md
+++ b/packages/inline-toolbar/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To be released
 
+## 4.1.0
+
+- add "sideEffects": false for tree shaking
+
 ## 4.0.0
 
 - Replace legacy lifecycle hooks with UNSAFE aliases; the required react version is 16.3

--- a/packages/inline-toolbar/package.json
+++ b/packages/inline-toolbar/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@draft-js-plugins/inline-toolbar",
-  "version": "4.0.0",
+  "version": "4.1.0",
+  "sideEffects": false,
   "description": "Toolbar Plugin for DraftJS",
   "author": {
     "name": "Benjamin Kniffler",

--- a/packages/linkify/CHANGELOG.md
+++ b/packages/linkify/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To Be Released
 
+## 4.1.0
+
+- add "sideEffects": false for tree shaking
+
 ## 4.0.0
 
 - Migrate styles to linaria

--- a/packages/linkify/package.json
+++ b/packages/linkify/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@draft-js-plugins/linkify",
-  "version": "4.0.0",
+  "version": "4.1.0",
+  "sideEffects": false,
   "description": "Linkify Plugin for DraftJS",
   "author": {
     "name": "Nik Graf",

--- a/packages/mention/CHANGELOG.md
+++ b/packages/mention/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To be released
 
+## 4.1.0
+
+- add "sideEffects": false for tree shaking
 - Fix regex to ignore trigger in text with supportWhitespace [#1723](https://github.com/draft-js-plugins/draft-js-plugins/issues/1723)
 
 ## 4.0.2

--- a/packages/mention/package.json
+++ b/packages/mention/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@draft-js-plugins/mention",
-  "version": "4.0.2",
+  "version": "4.1.0",
+  "sideEffects": false,
   "description": "Mention Plugin for DraftJS",
   "author": {
     "name": "Nik Graf",

--- a/packages/resizeable/CHANGELOG.md
+++ b/packages/resizeable/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To be released
 
+## 4.1.0
+
+- add "sideEffects": false for tree shaking
+
 ## 4.0.0
 
 - Hide internals in single bundle

--- a/packages/resizeable/package.json
+++ b/packages/resizeable/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@draft-js-plugins/resizeable",
-  "version": "4.0.0",
+  "version": "4.1.0",
+  "sideEffects": false,
   "description": "Resizeable Plugin for DraftJS",
   "author": {
     "name": "Benjamin Kniffler",

--- a/packages/side-toolbar/CHANGELOG.md
+++ b/packages/side-toolbar/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To be released
 
+## 4.1.0
+
+- add "sideEffects": false for tree shaking
+
 ## 4.0.0
 
 - Migrate styles to linaria

--- a/packages/side-toolbar/package.json
+++ b/packages/side-toolbar/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@draft-js-plugins/side-toolbar",
-  "version": "4.0.0",
+  "version": "4.1.0",
+  "sideEffects": false,
   "description": "Toolbar Plugin for DraftJS",
   "author": {
     "name": "Benjamin Kniffler",

--- a/packages/static-toolbar/CHANGELOG.md
+++ b/packages/static-toolbar/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To be released
 
+## 4.1.0
+
+- add "sideEffects": false for tree shaking
+
 ## 4.0.0
 
 - Migrate styles to linaria

--- a/packages/static-toolbar/package.json
+++ b/packages/static-toolbar/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@draft-js-plugins/static-toolbar",
-  "version": "4.0.0",
+  "version": "4.1.0",
+  "sideEffects": false,
   "description": "Static Toolbar Plugin for DraftJS",
   "author": {
     "name": "Julian Krispel",

--- a/packages/sticker/CHANGELOG.md
+++ b/packages/sticker/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To Be Released
 
+## 4.1.0
+
+- add "sideEffects": false for tree shaking
+
 ## 4.0.0
 
 - Migrate styles to linaria

--- a/packages/sticker/package.json
+++ b/packages/sticker/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@draft-js-plugins/sticker",
-  "version": "4.0.0",
+  "version": "4.1.0",
+  "sideEffects": false,
   "description": "Sticker Plugin for DraftJS",
   "author": {
     "name": "Nik Graf",

--- a/packages/undo/CHANGELOG.md
+++ b/packages/undo/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To be released
 
+## 4.1.0
+
+- add "sideEffects": false for tree shaking
+
 ## 4.0.0
 
 - Migrate styles to linaria

--- a/packages/undo/package.json
+++ b/packages/undo/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@draft-js-plugins/undo",
-  "version": "4.0.0",
+  "version": "4.1.0",
+  "sideEffects": false,
   "description": "Undo Plugin for DraftJS",
   "author": {
     "name": "Nik Graf",

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To be release
 
+## 4.1.0
+
+- add "sideEffects": false for tree shaking
+
 ## 4.0.0
 
 - Hide internals in single bundle

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@draft-js-plugins/utils",
-  "version": "4.0.0",
+  "version": "4.1.0",
+  "sideEffects": false,
   "description": "Plugin utilities for draft js",
   "author": {
     "name": "Julian Krispel-Smasel",

--- a/packages/video/CHANGELOG.md
+++ b/packages/video/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To be released
 
+## 4.1.0
+
+- add "sideEffects": false for tree shaking
+
 ## 4.0.0
 
 - Bugfix: check if entity key is null before attemmpting to get entity which was breaking interaction in the editor in some situations. https://github.com/draft-js-plugins/draft-js-plugins/issues/1122

--- a/packages/video/package.json
+++ b/packages/video/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@draft-js-plugins/video",
-  "version": "4.0.0",
+  "version": "4.1.0",
+  "sideEffects": false,
   "description": "Video Plugin for DraftJS",
   "author": {
     "name": "Anchen li"


### PR DESCRIPTION
## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

Adds the `"sideEffects": false` to the `package.json` of all plugins to enable tree shaking: https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free
Should reduce the resulting bundle size as reported in #859 
