### PR TITLE
Use current inline style for mention

### DIFF
--- a/packages/mention/src/modifiers/addMention.ts
+++ b/packages/mention/src/modifiers/addMention.ts
@@ -32,7 +32,7 @@ export default function addMention(
     editorState.getCurrentContent(),
     mentionTextSelection,
     `${mentionPrefix}${mention.name}`,
-    undefined, // no inline style needed
+    editorState.getCurrentInlineStyle(),
     entityKey
   );
 


### PR DESCRIPTION
When inserting a mention, the current inline styles should be applied to the text (for instance font size, font family and text decoration) rather than only the default styles of the mention.