### PR TITLE
[Side Toolbar Plugin] add option to customize button

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,7 +16,12 @@ module.exports = {
       parser: '@typescript-eslint/parser',
       rules: {
         'react/jsx-indent': 0, //disabeld as it throws the error: "TypeError: Cannot read property 'type' of null"
-        '@typescript-eslint/ban-ts-ignore': 0,
+        '@typescript-eslint/ban-ts-comment': [
+          0,
+          {
+            'ts-ignore': 'allow-with-description',
+          },
+        ],
         '@typescript-eslint/explicit-function-return-type': [
           'error',
           {

--- a/packages/docs/next-env.d.ts
+++ b/packages/docs/next-env.d.ts
@@ -1,7 +1,3 @@
 /// <reference types="next" />
 /// <reference types="next/types/global" />
-
-declare module '!!raw-loader!*' {
-  const contents: string;
-  export default contents;
-}
+/// <reference types="next/image-types/global" />

--- a/packages/docs/next-env.d.ts
+++ b/packages/docs/next-env.d.ts
@@ -1,3 +1,8 @@
 /// <reference types="next" />
 /// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
+
+declare module '!!raw-loader!*' {
+  const contents: string;
+  export default contents;
+}

--- a/packages/docs/pages/plugin/mention/index.tsx
+++ b/packages/docs/pages/plugin/mention/index.tsx
@@ -32,6 +32,7 @@ import multiComponentExampleCode from '!!raw-loader!../../../components/Examples
 // eslint-disable-next-line import/no-unresolved
 import multiComponentExampleStylesCode from '!!raw-loader!../../../components/Examples/mention/MultiMentionTriggers/MultiMentionTriggers.module.css';
 // eslint-disable-next-line import/no-unresolved
+//@ts-ignore sample is js
 import webpackConfig from '!!raw-loader!../../../components/Examples/mention/webpackConfig';
 
 import styles from './Mention.module.css';
@@ -348,7 +349,7 @@ export default function Mention(): ReactElement {
           name="Mentions.ts"
         />
         <Code
-          code={simpleExampleEditorStylesCode}
+          code={simpleExampleEditorStylesCode as unknown as string}
           name="SimpleMentionEditor.module.css"
         />
       </Container>
@@ -360,7 +361,7 @@ export default function Mention(): ReactElement {
           name="CustomMentionEditor.ts"
         />
         <Code
-          code={customExampleMentionsStylesCode}
+          code={customExampleMentionsStylesCode as unknown as string}
           name="MentionsStyles.module.css"
         />
         <Code
@@ -368,7 +369,7 @@ export default function Mention(): ReactElement {
           name="Mentions.ts"
         />
         <Code
-          code={customExampleEditorStylesCode}
+          code={customExampleEditorStylesCode as unknown as string}
           name="CustomMentionEditor.module.css"
         />
       </Container>
@@ -380,7 +381,7 @@ export default function Mention(): ReactElement {
           name="RemoteMentionEditor.tsx"
         />
         <Code
-          code={remoteExampleEditorStylesCode}
+          code={remoteExampleEditorStylesCode as unknown as string}
           name="RemoteMentionEditor.module.css"
         />
       </Container>
@@ -392,7 +393,7 @@ export default function Mention(): ReactElement {
           name="CustomComponentMentionEditor.tsx"
         />
         <Code
-          code={customComponentExampleStylesCode}
+          code={customComponentExampleStylesCode as unknown as string}
           name="CustomComponentMentionEditor.module.css"
         />
       </Container>
@@ -404,7 +405,7 @@ export default function Mention(): ReactElement {
           name="MultiMentionTriggers.tsx"
         />
         <Code
-          code={multiComponentExampleStylesCode}
+          code={multiComponentExampleStylesCode as unknown as string}
           name="MultiMentionTriggers.module.css"
         />
       </Container>

--- a/packages/docs/pages/plugin/mention/index.tsx
+++ b/packages/docs/pages/plugin/mention/index.tsx
@@ -32,7 +32,6 @@ import multiComponentExampleCode from '!!raw-loader!../../../components/Examples
 // eslint-disable-next-line import/no-unresolved
 import multiComponentExampleStylesCode from '!!raw-loader!../../../components/Examples/mention/MultiMentionTriggers/MultiMentionTriggers.module.css';
 // eslint-disable-next-line import/no-unresolved
-//@ts-ignore sample is js
 import webpackConfig from '!!raw-loader!../../../components/Examples/mention/webpackConfig';
 
 import styles from './Mention.module.css';
@@ -349,7 +348,7 @@ export default function Mention(): ReactElement {
           name="Mentions.ts"
         />
         <Code
-          code={simpleExampleEditorStylesCode as unknown as string}
+          code={simpleExampleEditorStylesCode}
           name="SimpleMentionEditor.module.css"
         />
       </Container>
@@ -361,7 +360,7 @@ export default function Mention(): ReactElement {
           name="CustomMentionEditor.ts"
         />
         <Code
-          code={customExampleMentionsStylesCode as unknown as string}
+          code={customExampleMentionsStylesCode}
           name="MentionsStyles.module.css"
         />
         <Code
@@ -369,7 +368,7 @@ export default function Mention(): ReactElement {
           name="Mentions.ts"
         />
         <Code
-          code={customExampleEditorStylesCode as unknown as string}
+          code={customExampleEditorStylesCode}
           name="CustomMentionEditor.module.css"
         />
       </Container>
@@ -381,7 +380,7 @@ export default function Mention(): ReactElement {
           name="RemoteMentionEditor.tsx"
         />
         <Code
-          code={remoteExampleEditorStylesCode as unknown as string}
+          code={remoteExampleEditorStylesCode}
           name="RemoteMentionEditor.module.css"
         />
       </Container>
@@ -393,7 +392,7 @@ export default function Mention(): ReactElement {
           name="CustomComponentMentionEditor.tsx"
         />
         <Code
-          code={customComponentExampleStylesCode as unknown as string}
+          code={customComponentExampleStylesCode}
           name="CustomComponentMentionEditor.module.css"
         />
       </Container>
@@ -405,7 +404,7 @@ export default function Mention(): ReactElement {
           name="MultiMentionTriggers.tsx"
         />
         <Code
-          code={multiComponentExampleStylesCode as unknown as string}
+          code={multiComponentExampleStylesCode}
           name="MultiMentionTriggers.module.css"
         />
       </Container>

--- a/packages/docs/pages/plugin/side-toolbar/index.js
+++ b/packages/docs/pages/plugin/side-toolbar/index.js
@@ -134,6 +134,14 @@ export default class App extends Component {
               option is used.
             </span>
           </div>
+
+          <div className={styles.paramBig}>
+            <span className={styles.paramName}>sideToolbarButtonComponent</span>
+            <span>
+              Button component to be used when a the Side Toolbar is visible.
+              Default to 3 dots.
+            </span>
+          </div>
         </Container>
         <Container>
           <Heading level={2}>Simple Side Toolbar Example</Heading>

--- a/packages/side-toolbar/CHANGELOG.md
+++ b/packages/side-toolbar/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To be released
 
+- add `sideToolbarButtonComponent` option for custom button component [#2179](https://github.com/draft-js-plugins/draft-js-plugins/issues/2179)
+
 ## 4.2.1
 
 - add `sideEffects` for css files [#1833](https://github.com/draft-js-plugins/draft-js-plugins/issues/1833)

--- a/packages/side-toolbar/src/components/BlockTypeSelect/SideToolbarButton.tsx
+++ b/packages/side-toolbar/src/components/BlockTypeSelect/SideToolbarButton.tsx
@@ -1,0 +1,23 @@
+import React, { ReactElement } from 'react';
+
+export interface SideToolbarButtonProps {
+  className?: string;
+}
+
+export default function SideToolbarButton({
+  className,
+}: SideToolbarButtonProps): ReactElement {
+  return (
+    <div className={className}>
+      <svg
+        height="24"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path d="M0 0h24v24H0z" fill="none" />
+        <path d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z" />
+      </svg>
+    </div>
+  );
+}

--- a/packages/side-toolbar/src/components/BlockTypeSelect/index.tsx
+++ b/packages/side-toolbar/src/components/BlockTypeSelect/index.tsx
@@ -5,11 +5,13 @@ import React, {
   MouseEvent,
   ReactElement,
   Component,
+  ComponentType,
 } from 'react';
 import PropTypes from 'prop-types';
 import { EditorState } from 'draft-js';
 import { DraftJsButtonTheme } from '@draft-js-plugins/buttons';
 import { SideToolbarPluginTheme } from '../../theme';
+import { SideToolbarButtonProps } from './SideToolbarButton';
 
 export interface BlockTypeSelectChildProps {
   theme: DraftJsButtonTheme;
@@ -23,6 +25,7 @@ interface BlockTypeSelectProps {
   getEditorState(): EditorState;
   setEditorState(state: EditorState): void;
   childNodes: FC<BlockTypeSelectChildProps>;
+  sideToolbarButtonComponent: ComponentType<SideToolbarButtonProps>;
 }
 
 export default class BlockTypeSelect extends Component<BlockTypeSelectProps> {
@@ -59,24 +62,20 @@ export default class BlockTypeSelect extends Component<BlockTypeSelectProps> {
   };
 
   render(): ReactElement {
-    const { theme, getEditorState, setEditorState } = this.props;
+    const {
+      theme,
+      getEditorState,
+      setEditorState,
+      sideToolbarButtonComponent: SideToolbarButton,
+    } = this.props;
     return (
       <div
         onMouseEnter={this.onMouseEnter}
         onMouseLeave={this.onMouseLeave}
         onMouseDown={this.onMouseDown}
       >
-        <div className={theme.blockTypeSelectStyles?.blockType}>
-          <svg
-            height="24"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path d="M0 0h24v24H0z" fill="none" />
-            <path d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z" />
-          </svg>
-        </div>
+        <SideToolbarButton className={theme.blockTypeSelectStyles?.blockType} />
+
         {/*
           The spacer is needed so the popup doesn't go away when moving from the
           blockType div to the popup.

--- a/packages/side-toolbar/src/components/Toolbar/index.tsx
+++ b/packages/side-toolbar/src/components/Toolbar/index.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/no-array-index-key */
-import React, { ReactElement, FC } from 'react';
+import React, { ReactElement, FC, ComponentType } from 'react';
 import PropTypes from 'prop-types';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
@@ -21,6 +21,7 @@ import {
   SideToolbarPosition,
 } from '../..';
 import Popover from './Popover';
+import { SideToolbarButtonProps } from '../BlockTypeSelect/SideToolbarButton';
 
 export type SideToolbarChildrenProps = BlockTypeSelectChildProps;
 
@@ -30,6 +31,7 @@ interface ToolbarProps {
   position: SideToolbarPosition;
   theme: SideToolbarPluginTheme;
   popperOptions?: PopperOptions;
+  sideToolbarButtonComponent: ComponentType<SideToolbarButtonProps>;
 }
 
 interface ToolbarState {
@@ -96,7 +98,14 @@ export default class Toolbar extends React.Component<ToolbarProps> {
   };
 
   render(): ReactElement | null {
-    const { theme, store, popperOptions, position, children } = this.props;
+    const {
+      theme,
+      store,
+      popperOptions,
+      position,
+      children,
+      sideToolbarButtonComponent,
+    } = this.props;
 
     if (this.state.referenceElement === null) {
       //do not show popover if reference element is not there
@@ -115,6 +124,7 @@ export default class Toolbar extends React.Component<ToolbarProps> {
           setEditorState={store.getItem('setEditorState')!}
           theme={theme}
           childNodes={children!}
+          sideToolbarButtonComponent={sideToolbarButtonComponent}
         />
       </Popover>
     );

--- a/packages/side-toolbar/src/index.tsx
+++ b/packages/side-toolbar/src/index.tsx
@@ -6,8 +6,10 @@ import * as PopperJS from '@popperjs/core';
 import { Modifier } from 'react-popper';
 import Toolbar, { SideToolbarChildrenProps } from './components/Toolbar';
 import { defaultTheme, SideToolbarPluginTheme } from './theme';
+import type { SideToolbarButtonProps } from './components/BlockTypeSelect/SideToolbarButton';
+import SideToolbarButton from './components/BlockTypeSelect/SideToolbarButton';
 
-export type { SideToolbarPluginTheme };
+export type { SideToolbarPluginTheme, SideToolbarButtonProps };
 
 export type SideToolbarPosition = 'left' | 'right';
 
@@ -15,6 +17,7 @@ export interface SideToolbarPluginConfig {
   theme?: SideToolbarPluginTheme;
   position?: SideToolbarPosition;
   popperOptions?: PopperOptions;
+  sideToolbarButtonComponent?: ComponentType<SideToolbarButtonProps>;
 }
 
 export type PopperOptions = Omit<Partial<PopperJS.Options>, 'modifiers'> & {
@@ -53,6 +56,7 @@ export default (config: SideToolbarPluginConfig = {}): SideToolbarPlugin => {
   const {
     position = defaultPostion,
     theme = defaultTheme,
+    sideToolbarButtonComponent = SideToolbarButton,
     popperOptions,
   } = config;
 
@@ -63,6 +67,7 @@ export default (config: SideToolbarPluginConfig = {}): SideToolbarPlugin => {
       theme={theme}
       position={position}
       popperOptions={popperOptions}
+      sideToolbarButtonComponent={sideToolbarButtonComponent}
     />
   );
 


### PR DESCRIPTION
## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

Adds the `sideToolbarButtonComponent` option to customize the sidebar button.
closes #2179
