### PR TITLE
added onOpen and onClose callback props to EmojiSelect

### DIFF
--- a/packages/emoji/CHANGELOG.md
+++ b/packages/emoji/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To be released
 
+### Added
+
+- add onOpen and onClose callback props to EmojiSelect
+
 ## 4.1.0
 
 - add "sideEffects": false for tree shaking

--- a/packages/emoji/src/components/EmojiSelect/index.tsx
+++ b/packages/emoji/src/components/EmojiSelect/index.tsx
@@ -17,7 +17,7 @@ import {
 } from '../../index';
 
 const emojis = createEmojisFromStrategy();
-// export type EmojiSelectPubParams = Record<string, unknown>;
+
 export interface EmojiSelectPubParams {
   onClose?(): void;
   onOpen?(): void;
@@ -113,8 +113,6 @@ export default class EmojiSelect extends Component<EmojiSelectParams> {
       selectButtonContent,
       toneSelectOpenDelay,
       emojiImage,
-      onOpen,
-      onClose
     } = this.props;
     const buttonClassName = this.state.isOpen
       ? theme.emojiSelectButtonPressed

--- a/packages/emoji/src/components/EmojiSelect/index.tsx
+++ b/packages/emoji/src/components/EmojiSelect/index.tsx
@@ -17,7 +17,11 @@ import {
 } from '../../index';
 
 const emojis = createEmojisFromStrategy();
-export type EmojiSelectPubParams = Record<string, unknown>;
+// export type EmojiSelectPubParams = Record<string, unknown>;
+export interface EmojiSelectPubParams {
+  onClose?(): void;
+  onOpen?(): void;
+}
 
 interface EmojiSelectParams extends EmojiSelectPubParams {
   theme: EmojiPluginTheme;
@@ -84,6 +88,9 @@ export default class EmojiSelect extends Component<EmojiSelectParams> {
         isOpen: true,
       });
     }
+    if (this.props.onOpen) {
+      this.props.onOpen();
+    }
   };
 
   // Close the popover
@@ -92,6 +99,9 @@ export default class EmojiSelect extends Component<EmojiSelectParams> {
       this.setState({
         isOpen: false,
       });
+    }
+    if (this.props.onClose) {
+      this.props.onClose();
     }
   };
 
@@ -103,6 +113,8 @@ export default class EmojiSelect extends Component<EmojiSelectParams> {
       selectButtonContent,
       toneSelectOpenDelay,
       emojiImage,
+      onOpen,
+      onClose
     } = this.props;
     const buttonClassName = this.state.isOpen
       ? theme.emojiSelectButtonPressed


### PR DESCRIPTION
Please check out Contributing Guidelines. By following this template you help us to review your code.
https://github.com/draft-js-plugins/draft-js-plugins/blob/master/CONTRIBUTING.md

## Checklist

- [ ] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [ ] Add/Update tests if you add/change new functionality
- [ ] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

Whether you're fixing a bug or writing a new feature, please open an issue first and discuss with us. We're also reachable on [the draft js slack](https://draftjs.herokuapp.com/)

Briefly describe the use-case/problem you're solving, reference the issue for this bug/feature here:
This one closes https://github.com/draft-js-plugins/draft-js-plugins/issues/1580 
Some users desired onOpen and onClose props to be thrown to EmojiSelect

## Implementation

Briefly describe your solution.
added callback props to be called upon closing and opening of the popover

## Demo

If you're implementing or changing a feature, please add a gif to demo the change, thanks!
