### PR TITLE
[Editor] fixing setting focus

### DIFF
--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -5,9 +5,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To be released
 
+## 4.1.2
+
+- Use `EditorState.moveSelectionToEnd` instead of  `EditorState.moveFocusToEnd` to prevent focus [#2521](https://github.com/draft-js-plugins/draft-js-plugins/issues/2521)
+
 ## 4.1.1
 
 - Use `EditorState.moveFocusToEnd` to move focus to end [#2469](https://github.com/draft-js-plugins/draft-js-plugins/issues/2469)
+
 ## 4.1.0
 
 - add "sideEffects": false for tree shaking

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draft-js-plugins/editor",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "sideEffects": false,
   "description": "Editor for DraftJS Plugins",
   "author": {

--- a/packages/editor/src/Editor/index.tsx
+++ b/packages/editor/src/Editor/index.tsx
@@ -107,7 +107,7 @@ class PluginEditor extends Component<PluginEditorProps> {
     );
 
     const editorState = EditorState.set(this.props.editorState, { decorator });
-    this.onChange(EditorState.moveFocusToEnd(editorState));
+    this.onChange(EditorState.moveSelectionToEnd(editorState));
   }
 
   componentDidUpdate(prevProps: PluginEditorProps): void {
@@ -136,7 +136,7 @@ class PluginEditor extends Component<PluginEditorProps> {
     const editorState = EditorState.set(next.editorState, {
       decorator: currDec,
     });
-    this.onChange(EditorState.moveFocusToEnd(editorState));
+    this.onChange(EditorState.moveSelectionToEnd(editorState));
   }
 
   componentWillUnmount(): void {


### PR DESCRIPTION
## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Implementation
Using `EditorState.moveSelectionToEnd` instead of  `EditorState.moveFocusToEnd`

closes #2521, #2586