### PR TITLE
Missing plugins shown on /plugin docs page

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ High quality plugins with great UX on top of [DraftJS](https://github.com/facebo
 
 ## Available Plugins (incl. Docs)
 
+- [Anchor](https://www.draft-js-plugins.com/plugin/anchor)
 - [Alignment](https://www.draft-js-plugins.com/plugin/alignment)
 - [Counter](https://www.draft-js-plugins.com/plugin/counter)
 - [Drag and Drop](https://www.draft-js-plugins.com/plugin/drag-n-drop)
+- [Divider](https://www.draft-js-plugins.com/plugin/divider)
 - [Emoji](https://www.draft-js-plugins.com/plugin/emoji)
 - [Focus](https://www.draft-js-plugins.com/plugin/focus)
 - [Hashtag](https://www.draft-js-plugins.com/plugin/hashtag)
@@ -20,6 +22,7 @@ High quality plugins with great UX on top of [DraftJS](https://github.com/facebo
 - [Mention](https://www.draft-js-plugins.com/plugin/mention)
 - [Resizeable](https://www.draft-js-plugins.com/plugin/resizeable)
 - [Side Toolbar](https://www.draft-js-plugins.com/plugin/side-toolbar)
+- [Static Toolbar](https://www.draft-js-plugins.com/plugin/static-toolbar)
 - [Sticker](https://www.draft-js-plugins.com/plugin/sticker)
 - [Undo](https://www.draft-js-plugins.com/plugin/undo)
 - [Video](https://www.draft-js-plugins.com/plugin/video)


### PR DESCRIPTION
Please check out Contributing Guidelines. By following this template you help us to review your code.
https://github.com/draft-js-plugins/draft-js-plugins/blob/master/CONTRIBUTING.md

## Checklist

- [ ] Fix any eslint errors that occur
- [ ] Update change-log for every plugin you touch
- [ ] Add/Update tests if you add/change new functionality
- [ ] Add/Update docs if you add/change functionality
- [ ] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

Whether you're fixing a bug or writing a new feature, please open an issue first and discuss with us. We're also reachable on [the draft js slack](https://draftjs.herokuapp.com/)

Briefly describe the use-case/problem you're solving, reference the issue for this bug/feature here

## Implementation

Briefly describe your solution

## Demo

If you're implementing or changing a feature, please add a gif to demo the change, thanks!
