### PR TITLE
[Alignment Plugin] add wrapper for color block

### DIFF
--- a/packages/alignment/src/createDecorator.tsx
+++ b/packages/alignment/src/createDecorator.tsx
@@ -31,9 +31,7 @@ const getDisplayName = (WrappedComponent: WrappedComponentType): string => {
 export default ({ store }: { store: AlignmentPluginStore }) => (
   WrappedComponent: WrappedComponentType
 ): ComponentType<BlockAlignmentDecoratorParams> =>
-  class BlockAlignmentDecorator extends Component<
-    BlockAlignmentDecoratorParams
-  > {
+  class BlockAlignmentDecorator extends Component<BlockAlignmentDecoratorParams> {
     static displayName = `Alignment(${getDisplayName(WrappedComponent)})`;
     static WrappedComponent: ComponentType<BlockAlignmentDecoratorParams> =
       WrappedComponent.WrappedComponent || WrappedComponent;
@@ -85,7 +83,6 @@ export default ({ store }: { store: AlignmentPluginStore }) => (
           display: 'block',
         };
       }
-
       return (
         <WrappedComponent
           {...elementProps}

--- a/packages/docs/components/Examples/alignment/SimpleAlignmentEditor/editorStyles.module.css
+++ b/packages/docs/components/Examples/alignment/SimpleAlignmentEditor/editorStyles.module.css
@@ -5,7 +5,7 @@
   padding: 16px;
   border-radius: 2px;
   margin-bottom: 2em;
-  box-shadow: inset 0px 1px 8px -3px #ABABAB;
+  box-shadow: inset 0px 1px 8px -3px #ababab;
   background: #fefefe;
 }
 
@@ -15,4 +15,9 @@
 
 .options {
   margin-bottom: 20px;
+}
+
+.wrapper {
+  position: relative;
+  z-index: 1;
 }

--- a/packages/docs/components/Examples/alignment/SimpleAlignmentEditor/index.js
+++ b/packages/docs/components/Examples/alignment/SimpleAlignmentEditor/index.js
@@ -1,5 +1,10 @@
 import React, { Component } from 'react';
-import { convertFromRaw, EditorState } from 'draft-js';
+import {
+  convertFromRaw,
+  DefaultDraftBlockRenderMap,
+  EditorState,
+} from 'draft-js';
+import Immutable from 'immutable';
 
 import Editor, { composeDecorators } from '@draft-js-plugins/editor';
 
@@ -70,6 +75,18 @@ const initialState = {
 };
 /* eslint-enable */
 
+function BlockWrapper({ children }) {
+  return <div className={editorStyles.wrapper}>{children}</div>;
+}
+
+const blockRenderMap = Immutable.Map({
+  atomic: {
+    element: 'figure',
+    wrapper: <BlockWrapper />,
+  },
+});
+const extendedBlockRenderMap = DefaultDraftBlockRenderMap.merge(blockRenderMap);
+
 export default class SimpleAlignmentEditor extends Component {
   state = {
     editorState: EditorState.createWithContent(convertFromRaw(initialState)),
@@ -96,6 +113,7 @@ export default class SimpleAlignmentEditor extends Component {
             ref={(element) => {
               this.editor = element;
             }}
+            blockRenderMap={extendedBlockRenderMap}
           />
           <AlignmentTool />
         </div>

--- a/packages/docs/components/Examples/alignment/ThemedAlignmentEditor/editorStyles.module.css
+++ b/packages/docs/components/Examples/alignment/ThemedAlignmentEditor/editorStyles.module.css
@@ -5,7 +5,7 @@
   padding: 16px;
   border-radius: 2px;
   margin-bottom: 2em;
-  box-shadow: inset 0px 1px 8px -3px #ABABAB;
+  box-shadow: inset 0px 1px 8px -3px #ababab;
   background: #fefefe;
 }
 
@@ -15,4 +15,9 @@
 
 .options {
   margin-bottom: 20px;
+}
+
+.wrapper {
+  position: relative;
+  z-index: 1;
 }

--- a/packages/docs/components/Examples/alignment/ThemedAlignmentEditor/index.js
+++ b/packages/docs/components/Examples/alignment/ThemedAlignmentEditor/index.js
@@ -1,5 +1,10 @@
 import React, { Component } from 'react';
-import { convertFromRaw, EditorState } from 'draft-js';
+import {
+  convertFromRaw,
+  DefaultDraftBlockRenderMap,
+  EditorState,
+} from 'draft-js';
+import Immutable from 'immutable';
 import Editor, { composeDecorators } from '@draft-js-plugins/editor';
 import createAlignmentPlugin from '@draft-js-plugins/alignment';
 import createFocusPlugin from '@draft-js-plugins/focus';
@@ -74,6 +79,18 @@ const initialState = {
 };
 /* eslint-enable */
 
+function BlockWrapper({ children }) {
+  return <div className={editorStyles.wrapper}>{children}</div>;
+}
+
+const blockRenderMap = Immutable.Map({
+  atomic: {
+    element: 'figure',
+    wrapper: <BlockWrapper />,
+  },
+});
+const extendedBlockRenderMap = DefaultDraftBlockRenderMap.merge(blockRenderMap);
+
 export default class ThemedAlignmentEditor extends Component {
   state = {
     editorState: EditorState.createWithContent(convertFromRaw(initialState)),
@@ -100,6 +117,7 @@ export default class ThemedAlignmentEditor extends Component {
             ref={(element) => {
               this.editor = element;
             }}
+            blockRenderMap={extendedBlockRenderMap}
           />
           <AlignmentTool />
         </div>

--- a/stories/alignment/src/SimpleAlignmentEditor.tsx
+++ b/stories/alignment/src/SimpleAlignmentEditor.tsx
@@ -1,5 +1,11 @@
-import React, { useState, useRef, ReactElement } from 'react';
-import { convertFromRaw, EditorState, RawDraftContentState } from 'draft-js';
+import React, { useState, useRef, ReactElement, ReactNode } from 'react';
+import {
+  convertFromRaw,
+  DefaultDraftBlockRenderMap,
+  EditorState,
+  RawDraftContentState,
+} from 'draft-js';
+import Immutable from 'immutable';
 import Editor, { composeDecorators } from '@draft-js-plugins/editor';
 import createAlignmentPlugin from '@draft-js-plugins/alignment';
 import createFocusPlugin from '@draft-js-plugins/focus';
@@ -67,6 +73,18 @@ const initialState: RawDraftContentState = {
 };
 /* eslint-enable */
 
+function BlockWrapper({ children }: { children?: ReactNode }): ReactElement {
+  return <div className={editorStyles.wrapper}>{children}</div>;
+}
+
+const blockRenderMap = Immutable.Map({
+  atomic: {
+    element: 'figure',
+    wrapper: <BlockWrapper />,
+  },
+});
+const extendedBlockRenderMap = DefaultDraftBlockRenderMap.merge(blockRenderMap);
+
 const SimpleAlignmentEditor = (): ReactElement => {
   const [editorState, setEditorState] = useState(
     EditorState.createWithContent(convertFromRaw(initialState))
@@ -91,6 +109,7 @@ const SimpleAlignmentEditor = (): ReactElement => {
           ref={(element) => {
             editor.current = element;
           }}
+          blockRenderMap={extendedBlockRenderMap}
         />
         <AlignmentTool />
       </div>

--- a/stories/alignment/src/editorStyles.css
+++ b/stories/alignment/src/editorStyles.css
@@ -5,7 +5,7 @@
   padding: 16px;
   border-radius: 2px;
   margin-bottom: 2em;
-  box-shadow: inset 0px 1px 8px -3px #ABABAB;
+  box-shadow: inset 0px 1px 8px -3px #ababab;
   background: #fefefe;
 }
 
@@ -15,4 +15,9 @@
 
 .options {
   margin-bottom: 20px;
+}
+
+.wrapper {
+  position: relative;
+  z-index: 1;
 }


### PR DESCRIPTION
## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

closes #1605

## Implementation

This PR moves the color block above the text line which prevent the selection of the color block.
