### PR TITLE
Adjust Jest config to be able to run from plugins

### DIFF
--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -1,0 +1,24 @@
+// For a detailed explanation regarding each configuration property, visit:
+// https://jestjs.io/docs/en/configuration.html
+
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: [`${__dirname}/jestHelper.js`],
+  moduleFileExtensions: ['jsx', 'js', 'ts', 'tsx'],
+  transform: {
+    '^.+\\.(js|jsx)$': 'babel-jest',
+  },
+  moduleDirectories: ['node_modules', 'src'],
+  testPathIgnorePatterns: ['./node_modules/'],
+  collectCoverageFrom: [],
+  coveragePathIgnorePatterns: ['.stories.*'],
+  coverageThreshold: {
+    global: {},
+  },
+  globals: {
+    'ts-jest': {
+      babelConfig: true,
+    },
+  },
+};

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -18,7 +18,7 @@ module.exports = {
   },
   globals: {
     'ts-jest': {
-      babelConfig: true,
+      babelConfig: `${__dirname}/babel.config.js`,
     },
   },
 };

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -7,6 +7,7 @@ module.exports = {
   setupFilesAfterEnv: [`${__dirname}/jestHelper.js`],
   moduleFileExtensions: ['jsx', 'js', 'ts', 'tsx'],
   transform: {
+    '^.+\\.tsx?$': 'ts-jest',
     '^.+\\.(js|jsx)$': 'babel-jest',
   },
   moduleDirectories: ['node_modules', 'src'],

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,24 +1,13 @@
-// For a detailed explanation regarding each configuration property, visit:
-// https://jestjs.io/docs/en/configuration.html
+const base = require('./jest.config.base.js');
 
 module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'jsdom',
-  setupFilesAfterEnv: ['<rootDir>/jestHelper.js'],
-  moduleFileExtensions: ['jsx', 'js', 'ts', 'tsx'],
-  transform: {
-    '^.+\\.(js|jsx)$': 'babel-jest',
-  },
-  moduleDirectories: ['node_modules', 'src'],
-  testPathIgnorePatterns: ['./node_modules/'],
-  collectCoverageFrom: [],
-  coveragePathIgnorePatterns: ['.stories.*'],
-  coverageThreshold: {
-    global: {},
-  },
-  globals: {
-    'ts-jest': {
-      babelConfig: true,
+  ...base,
+  projects: [
+    {
+      ...base,
+      displayName: 'root',
+      modulePathIgnorePatterns: ['packages'],
     },
-  },
+    '<rootDir>/packages/*/jest.config.js',
+  ],
 };

--- a/jestHelper.js
+++ b/jestHelper.js
@@ -1,1 +1,1 @@
-import '@testing-library/jest-dom/extend-expect';
+require('@testing-library/jest-dom/extend-expect');

--- a/packages/alignment/jest.config.js
+++ b/packages/alignment/jest.config.js
@@ -1,0 +1,8 @@
+const base = require('../../jest.config.base.js');
+const packageName = require('./package').name;
+
+module.exports = {
+  ...base,
+  displayName: packageName,
+  name: packageName,
+};

--- a/packages/alignment/package.json
+++ b/packages/alignment/package.json
@@ -31,7 +31,8 @@
     "build": "yarn build:js && yarn build:dts && yarn build:css",
     "build:js": "yarn rollup --config ../../rollup.config.js",
     "build:dts": "tsc -d",
-    "build:css": "node ../../scripts/build-css.js $(pwd)"
+    "build:css": "node ../../scripts/build-css.js $(pwd)",
+    "test": "jest"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/anchor/jest.config.js
+++ b/packages/anchor/jest.config.js
@@ -1,0 +1,8 @@
+const base = require('../../jest.config.base.js');
+const packageName = require('./package').name;
+
+module.exports = {
+  ...base,
+  displayName: packageName,
+  name: packageName,
+};

--- a/packages/anchor/package.json
+++ b/packages/anchor/package.json
@@ -33,7 +33,8 @@
     "build": "yarn build:js && yarn build:dts && yarn build:css",
     "build:js": "yarn rollup --config ../../rollup.config.js",
     "build:dts": "tsc -d",
-    "build:css": "node ../../scripts/build-css.js $(pwd)"
+    "build:css": "node ../../scripts/build-css.js $(pwd)",
+    "test": "jest"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/buttons/jest.config.js
+++ b/packages/buttons/jest.config.js
@@ -1,0 +1,8 @@
+const base = require('../../jest.config.base.js');
+const packageName = require('./package').name;
+
+module.exports = {
+  ...base,
+  displayName: packageName,
+  name: packageName,
+};

--- a/packages/buttons/package.json
+++ b/packages/buttons/package.json
@@ -30,7 +30,8 @@
     "clean": "yarn rimraf lib",
     "build": "yarn build:js && yarn build:dts",
     "build:js": "yarn rollup --config ../../rollup.config.js",
-    "build:dts": "tsc -d"
+    "build:dts": "tsc -d",
+    "test": "jest"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/counter/jest.config.js
+++ b/packages/counter/jest.config.js
@@ -1,0 +1,8 @@
+const base = require('../../jest.config.base.js');
+const packageName = require('./package').name;
+
+module.exports = {
+  ...base,
+  displayName: packageName,
+  name: packageName,
+};

--- a/packages/counter/package.json
+++ b/packages/counter/package.json
@@ -32,7 +32,8 @@
     "build": "yarn build:js && yarn build:dts && yarn build:css",
     "build:js": "yarn rollup --config ../../rollup.config.js",
     "build:dts": "tsc -d --emitDeclarationOnly --declarationDir lib",
-    "build:css": "node ../../scripts/build-css.js $(pwd)"
+    "build:css": "node ../../scripts/build-css.js $(pwd)",
+    "test": "jest"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/divider/jest.config.js
+++ b/packages/divider/jest.config.js
@@ -1,0 +1,8 @@
+const base = require('../../jest.config.base.js');
+const packageName = require('./package').name;
+
+module.exports = {
+  ...base,
+  displayName: packageName,
+  name: packageName,
+};

--- a/packages/divider/package.json
+++ b/packages/divider/package.json
@@ -32,7 +32,8 @@
     "build": "yarn build:js && yarn build:dts && yarn build:css",
     "build:js": "yarn rollup --config ../../rollup.config.js",
     "build:dts": "tsc -d",
-    "build:css": "node ../../scripts/build-css.js $(pwd)"
+    "build:css": "node ../../scripts/build-css.js $(pwd)",
+    "test": "jest"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/drag-n-drop-upload/jest.config.js
+++ b/packages/drag-n-drop-upload/jest.config.js
@@ -1,0 +1,8 @@
+const base = require('../../jest.config.base.js');
+const packageName = require('./package').name;
+
+module.exports = {
+  ...base,
+  displayName: packageName,
+  name: packageName,
+};

--- a/packages/drag-n-drop-upload/package.json
+++ b/packages/drag-n-drop-upload/package.json
@@ -30,7 +30,8 @@
     "clean": "yarn rimraf lib",
     "build": "yarn build:js && yarn build:dts",
     "build:js": "yarn rollup --config ../../rollup.config.js",
-    "build:dts": "tsc -d"
+    "build:dts": "tsc -d",
+    "test": "jest"
   },
   "license": "MIT",
   "peerDependencies": {

--- a/packages/drag-n-drop/jest.config.js
+++ b/packages/drag-n-drop/jest.config.js
@@ -1,0 +1,8 @@
+const base = require('../../jest.config.base.js');
+const packageName = require('./package').name;
+
+module.exports = {
+  ...base,
+  displayName: packageName,
+  name: packageName,
+};

--- a/packages/drag-n-drop/package.json
+++ b/packages/drag-n-drop/package.json
@@ -30,7 +30,8 @@
     "clean": "yarn rimraf lib",
     "build": "yarn build:js && yarn build:dts",
     "build:js": "yarn rollup --config ../../rollup.config.js",
-    "build:dts": "tsc -d"
+    "build:dts": "tsc -d",
+    "test": "jest"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/editor/jest.config.js
+++ b/packages/editor/jest.config.js
@@ -1,0 +1,8 @@
+const base = require('../../jest.config.base.js');
+const packageName = require('./package').name;
+
+module.exports = {
+  ...base,
+  displayName: packageName,
+  name: packageName,
+};

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -31,7 +31,8 @@
     "clean": "yarn rimraf lib",
     "build": "yarn build:js && yarn build:dts",
     "build:js": "yarn rollup --config ../../rollup.config.js",
-    "build:dts": "tsc -d"
+    "build:dts": "tsc -d",
+    "test": "jest"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/emoji/jest.config.js
+++ b/packages/emoji/jest.config.js
@@ -1,0 +1,8 @@
+const base = require('../../jest.config.base.js');
+const packageName = require('./package').name;
+
+module.exports = {
+  ...base,
+  displayName: packageName,
+  name: packageName,
+};

--- a/packages/emoji/package.json
+++ b/packages/emoji/package.json
@@ -32,7 +32,8 @@
     "build": "yarn build:js && yarn build:dts && yarn build:css",
     "build:js": "yarn rollup --config ../../rollup.config.js",
     "build:dts": "tsc -d --emitDeclarationOnly --declarationDir lib",
-    "build:css": "node ../../scripts/build-css.js $(pwd)"
+    "build:css": "node ../../scripts/build-css.js $(pwd)",
+    "test": "jest"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/focus/jest.config.js
+++ b/packages/focus/jest.config.js
@@ -1,0 +1,8 @@
+const base = require('../../jest.config.base.js');
+const packageName = require('./package').name;
+
+module.exports = {
+  ...base,
+  displayName: packageName,
+  name: packageName,
+};

--- a/packages/focus/package.json
+++ b/packages/focus/package.json
@@ -31,7 +31,8 @@
     "build": "yarn build:js && yarn build:dts && yarn build:css",
     "build:js": "yarn rollup --config ../../rollup.config.js",
     "build:dts": "tsc -d --emitDeclarationOnly --declarationDir lib",
-    "build:css": "node ../../scripts/build-css.js $(pwd)"
+    "build:css": "node ../../scripts/build-css.js $(pwd)",
+    "test": "jest"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/hashtag/jest.config.js
+++ b/packages/hashtag/jest.config.js
@@ -1,0 +1,8 @@
+const base = require('../../jest.config.base.js');
+const packageName = require('./package').name;
+
+module.exports = {
+  ...base,
+  displayName: packageName,
+  name: packageName,
+};

--- a/packages/hashtag/package.json
+++ b/packages/hashtag/package.json
@@ -32,7 +32,8 @@
     "build": "yarn build:js && yarn build:dts && yarn build:css",
     "build:js": "yarn rollup --config ../../rollup.config.js",
     "build:dts": "tsc -d --emitDeclarationOnly --declarationDir lib",
-    "build:css": "node ../../scripts/build-css.js $(pwd)"
+    "build:css": "node ../../scripts/build-css.js $(pwd)",
+    "test": "jest"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/image/jest.config.js
+++ b/packages/image/jest.config.js
@@ -1,0 +1,8 @@
+const base = require('../../jest.config.base.js');
+const packageName = require('./package').name;
+
+module.exports = {
+  ...base,
+  displayName: packageName,
+  name: packageName,
+};

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -31,7 +31,8 @@
     "build": "yarn build:js && yarn build:dts && yarn build:css",
     "build:js": "yarn rollup --config ../../rollup.config.js",
     "build:dts": "tsc -d --emitDeclarationOnly --declarationDir lib",
-    "build:css": "node ../../scripts/build-css.js $(pwd)"
+    "build:css": "node ../../scripts/build-css.js $(pwd)",
+    "test": "jest"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/inline-toolbar/jest.config.js
+++ b/packages/inline-toolbar/jest.config.js
@@ -1,0 +1,8 @@
+const base = require('../../jest.config.base.js');
+const packageName = require('./package').name;
+
+module.exports = {
+  ...base,
+  displayName: packageName,
+  name: packageName,
+};

--- a/packages/inline-toolbar/package.json
+++ b/packages/inline-toolbar/package.json
@@ -31,7 +31,8 @@
     "build": "yarn build:js && yarn build:dts && yarn build:css",
     "build:js": "yarn rollup --config ../../rollup.config.js",
     "build:dts": "tsc -d --emitDeclarationOnly --declarationDir lib",
-    "build:css": "node ../../scripts/build-css.js $(pwd)"
+    "build:css": "node ../../scripts/build-css.js $(pwd)",
+    "test": "jest"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/linkify/jest.config.js
+++ b/packages/linkify/jest.config.js
@@ -1,0 +1,8 @@
+const base = require('../../jest.config.base.js');
+const packageName = require('./package').name;
+
+module.exports = {
+  ...base,
+  displayName: packageName,
+  name: packageName,
+};

--- a/packages/linkify/package.json
+++ b/packages/linkify/package.json
@@ -32,7 +32,8 @@
     "build": "yarn build:js && yarn build:dts && yarn build:css",
     "build:js": "yarn rollup --config ../../rollup.config.js",
     "build:dts": "tsc -d",
-    "build:css": "node ../../scripts/build-css.js $(pwd)"
+    "build:css": "node ../../scripts/build-css.js $(pwd)",
+    "test": "jest"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/mention/jest.config.js
+++ b/packages/mention/jest.config.js
@@ -1,0 +1,8 @@
+const base = require('../../jest.config.base.js');
+const packageName = require('./package').name;
+
+module.exports = {
+  ...base,
+  displayName: packageName,
+  name: packageName,
+};

--- a/packages/mention/package.json
+++ b/packages/mention/package.json
@@ -32,7 +32,8 @@
     "build": "yarn build:js && yarn build:dts && yarn build:css",
     "build:js": "yarn rollup --config ../../rollup.config.js",
     "build:dts": "tsc -d",
-    "build:css": "node ../../scripts/build-css.js $(pwd)"
+    "build:css": "node ../../scripts/build-css.js $(pwd)",
+    "test": "jest"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/resizeable/jest.config.js
+++ b/packages/resizeable/jest.config.js
@@ -1,0 +1,8 @@
+const base = require('../../jest.config.base.js');
+const packageName = require('./package').name;
+
+module.exports = {
+  ...base,
+  displayName: packageName,
+  name: packageName,
+};

--- a/packages/resizeable/package.json
+++ b/packages/resizeable/package.json
@@ -30,7 +30,8 @@
     "clean": "yarn rimraf lib",
     "build": "yarn build:js && yarn build:dts",
     "build:js": "yarn rollup --config ../../rollup.config.js",
-    "build:dts": "tsc -d"
+    "build:dts": "tsc -d",
+    "test": "jest"
   },
   "license": "MIT",
   "peerDependencies": {

--- a/packages/side-toolbar/jest.config.js
+++ b/packages/side-toolbar/jest.config.js
@@ -1,0 +1,8 @@
+const base = require('../../jest.config.base.js');
+const packageName = require('./package').name;
+
+module.exports = {
+  ...base,
+  displayName: packageName,
+  name: packageName,
+};

--- a/packages/side-toolbar/package.json
+++ b/packages/side-toolbar/package.json
@@ -31,7 +31,8 @@
     "build": "yarn build:js && yarn build:dts && yarn build:css",
     "build:js": "yarn rollup --config ../../rollup.config.js",
     "build:dts": "tsc -d",
-    "build:css": "node ../../scripts/build-css.js $(pwd)"
+    "build:css": "node ../../scripts/build-css.js $(pwd)",
+    "test": "jest"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/static-toolbar/jest.config.js
+++ b/packages/static-toolbar/jest.config.js
@@ -1,0 +1,8 @@
+const base = require('../../jest.config.base.js');
+const packageName = require('./package').name;
+
+module.exports = {
+  ...base,
+  displayName: packageName,
+  name: packageName,
+};

--- a/packages/static-toolbar/package.json
+++ b/packages/static-toolbar/package.json
@@ -31,7 +31,8 @@
     "build": "yarn build:js && yarn build:dts && yarn build:css",
     "build:js": "yarn rollup --config ../../rollup.config.js",
     "build:dts": "tsc -d",
-    "build:css": "node ../../scripts/build-css.js $(pwd)"
+    "build:css": "node ../../scripts/build-css.js $(pwd)",
+    "test": "jest"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/sticker/jest.config.js
+++ b/packages/sticker/jest.config.js
@@ -1,0 +1,8 @@
+const base = require('../../jest.config.base.js');
+const packageName = require('./package').name;
+
+module.exports = {
+  ...base,
+  displayName: packageName,
+  name: packageName,
+};

--- a/packages/sticker/package.json
+++ b/packages/sticker/package.json
@@ -32,7 +32,8 @@
     "build": "yarn build:js && yarn build:dts && yarn build:css",
     "build:js": "yarn rollup --config ../../rollup.config.js",
     "build:dts": "tsc -d",
-    "build:css": "node ../../scripts/build-css.js $(pwd)"
+    "build:css": "node ../../scripts/build-css.js $(pwd)",
+    "test": "jest"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/undo/jest.config.js
+++ b/packages/undo/jest.config.js
@@ -1,0 +1,8 @@
+const base = require('../../jest.config.base.js');
+const packageName = require('./package').name;
+
+module.exports = {
+  ...base,
+  displayName: packageName,
+  name: packageName,
+};

--- a/packages/undo/package.json
+++ b/packages/undo/package.json
@@ -32,7 +32,8 @@
     "build": "yarn build:js && yarn build:dts && yarn build:css",
     "build:js": "yarn rollup --config ../../rollup.config.js",
     "build:dts": "tsc -d",
-    "build:css": "node ../../scripts/build-css.js $(pwd)"
+    "build:css": "node ../../scripts/build-css.js $(pwd)",
+    "test": "jest"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/utils/jest.config.js
+++ b/packages/utils/jest.config.js
@@ -1,0 +1,8 @@
+const base = require('../../jest.config.base.js');
+const packageName = require('./package').name;
+
+module.exports = {
+  ...base,
+  displayName: packageName,
+  name: packageName,
+};

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -30,7 +30,8 @@
     "clean": "yarn rimraf lib",
     "build": "yarn build:js && yarn build:dts",
     "build:js": "yarn rollup --config ../../rollup.config.js",
-    "build:dts": "tsc -d --emitDeclarationOnly --declarationDir lib"
+    "build:dts": "tsc -d --emitDeclarationOnly --declarationDir lib",
+    "test": "jest"
   },
   "license": "MIT",
   "peerDependencies": {

--- a/packages/video/jest.config.js
+++ b/packages/video/jest.config.js
@@ -1,0 +1,8 @@
+const base = require('../../jest.config.base.js');
+const packageName = require('./package').name;
+
+module.exports = {
+  ...base,
+  displayName: packageName,
+  name: packageName,
+};

--- a/packages/video/package.json
+++ b/packages/video/package.json
@@ -30,7 +30,8 @@
     "build": "yarn build:js && yarn build:dts && yarn build:css",
     "build:js": "yarn rollup --config ../../rollup.config.js",
     "build:dts": "tsc -d",
-    "build:css": "node ../../scripts/build-css.js $(pwd)"
+    "build:css": "node ../../scripts/build-css.js $(pwd)",
+    "test": "jest"
   },
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [ ] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

Currently it is not possible to run the test inside a single plugin like `packages/mention` as there is no `test` script configured.

## Implementation

This PR adds a global jest config which is used in a jest config each plugin package. It is now possible to run `yarn test` from the root folder for all packages and inside package for it alone. The packages have now a name to identify them easily,

## Demo

![tests](https://user-images.githubusercontent.com/73121913/105680914-b793a280-5ef0-11eb-8359-4a209bfe4283.png)
