### PR TITLE
[Alignment Plugin] Set visibleBlock to null on decorator destructing

### DIFF
--- a/packages/alignment/CHANGELOG.md
+++ b/packages/alignment/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To be released
 
+## 5.0.2
+
+- set `visibleBlock` to null on decorator destructing [#2277](https://github.com/draft-js-plugins/draft-js-plugins/issues/2277)
+
 ## 5.0.1
 
 - add `sideEffects` for css files [#1833](https://github.com/draft-js-plugins/draft-js-plugins/issues/1833)

--- a/packages/alignment/package.json
+++ b/packages/alignment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draft-js-plugins/alignment",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "sideEffects": [
     "*.css"
   ],

--- a/packages/alignment/src/createDecorator.tsx
+++ b/packages/alignment/src/createDecorator.tsx
@@ -53,6 +53,9 @@ export default ({ store }: { store: AlignmentPluginStore }) =>
         } else if (store.getItem('visibleBlock') === block.getKey()) {
           store.updateItem('visibleBlock', null);
         }
+        return () => {
+          store.updateItem('visibleBlock', null);
+        };
       }, [blockProps.isFocused, blockProps.isCollapsedSelection, store]);
 
       const alignment = blockProps.alignment;


### PR DESCRIPTION
## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

closes #2277 
