### PR TITLE
[Mention Plugin] delay scrolling into view

### DIFF
--- a/packages/mention/CHANGELOG.md
+++ b/packages/mention/CHANGELOG.md
@@ -5,8 +5,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To Be Released
 
-## 4.6.1
-
 - delay scrolling into view for selected item in mention list [#2233](https://github.com/draft-js-plugins/draft-js-plugins/issues/2233)
 
 ## 4.6.0

--- a/packages/mention/CHANGELOG.md
+++ b/packages/mention/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To Be Released
 
+## 4.6.1
+
+- delay scrolling into view for selected item in mention list [#2233](https://github.com/draft-js-plugins/draft-js-plugins/issues/2233)
+
 ## 4.6.0
 
 - sroll focused `Entry` component into view [#997](https://github.com/draft-js-plugins/draft-js-plugins/issues/997)

--- a/packages/mention/package.json
+++ b/packages/mention/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draft-js-plugins/mention",
-  "version": "4.6.1",
+  "version": "4.6.0",
   "sideEffects": [
     "*.css"
   ],

--- a/packages/mention/package.json
+++ b/packages/mention/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draft-js-plugins/mention",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "sideEffects": [
     "*.css"
   ],

--- a/packages/mention/src/MentionSuggestions/Entry/Entry.tsx
+++ b/packages/mention/src/MentionSuggestions/Entry/Entry.tsx
@@ -50,8 +50,11 @@ const Entry = ({
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (isFocused && ref.current) {
-      ref.current.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    if (isFocused) {
+      //delay the scrolling as the popup needs some time for positioning
+      requestAnimationFrame(() =>
+        ref.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+      );
     }
   }, [isFocused]);
 


### PR DESCRIPTION
## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

delays the scroll into view for the selected mention list item as the popup takes some time for positioning.
closes #2233
