### PR TITLE
Custom image example - Missing styles from plugins

### DIFF
--- a/packages/docs/components/Examples/image/CustomImageEditor/index.js
+++ b/packages/docs/components/Examples/image/CustomImageEditor/index.js
@@ -17,6 +17,10 @@ import createDragNDropUploadPlugin from '@draft-js-plugins/drag-n-drop-upload';
 import editorStyles from './editorStyles.module.css';
 import mockUpload from './mockUpload';
 
+import '@draft-js-plugins/image/lib/plugin.css';
+import '@draft-js-plugins/alignment/lib/plugin.css';
+import '@draft-js-plugins/focus/lib/plugin.css';
+
 const focusPlugin = createFocusPlugin();
 const resizeablePlugin = createResizeablePlugin();
 const blockDndPlugin = createBlockDndPlugin();


### PR DESCRIPTION
See https://github.com/draft-js-plugins/draft-js-plugins/issues/1151 for example of what happens when styles aren't imported.

Please check out Contributing Guidelines. By following this template you help us to review your code.
https://github.com/draft-js-plugins/draft-js-plugins/blob/master/CONTRIBUTING.md

## Checklist

- [ ] Fix any eslint errors that occur
- [ ] Update change-log for every plugin you touch
- [ ] Add/Update tests if you add/change new functionality
- [ ] Add/Update docs if you add/change functionality
- [ ] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

Whether you're fixing a bug or writing a new feature, please open an issue first and discuss with us. We're also reachable on [the draft js slack](https://draftjs.herokuapp.com/)

Briefly describe the use-case/problem you're solving, reference the issue for this bug/feature here

## Implementation

Briefly describe your solution

## Demo

If you're implementing or changing a feature, please add a gif to demo the change, thanks!
