### PR TITLE
[Anchor Plugin] make link button customizable

### DIFF
--- a/packages/anchor/CHANGELOG.md
+++ b/packages/anchor/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To be released
 
+## 4.1.1
+
+- add LinkButton config option to create own link buttons
+
 ## 4.1.0
 
 - add "sideEffects": false for tree shaking

--- a/packages/anchor/package.json
+++ b/packages/anchor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draft-js-plugins/anchor",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "sideEffects": false,
   "description": "Link Plugin for DraftJS",
   "author": {

--- a/packages/anchor/src/components/DefaultLinkButton.tsx
+++ b/packages/anchor/src/components/DefaultLinkButton.tsx
@@ -1,0 +1,44 @@
+import React, { ReactElement, MouseEvent } from 'react';
+import clsx from 'clsx';
+import { LinkButtonTheme } from './LinkButton';
+
+export interface DefaultLinkButtonProps {
+  hasLinkSelected: boolean;
+  onRemoveLinkAtSelection(): void;
+  onAddLinkClick(event: MouseEvent): void;
+  theme: LinkButtonTheme;
+}
+
+export default function DefaultLinkButton({
+  hasLinkSelected,
+  onRemoveLinkAtSelection,
+  onAddLinkClick,
+  theme,
+}: DefaultLinkButtonProps): ReactElement {
+  const className = clsx(theme.button, hasLinkSelected && theme.active);
+
+  return (
+    <div
+      className={theme.buttonWrapper}
+      onMouseDown={(event: MouseEvent): void => {
+        event.preventDefault();
+      }}
+    >
+      <button
+        className={className}
+        onClick={hasLinkSelected ? onRemoveLinkAtSelection : onAddLinkClick}
+        type="button"
+      >
+        <svg
+          height="24"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path d="M0 0h24v24H0z" fill="none" />
+          <path d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z" />
+        </svg>
+      </button>
+    </div>
+  );
+}

--- a/packages/anchor/src/components/LinkButton.tsx
+++ b/packages/anchor/src/components/LinkButton.tsx
@@ -1,10 +1,10 @@
 import React, { ComponentType, MouseEvent, ReactElement } from 'react';
 import PropTypes from 'prop-types';
-import clsx from 'clsx';
 import EditorUtils from '@draft-js-plugins/utils';
 import AddLinkForm, { AddLinkFormPubParams } from './AddLinkForm';
 import { AnchorPluginTheme } from '../theme';
 import { AnchorPluginStore } from '..';
+import { DefaultLinkButtonProps } from './DefaultLinkButton';
 
 export interface LinkButtonTheme {
   button: string;
@@ -23,18 +23,22 @@ interface LinkButtonParams extends LinkButtonPubParams {
   placeholder?: string;
   onRemoveLinkAtSelection(): void;
   validateUrl?(url: string): boolean;
+  linkButton: ComponentType<DefaultLinkButtonProps>;
 }
 
-const LinkButton = (props: LinkButtonParams): ReactElement => {
-  const onMouseDown = (event: MouseEvent): void => {
-    event.preventDefault();
-  };
-
+const LinkButton = ({
+  ownTheme,
+  placeholder,
+  onOverrideContent,
+  validateUrl,
+  theme,
+  onRemoveLinkAtSelection,
+  store,
+  linkButton: InnerLinkButton,
+}: LinkButtonParams): ReactElement => {
   const onAddLinkClick = (event: MouseEvent): void => {
     event.preventDefault();
     event.stopPropagation();
-
-    const { ownTheme, placeholder, onOverrideContent, validateUrl } = props;
 
     const content = (contentProps: AddLinkFormPubParams): ReactElement => (
       <AddLinkForm
@@ -48,31 +52,18 @@ const LinkButton = (props: LinkButtonParams): ReactElement => {
     onOverrideContent(content);
   };
 
-  const { theme, onRemoveLinkAtSelection } = props;
-  const store = props.store.getEditorState?.();
-  const hasLinkSelected = store ? EditorUtils.hasEntity(store, 'LINK') : false;
-  const className = hasLinkSelected
-    ? clsx(theme.button, theme.active)
-    : theme.button;
+  const editorState = store.getEditorState?.();
+  const hasLinkSelected = editorState
+    ? EditorUtils.hasEntity(editorState, 'LINK')
+    : false;
 
   return (
-    <div className={theme.buttonWrapper} onMouseDown={onMouseDown}>
-      <button
-        className={className}
-        onClick={hasLinkSelected ? onRemoveLinkAtSelection : onAddLinkClick}
-        type="button"
-      >
-        <svg
-          height="24"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path d="M0 0h24v24H0z" fill="none" />
-          <path d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z" />
-        </svg>
-      </button>
-    </div>
+    <InnerLinkButton
+      onRemoveLinkAtSelection={onRemoveLinkAtSelection}
+      hasLinkSelected={hasLinkSelected}
+      onAddLinkClick={onAddLinkClick}
+      theme={theme}
+    />
   );
 };
 

--- a/packages/anchor/src/index.tsx
+++ b/packages/anchor/src/index.tsx
@@ -11,6 +11,9 @@ import LinkButton, { LinkButtonPubParams } from './components/LinkButton';
 import linkStrategy from './linkStrategy';
 import { defaultTheme } from './theme';
 import type { AnchorPluginTheme } from './theme';
+import DefaultLinkButton, {
+  DefaultLinkButtonProps,
+} from './components/DefaultLinkButton';
 
 export type { AnchorPluginTheme } from './theme';
 
@@ -20,6 +23,7 @@ export interface AnchorPluginConfig {
   Link?: ComponentType<AnchorHTMLAttributes<HTMLAnchorElement>>;
   linkTarget?: string;
   validateUrl?: (url: string) => boolean;
+  LinkButton?: ComponentType<DefaultLinkButtonProps>;
 }
 
 export type AnchorPlugin = EditorPlugin & {
@@ -38,6 +42,7 @@ export default (config: AnchorPluginConfig = {}): AnchorPlugin => {
     Link,
     linkTarget,
     validateUrl,
+    LinkButton: linkButton,
   } = config;
 
   const store: AnchorPluginStore = {
@@ -61,6 +66,7 @@ export default (config: AnchorPluginConfig = {}): AnchorPlugin => {
         )
       }
       validateUrl={validateUrl}
+      linkButton={linkButton || DefaultLinkButton}
     />
   );
 

--- a/packages/anchor/src/index.tsx
+++ b/packages/anchor/src/index.tsx
@@ -16,6 +16,7 @@ import DefaultLinkButton, {
 } from './components/DefaultLinkButton';
 
 export type { AnchorPluginTheme } from './theme';
+export type { DefaultLinkButtonProps } from './components/DefaultLinkButton';
 
 export interface AnchorPluginConfig {
   theme?: AnchorPluginTheme;

--- a/packages/docs/pages/plugin/anchor/index.js
+++ b/packages/docs/pages/plugin/anchor/index.js
@@ -100,6 +100,13 @@ export default class App extends Component {
             <span className={styles.paramName}>Link</span>
             <span>Specify the link component that will be rendered.</span>
           </div>
+          <div>
+            <span className={styles.paramName}>LinkButton</span>
+            <span>
+              Specify the button component that will be rendered to add and
+              remove links.
+            </span>
+          </div>
         </Container>
         <Container>
           <Heading level={2}>Simple Link Plugin Example</Heading>


### PR DESCRIPTION
## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [ ] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

Currently the link button is not customizable with a fixed SVG icon.

## Implementation

I added a optional `LinkButton` property to the plugin config to set a custom component for rendering.
