### PR TITLE
Remove all non printable characters from emojibase data

### DIFF
--- a/packages/emoji/CHANGELOG.md
+++ b/packages/emoji/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## To be released
 
 - upgrade to `emojibase@6`
+- escaping variation selector-16 character when splitting emojis into categories [here](https://github.com/draft-js-plugins/draft-js-plugins/issues/2599)
 
 ### Added
 

--- a/packages/emoji/CHANGELOG.md
+++ b/packages/emoji/CHANGELOG.md
@@ -5,13 +5,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To be released
 
+## 4.6.0
+
 - upgrade to `emojibase@6`
-- escaping variation selector-16 character when splitting emojis into categories [here](https://github.com/draft-js-plugins/draft-js-plugins/issues/2599)
-
-### Added
-
-- added Support header-menu position customization for emoji picker to have "top/Bottom" position
-- You can find more details [here](https://github.com/draft-js-plugins/draft-js-plugins/pull/2433)
+- escaping variation selector-16 character when splitting emojis into categories [#2599](https://github.com/draft-js-plugins/draft-js-plugins/issues/2599)
+- added Support header-menu position customization for emoji picker to have "top/Bottom" position [#2433](https://github.com/draft-js-plugins/draft-js-plugins/pull/2433)
 
 ## 4.5.5
 

--- a/packages/emoji/package.json
+++ b/packages/emoji/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draft-js-plugins/emoji",
-  "version": "4.5.5",
+  "version": "4.6.0",
   "sideEffects": [
     "*.css"
   ],

--- a/packages/emoji/src/utils/createEmojisFromStrategy.ts
+++ b/packages/emoji/src/utils/createEmojisFromStrategy.ts
@@ -7,12 +7,18 @@ export interface EmojiStrategy {
   };
 }
 
+// Filtering out all non printable characters.
+// All the printable characters of ASCII are conveniently in one continuous range
+function escapeNonASCIICharacters(str: string): string {
+  return str.replace(/[^ -~]+/g, '');
+}
+
 export default function createEmojisFromStrategy(): EmojiStrategy {
   const emojis: EmojiStrategy = {};
 
   for (const item of data) {
     const shortName = toShort(item.unicode);
-    const emoji = emojiList[shortName];
+    const emoji = emojiList[escapeNonASCIICharacters(shortName)];
     if (emoji) {
       if (!emojis[emoji.category]) {
         emojis[emoji.category] = {};


### PR DESCRIPTION
## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Implementation

escaping variation selector-16 character when splitting emojis into categories

## Demo
Before: 
![pic-selected-220210-1404-53](https://user-images.githubusercontent.com/12135564/153424511-9671ec96-225f-49d7-8239-a04d74755dd4.png)

After (+8 hand gesture emojis here):
![pic-selected-220210-1404-22](https://user-images.githubusercontent.com/12135564/153424434-a4f96b3d-8ae3-425c-b6d7-075c16d46677.png)

