### PR TITLE
fixing mention composition

### DIFF
--- a/packages/mention/src/MentionSuggestionsPortal.tsx
+++ b/packages/mention/src/MentionSuggestionsPortal.tsx
@@ -1,5 +1,5 @@
 import { EditorState } from 'draft-js';
-import React, { ReactElement, ReactNode, useEffect, useRef } from 'react';
+import React, { ReactElement, ReactNode, useEffect, useLayoutEffect, useRef } from 'react';
 import { MentionPluginStore } from '.';
 
 export interface MentionSuggestionsPortalProps {
@@ -36,14 +36,12 @@ export default function MentionSuggestionsPortal(
   // then properly mount and register after. Prior to this change,
   // UNSAFE_componentWillMount would not fire after componentWillUnmount even though it
   // was still in the DOM, so it wasn't re-registering the offsetkey.
-  useEffect(() => {
+  useLayoutEffect(() => {
     props.store.register(props.offsetKey);
     props.store.setIsOpened(true);
     updatePortalClientRect(props);
-
     // trigger a re-render so the MentionSuggestions becomes active
     props.store.setEditorState!(props.store.getEditorState!());
-
     return () => {
       props.store.unregister(props.offsetKey);
       props.store.setIsOpened(false);

--- a/packages/mention/src/MentionSuggestionsPortal.tsx
+++ b/packages/mention/src/MentionSuggestionsPortal.tsx
@@ -2,6 +2,9 @@ import { EditorState } from 'draft-js';
 import React, { ReactElement, ReactNode, useEffect, useLayoutEffect, useRef } from 'react';
 import { MentionPluginStore } from '.';
 
+const useIsomorphicLayoutEffect =
+  typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+
 export interface MentionSuggestionsPortalProps {
   offsetKey: string;
   store: MentionPluginStore;
@@ -36,7 +39,7 @@ export default function MentionSuggestionsPortal(
   // then properly mount and register after. Prior to this change,
   // UNSAFE_componentWillMount would not fire after componentWillUnmount even though it
   // was still in the DOM, so it wasn't re-registering the offsetkey.
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     props.store.register(props.offsetKey);
     props.store.setIsOpened(true);
     updatePortalClientRect(props);


### PR DESCRIPTION
Please check out Contributing Guidelines. By following this template you help us to review your code.
https://github.com/draft-js-plugins/draft-js-plugins/blob/master/CONTRIBUTING.md

## Checklist

- [ ] Fix any eslint errors that occur
- [ ] Update change-log for every plugin you touch
- [ ] Add/Update tests if you add/change new functionality
- [ ] Add/Update docs if you add/change functionality
- [ ] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

Whether you're fixing a bug or writing a new feature, please open an issue first and discuss with us. We're also reachable on [the draft js slack](https://draftjs.herokuapp.com/)

Briefly describe the use-case/problem you're solving, reference the issue for this bug/feature here

## Implementation

in the draftjs  when compositionEnd, it will force re-render, and all the block will unmount, and mount
when useEffect, we will get old state, and using old state to setState, it cause the bug.

https://github.com/facebook/draft-js/blob/master/src/component/handlers/composition/DraftEditorCompositionHandler.js#L242


## Demo


https://user-images.githubusercontent.com/9846613/106443738-d1685300-64b7-11eb-87c0-dd552d6271d3.mov



If you're implementing or changing a feature, please add a gif to demo the change, thanks!
