### PR TITLE
Add Japanese symbol to default regExp

### DIFF
--- a/packages/docs/components/Examples/mention/CustomMentionEditor/Mentions.ts
+++ b/packages/docs/components/Examples/mention/CustomMentionEditor/Mentions.ts
@@ -39,6 +39,13 @@ const mentions: MentionData[] = [
     title: 'Randomly Generated User',
     avatar: 'https://randomuser.me/api/portraits/men/36.jpg',
   },
+  {
+    name: '佐々木 小次郎',
+    title: 'Famous Japanese swordsman (SAMURAI)',
+    avatar:
+      'https://upload.wikimedia.org/wikipedia/commons/0/08/Sasaki-Ganryu-%28Kojiro%29-by-Utagawa-Kuniyoshi-1845.png',
+    url: 'https://en.wikipedia.org/wiki/Sasaki_Kojir%C5%8D',
+  },
 ];
 
 export default mentions;

--- a/packages/mention/CHANGELOG.md
+++ b/packages/mention/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To Be Released
 
+### Fixed
+
+- Add Japanese symbol to default regExp
+
 ## 5.1.0
 
 - Use current inline style for mention [#2414](https://github.com/draft-js-plugins/draft-js-plugins/issues/2414)

--- a/packages/mention/src/defaultRegExp.ts
+++ b/packages/mention/src/defaultRegExp.ts
@@ -9,6 +9,8 @@ export default '[' +
   '\u014A-\u017F' +
   // Cyrillic symbols: \u0410-\u044F - https://en.wikipedia.org/wiki/Cyrillic_script_in_Unicode
   '\u0410-\u044F' +
+  // Symbols that are sometimes used in Japanese names: \u3005-\u3006
+  '\u3005-\u3006' +
   // hiragana (japanese): \u3040-\u309F - https://gist.github.com/ryanmcgrath/982242#file-japaneseregex-js
   '\u3040-\u309F' +
   // katakana (japanese): \u30A0-\u30FF - https://gist.github.com/ryanmcgrath/982242#file-japaneseregex-js


### PR DESCRIPTION
Please check out Contributing Guidelines. By following this template you help us to review your code.
https://github.com/draft-js-plugins/draft-js-plugins/blob/master/CONTRIBUTING.md

## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

Some characters are not supported by mention plugin.
These may be used for Japanese personal names.
In particular, `々 (\u3005)` is commonly used.

## Implementation

Add characters to regExp.

## Demo

https://user-images.githubusercontent.com/233012/147100271-52a991f3-ebab-4a1f-8101-2f62c6088ae3.mp4


