### PR TITLE
[Mention Plugin] Remove entryComponent from plugin config

### DIFF
--- a/packages/mention/CHANGELOG.md
+++ b/packages/mention/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To be released
 
+## 4.2.0
+
+- remove `entryComponent` from plugin config [#1736](https://github.com/draft-js-plugins/draft-js-plugins/issues/1736)
+
 ## 4.1.0
 
 - add "sideEffects": false for tree shaking

--- a/packages/mention/package.json
+++ b/packages/mention/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draft-js-plugins/mention",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "sideEffects": false,
   "description": "Mention Plugin for DraftJS",
   "author": {

--- a/packages/mention/src/index.tsx
+++ b/packages/mention/src/index.tsx
@@ -19,7 +19,6 @@ import { defaultTheme, MentionPluginTheme } from './theme';
 import mentionStrategy from './mentionStrategy';
 import mentionSuggestionsStrategy from './mentionSuggestionsStrategy';
 import suggestionsFilter from './utils/defaultSuggestionsFilter';
-import { EntryComponentProps } from './MentionSuggestions/Entry/Entry';
 
 export { default as MentionSuggestions } from './MentionSuggestions/MentionSuggestions';
 
@@ -61,7 +60,6 @@ export interface MentionPluginConfig {
   mentionTrigger?: string;
   mentionRegExp?: string;
   supportWhitespace?: boolean;
-  entryComponent?: ComponentType<EntryComponentProps>;
 }
 
 interface ClientRectFunction {
@@ -141,7 +139,6 @@ export default (
     mentionTrigger = '@',
     mentionRegExp = defaultRegExp,
     supportWhitespace = false,
-    entryComponent,
   } = config;
   const mentionSearchProps = {
     ariaProps,
@@ -152,7 +149,6 @@ export default (
     positionSuggestions,
     mentionTrigger,
     mentionPrefix,
-    entryComponent,
   };
   const DecoratedMentionSuggestionsComponent = (
     props: MentionSuggestionsPubProps


### PR DESCRIPTION
## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [ ] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

See issue #1736 

## Implementation

This PR removes the undocumented plugin config option `entryComponent`. The config had overwritten the `entryComponent` option the `MentionSuggestion` component.
