### PR TITLE
Fix typo in docs

### DIFF
--- a/packages/docs/pages/plugin/emoji/index.js
+++ b/packages/docs/pages/plugin/emoji/index.js
@@ -413,7 +413,7 @@ export default class App extends Component {
               <span className={styles.paramName}>onSearchChange</span>
               <span>
                 A callback which is triggered whenever the search term changes.
-                The first argument is an object which constains the search term
+                The first argument is an object which contains the search term
                 in the property value.
               </span>
             </div>


### PR DESCRIPTION
## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

Noticed a small typo in the documentation for the `emoji` plugin.