### PR TITLE
[Mention Plugin] Modify RegEx to match trigger without leading space

### DIFF
--- a/packages/mention/CHANGELOG.md
+++ b/packages/mention/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To Be Released
 
+- modify trigger regex to allow triggering menu suggestions without leading space [#973]
+
 ## 4.5.2
 
 - add `sideEffects` for css files [#1833](https://github.com/draft-js-plugins/draft-js-plugins/issues/1833)

--- a/packages/mention/src/__test__/mentionSuggestionsStrategy.test.ts
+++ b/packages/mention/src/__test__/mentionSuggestionsStrategy.test.ts
@@ -38,10 +38,10 @@ describe('test strategy with whitespace support disabled', () => {
     ['should match not match spaces', '@the walking dead', ['@'], [[0, 4]]],
     ['match within text', 'a lof @of text', ['@'], [[6, 9]]],
     [
-      'should not match if no whitespace before trigger',
+      'should match if no whitespace before trigger',
       'a lof@of text',
       ['@'],
-      [],
+      [[5, 8]],
     ],
     [
       'should match multiple mentions',
@@ -94,10 +94,10 @@ describe('test strategy with whitespace support enabled', () => {
     ['should match a word with special characters', '@ęĻŌ', ['@'], [[0, 4]]],
     ['match within text', 'a lof @of text', ['@'], [[6, 14]]],
     [
-      'should not match if no whitespace before trigger',
+      'should match if no whitespace before trigger',
       'a lof@of text',
       ['@'],
-      [],
+      [[5, 13]],
     ],
     [
       'should match multiple mentions with spaces',
@@ -156,7 +156,7 @@ describe('test strategy with whitespace support enabled', () => {
         '@the walking dead tv the white house',
         [
           {
-            key: (key as unknown) as number,
+            key: key as unknown as number,
             offset: 20,
             length: 15,
           },
@@ -192,7 +192,10 @@ describe('multi mentions test strategy with whitespace support disabled', () => 
       'should match a word with special characters',
       '@ęĻŌ ęĻŌ(',
       ['@', '('],
-      [[0, 4]],
+      [
+        [0, 4],
+        [8, 9],
+      ],
     ],
     [
       'should match not match spaces',
@@ -213,10 +216,13 @@ describe('multi mentions test strategy with whitespace support disabled', () => 
       ],
     ],
     [
-      'should not match if no whitespace before trigger',
+      'should match if no whitespace before trigger',
       'a lof@of text(',
       ['@', '('],
-      [],
+      [
+        [5, 8],
+        [13, 14],
+      ],
     ],
     [
       'should match multiple mentions',
@@ -259,7 +265,10 @@ describe('multi mentions test strategy with whitespace support enabled', () => {
       'should match a word with special characters',
       '@ęĻŌ ęĻŌ(',
       ['@', '('],
-      [[0, 8]],
+      [
+        [0, 8],
+        [8, 9],
+      ],
     ],
     [
       'should match not match spaces',
@@ -280,10 +289,13 @@ describe('multi mentions test strategy with whitespace support enabled', () => {
       ],
     ],
     [
-      'should not match if no whitespace before trigger',
+      'should match if no whitespace before trigger',
       'a lof@of text(',
       ['@', '('],
-      [],
+      [
+        [5, 13],
+        [13, 14],
+      ],
     ],
     [
       'should match multiple mentions',
@@ -322,7 +334,7 @@ describe('multi mentions test strategy with whitespace support enabled', () => {
         '@the walking dead tv the white house',
         [
           {
-            key: (key as unknown) as number,
+            key: key as unknown as number,
             offset: 20,
             length: 15,
           },

--- a/packages/mention/src/mentionSuggestionsStrategy.ts
+++ b/packages/mention/src/mentionSuggestionsStrategy.ts
@@ -5,15 +5,6 @@ interface FindWithRegexCb {
   (start: number, end: number): void;
 }
 
-const whitespaceRegEx = /\s/;
-
-function checkForWhiteSpaceBeforeTrigger(text: string, index: number): boolean {
-  if (index === 0) {
-    return true;
-  }
-  return whitespaceRegEx.test(text[index - 1]);
-}
-
 function findInContentBlock(
   regex: RegExp,
   text: string,
@@ -35,8 +26,8 @@ function findInContentBlock(
     start = nonEntityStart + matchArr.index;
     const end = start + matchArr[0].length;
 
-    if (whitespaceRegEx.test(text[start])) {
-      //trim the result so that we have no whitespaces
+    // trim the result if we have a leading character
+    if (matchArr[1].length > 0) {
       start += 1;
     }
 
@@ -63,11 +54,7 @@ function findInContentBlockWithWhitespace(
     prevLastIndex = regex.lastIndex;
     start = nonEntityStart + matchArr.index;
     const end = start + matchArr[0].length;
-
-    //check if whitespace support is active that the char before the trigger is a white space #1844
-    if (checkForWhiteSpaceBeforeTrigger(text, matchArr.index)) {
-      callback(start, end);
-    }
+    callback(start, end);
   }
 }
 

--- a/packages/mention/src/mentionSuggestionsStrategy.ts
+++ b/packages/mention/src/mentionSuggestionsStrategy.ts
@@ -103,7 +103,7 @@ export default (
     .join('|')})`;
   const MENTION_REGEX = supportWhiteSpace
     ? new RegExp(`${triggerPattern}(${regExp}|\\s)*`, 'g')
-    : new RegExp(`(\\s|^)${triggerPattern}${regExp}*`, 'g');
+    : new RegExp(`(.|^)${triggerPattern}${regExp}*`, 'g');
 
   return (contentBlock: ContentBlock, callback: FindWithRegexCb) => {
     findWithRegex(MENTION_REGEX, contentBlock, supportWhiteSpace, callback);

--- a/packages/mention/src/utils/__test__/getSearchTextAt.test.ts
+++ b/packages/mention/src/utils/__test__/getSearchTextAt.test.ts
@@ -30,8 +30,8 @@ describe('getSearchTextAt', () => {
       3,
       [''],
       {
-        matchingString: 'Max',
-        begin: 0,
+        matchingString: '',
+        begin: 3,
         end: 3,
       },
     ],
@@ -41,8 +41,8 @@ describe('getSearchTextAt', () => {
       14,
       ['@'],
       {
-        matchingString: 'one@example.c',
-        begin: 0,
+        matchingString: 'example.c',
+        begin: 4,
         end: 14,
       },
     ],
@@ -52,8 +52,8 @@ describe('getSearchTextAt', () => {
       19,
       ['@'],
       {
-        matchingString: 'one@example.c',
-        begin: 5,
+        matchingString: 'example.c',
+        begin: 9,
         end: 19,
       },
     ],

--- a/packages/mention/src/utils/getSearchTextAt.ts
+++ b/packages/mention/src/utils/getSearchTextAt.ts
@@ -27,10 +27,10 @@ export default function getSearchTextAt(
   let valueStartIndex = 0;
 
   for (const match of matches) {
-    const spaceLen = match[1].length;
+    const charactersBeforeTriggerLen = match[1].length;
     const matchLen = match[2].length;
 
-    triggerStartIndex = (match.index || 0) + spaceLen;
+    triggerStartIndex = (match.index || 0) + charactersBeforeTriggerLen;
     valueStartIndex = triggerStartIndex + matchLen;
   }
 

--- a/packages/mention/src/utils/getSearchTextAt.ts
+++ b/packages/mention/src/utils/getSearchTextAt.ts
@@ -19,7 +19,7 @@ export default function getSearchTextAt(
     .map((trigger) => escapeRegExp(trigger))
     .join('|');
 
-  const TRIGGER_REGEX = new RegExp(`(\\s|^)(${triggerPattern})`, 'g');
+  const TRIGGER_REGEX = new RegExp(`(.|^)(${triggerPattern})`, 'g');
 
   const matches = str.matchAll(TRIGGER_REGEX);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -70,5 +70,5 @@
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
     "skipLibCheck": true
   },
-  "exclude": ["node_modules", "stories", "distTs"]
+  "exclude": ["node_modules", "stories", "distTs", "packages/docs"]
 }


### PR DESCRIPTION
## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [ ] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

fixes #973

## Implementation

Modified trigger regex to allow triggering suggestions in the middle of text without leading space

## Demo

![image](https://user-images.githubusercontent.com/401304/123672788-02b73600-d840-11eb-8f10-82cf66018b67.png)