### PR TITLE
Linkify it feature #2328

### DIFF
--- a/packages/docs/components/Examples/linkify/CustomComponentLinkifyEditor/index.js
+++ b/packages/docs/components/Examples/linkify/CustomComponentLinkifyEditor/index.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { EditorState } from 'draft-js';
 import Editor from '@draft-js-plugins/editor';
-import createLinkifyPlugin from '@draft-js-plugins/linkify';
+import createLinkifyPlugin, { linkifyIt } from '@draft-js-plugins/linkify';
 import editorStyles from './editorStyles.module.css';
 
 const linkifyPlugin = createLinkifyPlugin({
@@ -9,6 +9,8 @@ const linkifyPlugin = createLinkifyPlugin({
     // eslint-disable-next-line no-alert, jsx-a11y/anchor-has-content
     return <a {...props} onClick={() => alert('Clicked on Link!')} />;
   },
+  // exclude emails from being recognized as a link [https://www.npmjs.com/package/linkify-it]
+  linkifyit: linkifyIt.set({ fuzzyEmail: false }),
 });
 const plugins = [linkifyPlugin];
 

--- a/packages/docs/pages/plugin/linkify/index.js
+++ b/packages/docs/pages/plugin/linkify/index.js
@@ -125,15 +125,23 @@ export default class App extends Component {
               className
             </span>
           </div>
+          <div className={styles.param}>
+            <span className={styles.paramName}>linkifyit</span>
+            <span>
+              If provided this linkify-it object will be used instead of the
+              default linkify-it object. You can read more in Linkify-it website
+            </span>
+          </div>
           <Heading level={3}>Additional Exports</Heading>
           <div>
             In addition to the plugin the module exports{' '}
             <InlineCode code={'extractLinks'} />
-            . As first argument it takes the text string. The function returns a
-            list of linkifyit.Matches or null.
+            . As first argument it takes the text string, Second argument
+            (Optional) it takes linkify-It object. The function returns a list
+            of linkifyit.Matches or null.
             <Code
               code={
-                'function extractLinks(text: string): linkifyIt.Match[] | null;'
+                'function extractLinks(text: string, linkifyit: LinkifyIt): linkifyIt.Match[] | null;'
               }
             />
             It can be imported by:

--- a/packages/linkify/CHANGELOG.md
+++ b/packages/linkify/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To Be Released
 
+### Changed
+
+- Instead of using a defualt object of Linkify-it, we can pass it as an optional arg for `extractLinks` & `createLinkifyPlugin`. This change was important to give the ability to customize the default configurations of Linkify-it object.
+
 ## 4.1.1
 
 - add `sideEffects` for css files [#1833](https://github.com/draft-js-plugins/draft-js-plugins/issues/1833)

--- a/packages/linkify/src/index.tsx
+++ b/packages/linkify/src/index.tsx
@@ -1,16 +1,20 @@
 import React, { ComponentType, ReactElement } from 'react';
 import { EditorPlugin } from '@draft-js-plugins/editor';
+import linkifyItObj, { LinkifyIt } from 'linkify-it';
+import tlds from 'tlds';
 import Link, { LinkProps, ComponentProps } from './Link/Link';
 import linkStrategy from './linkStrategy';
 import { defaultTheme, LinkifyPluginTheme } from './theme';
 
 export { extractLinks } from './utils/extractLinks';
+export const linkifyIt = linkifyItObj().tlds(tlds) as LinkifyIt;
 
 export interface LinkifyPluginConfig {
   component?: ComponentType<ComponentProps>;
   theme?: LinkifyPluginTheme;
   target?: string;
   rel?: string;
+  linkifyit?: LinkifyIt;
 }
 
 export default (config: LinkifyPluginConfig = {}): EditorPlugin => {
@@ -41,7 +45,8 @@ export default (config: LinkifyPluginConfig = {}): EditorPlugin => {
   return {
     decorators: [
       {
-        strategy: linkStrategy,
+        strategy: (contentBlock, callback) =>
+          linkStrategy(contentBlock, callback, config.linkifyit as LinkifyIt),
         component: DecoratedLink,
       },
     ],

--- a/packages/linkify/src/linkStrategy.ts
+++ b/packages/linkify/src/linkStrategy.ts
@@ -1,12 +1,14 @@
 import { ContentBlock } from 'draft-js';
+import { LinkifyIt } from 'linkify-it';
 import { extractLinks } from './utils/extractLinks';
 
 // Gets all the links in the text, and returns them via the callback
 const linkStrategy = (
   contentBlock: ContentBlock,
-  callback: (start: number, end: number) => void
+  callback: (start: number, end: number) => void,
+  linkifyit: LinkifyIt
 ): void => {
-  const links = extractLinks(contentBlock.getText());
+  const links = extractLinks(contentBlock.getText(), linkifyit);
   if (links) {
     for (const link of links) {
       callback(link.index, link.lastIndex);

--- a/packages/linkify/src/utils/__test__/extractLinks.test.ts
+++ b/packages/linkify/src/utils/__test__/extractLinks.test.ts
@@ -1,3 +1,5 @@
+import LinkifyIt from 'linkify-it';
+import tlds from 'tlds';
 import { extractLinks } from '../extractLinks';
 
 test.each([
@@ -14,6 +16,34 @@ test.each([
   ],
 ])('%s', (_description, text, result) => {
   const match = extractLinks(text);
+  expect(
+    match
+      ? match.map(({ index, lastIndex, raw }) => ({ index, lastIndex, raw }))
+      : match
+  ).toEqual(result);
+});
+
+test.each([
+  [
+    'test empty string with custom linkify-It configurations [emails exlucded]',
+    '',
+    null,
+  ],
+  [
+    'text without link with custom linkify-It configurations [emails exlucded]',
+    'Lorem ipsum dolor sit amet, consectetur testme@test.com adipiscing elit. Vivamus tempor, elit eu auctor dapibus, nisi massa ultricies turpis, vitae egestas',
+    null,
+  ],
+  [
+    'text with link with custom linkify-It configurations [emails exlucded]',
+    'Lorem ipsum dolor sit amet, www.google.de consectetur testme@test.com adipiscing elit. Vivamus tempor, elit eu auctor dapibus, nisi massa ultricies turpis, vitae egestas',
+    [{ index: 28, lastIndex: 41, raw: 'www.google.de' }],
+  ],
+])('%s', (_description, text, result) => {
+  const match = extractLinks(
+    text,
+    LinkifyIt().tlds(tlds).set({ fuzzyEmail: false })
+  );
   expect(
     match
       ? match.map(({ index, lastIndex, raw }) => ({ index, lastIndex, raw }))

--- a/packages/linkify/src/utils/extractLinks.ts
+++ b/packages/linkify/src/utils/extractLinks.ts
@@ -1,9 +1,15 @@
-import linkifyIt from 'linkify-it';
+import linkifyIt, { LinkifyIt } from 'linkify-it';
 import tlds from 'tlds';
 
-export const linkify = linkifyIt();
-linkify.tlds(tlds);
+const linkify: LinkifyIt = linkifyIt().tlds(tlds);
 
-export function extractLinks(text: string): linkifyIt.Match[] | null {
+export function extractLinks(
+  text: string,
+  linkifyit: LinkifyIt = linkify
+): linkifyIt.Match[] | null {
+  if (linkifyit) {
+    linkifyit.tlds(tlds);
+    return linkifyit.match(text);
+  }
   return linkify.match(text);
 }


### PR DESCRIPTION
## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

Ability to configure linkify-it object in **createLinkifyPlugin** Funcation & **extractLinks** util. So we can control what is being recognized as a link in [DraftJS Linkify Plugin], you can read more [here](https://github.com/draft-js-plugins/draft-js-plugins/issues/2328)

## Implementation

pass linkify-it object as optional argument to **extractLinks** util & **createLinkifyPlugin** Funcation and if its not passed we use the default (old) one.

## Demo
![linkifyIt](https://user-images.githubusercontent.com/55086701/134791660-c48266db-13b8-4671-b449-6765c7d5f115.gif)

