### PR TITLE
Downgrade prepend-http to 3.0.1

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,6 +1,3 @@
 module.exports = {
   stories: ['../stories/index.js', '../stories/**/*.stories.*'],
-  typescript: {
-    reactDocgen: 'none', //see https://github.com/styleguidist/react-docgen-typescript/issues/356
-  },
 };

--- a/packages/anchor/package.json
+++ b/packages/anchor/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@draft-js-plugins/utils": "^4.0.0",
     "clsx": "^1.0.4",
-    "prepend-http": "4",
+    "prepend-http": "3.0.1",
     "prop-types": "^15.5.8",
     "tlds": "^1.221.1"
   },

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": ".",
+    "build": "exit 0",
     "build:gh-pages": "next build",
     "start": "next start",
     "deploy:gh-pages": "rm -rf node_modules/.cache && next build && next export && touch out/.nojekyll && git add out/ && git commit -m \"Deploy Next.js to gh-pages\" && git subtree push --prefix out origin gh-pages"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10710,10 +10710,10 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prepend-http@4:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-4.0.0.tgz#9fe6440f487962a8a0df3ad33f67cd2c0fc6a06f"
-  integrity sha512-s6SRDuOuRo7JXWh7115pmJdh53sX0Azuk/3znjVxSoD4GusXzzBDrLQgH0rspeHNs5f+Yihz7JIT3UBMwFEn6Q==
+prepend-http@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-3.0.1.tgz#3e724d58fd5867465b300bb9615009fa2f8ee3b6"
+  integrity sha512-BLxfZh+m6UiAiCPZFJ4+vYoL7NrRs5XgCTRrjseATAggXhdZKKxn+JUNmuVYWY23bDHgaEHodxw8mnmtVEDtHw==
 
 prepend-http@^1.0.0:
   version "1.0.4"


### PR DESCRIPTION
## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

fixing the next.js build error:
```
ModuleNotFoundError: Module not found: Error: ESM packages (prepend-http) need to be imported. Use 'import' to reference the package instead. https://nextjs.org/docs/messages/import-esm-externals
```