### PR TITLE
Custom image documentation - Missing styles

### DIFF
--- a/packages/docs/pages/plugin/image/index.js
+++ b/packages/docs/pages/plugin/image/index.js
@@ -156,6 +156,26 @@ export default class App extends Component {
             Alignment + Resize + Focus + Drag&apos;n&apos;Drop +
             Drag&apos;n&apos;Drop Upload Example
           </Heading>
+          <Heading level={3}>Prerequisites</Heading>
+          <Heading level={4}>NPM Imports</Heading>
+          <Code code="npm install @draft-js-plugins/alignment" />
+          <Code code="npm install @draft-js-plugins/focus" />
+          <Code code="npm install @draft-js-plugins/resizeable" />
+          <Code code="npm install @draft-js-plugins/drag-n-drop" />
+          <Code code="npm install @draft-js-plugins/drag-n-drop-upload" />
+          <Heading level={4}>Importing the default styles</Heading>
+          <p>
+            The prerequisite plugins ship with default styling available using these imports: &nbsp;
+            <InlineCode
+              code={"import '@draft-js-plugins/image/lib/plugin.css';"}
+            />
+            <InlineCode
+              code={"import '@draft-js-plugins/alignment/lib/plugin.css';"}
+            />
+            <InlineCode
+              code={"import '@draft-js-plugins/focus/lib/plugin.css';"}
+            />
+          </p>
           <CustomImageEditor />
           <Code code={customExampleCode} name="AddImageEditor.js" />
           <Code code={customExampleEditorStylesCode} name="editorStyles.css" />


### PR DESCRIPTION
As is the code doesn't have the required files present. We can't add to the code as it's used as an example on the docs page and there's a conflict with global styles. Therefore documenting on the page rather than in code just like the getting started guide.

Please check out Contributing Guidelines. By following this template you help us to review your code.
https://github.com/draft-js-plugins/draft-js-plugins/blob/master/CONTRIBUTING.md

## Checklist

- [ ] Fix any eslint errors that occur
- [ ] Update change-log for every plugin you touch
- [ ] Add/Update tests if you add/change new functionality
- [ ] Add/Update docs if you add/change functionality
- [ ] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

Whether you're fixing a bug or writing a new feature, please open an issue first and discuss with us. We're also reachable on [the draft js slack](https://draftjs.herokuapp.com/)

Briefly describe the use-case/problem you're solving, reference the issue for this bug/feature here

## Implementation

Briefly describe your solution

## Demo

If you're implementing or changing a feature, please add a gif to demo the change, thanks!
