### PR TITLE
feat: export Popover component for custom container usage without losing Popper functionally

### DIFF
--- a/packages/mention/CHANGELOG.md
+++ b/packages/mention/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To Be Released
 
+## 5.2.2
+
+- Export `Popover` component for `MentionSuggestions` prop `popoverContainer` without lose of Popper.js functionally  [#2684](https://github.com/draft-js-plugins/draft-js-plugins/issues/2684)
+
 ## 5.1.2
 
 - Fixing `popoverContainer` type for `MentionSuggestions` [#2633](https://github.com/draft-js-plugins/draft-js-plugins/issues/2633)

--- a/packages/mention/CHANGELOG.md
+++ b/packages/mention/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To Be Released
 
-## 5.2.2
+## 5.2.0
 
 - Export `Popover` component for `MentionSuggestions` prop `popoverContainer` without lose of Popper.js functionally  [#2684](https://github.com/draft-js-plugins/draft-js-plugins/issues/2684)
 

--- a/packages/mention/package.json
+++ b/packages/mention/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draft-js-plugins/mention",
-  "version": "5.2.2",
+  "version": "5.2.0",
   "sideEffects": [
     "*.css"
   ],

--- a/packages/mention/package.json
+++ b/packages/mention/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draft-js-plugins/mention",
-  "version": "5.1.2",
+  "version": "5.2.2",
   "sideEffects": [
     "*.css"
   ],

--- a/packages/mention/src/index.tsx
+++ b/packages/mention/src/index.tsx
@@ -21,6 +21,7 @@ import mentionSuggestionsStrategy from './mentionSuggestionsStrategy';
 import suggestionsFilter from './utils/defaultSuggestionsFilter';
 
 export { default as MentionSuggestions } from './MentionSuggestions/MentionSuggestions';
+export { default as Popover } from './MentionSuggestions/Popover';
 
 export { defaultTheme };
 export { addMention };

--- a/stories/mentions-custom-container-component/src/CustomComponentMentionEditor.stories.tsx
+++ b/stories/mentions-custom-container-component/src/CustomComponentMentionEditor.stories.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+
+import CustomContainerComponentMentionEditor from './CustomContainerComponentMentionEditor';
+
+export default {
+  title: 'Mentions/Mentions with styled suggestions container',
+  component: CustomContainerComponentMentionEditor,
+} as Meta;
+
+export const Default: Story = () => <CustomContainerComponentMentionEditor />;

--- a/stories/mentions-custom-container-component/src/CustomContainerComponentMentionEditor.tsx
+++ b/stories/mentions-custom-container-component/src/CustomContainerComponentMentionEditor.tsx
@@ -1,0 +1,67 @@
+import React, { ReactElement, useRef, useState } from 'react';
+import { EditorState } from 'draft-js';
+import Editor from '@draft-js-plugins/editor';
+import createMentionPlugin, {
+  Popover,
+  defaultSuggestionsFilter,
+} from '@draft-js-plugins/mention';
+import editorStyles from './editorStyles.css';
+import mentions from './mentions';
+
+const mentionPlugin = createMentionPlugin({
+  mentions,
+});
+const { MentionSuggestions } = mentionPlugin;
+const plugins = [mentionPlugin];
+
+const CustomMentionEditor = (): ReactElement => {
+  const [editorState, setEditorState] = useState(EditorState.createEmpty());
+  const editor = useRef<Editor>();
+
+  const [open, setOpen] = useState(false);
+  const [suggestions, setSuggestions] = useState(mentions);
+
+  const onChange = (value): void => {
+    setEditorState(value);
+  };
+
+  const focus = (): void => {
+    editor.current.focus();
+  };
+
+  const onOpenChange = (newOpen): void => {
+    setOpen(newOpen);
+  };
+
+  const onSearchChange = ({ value }): void => {
+    setSuggestions(defaultSuggestionsFilter(value, mentions));
+  };
+
+  return (
+    <div className={editorStyles.editor} onClick={focus}>
+      <Editor
+        editorState={editorState}
+        onChange={onChange}
+        plugins={plugins}
+        ref={(element) => {
+          editor.current = element;
+        }}
+      />
+      <MentionSuggestions
+        open={open}
+        onOpenChange={onOpenChange}
+        onSearchChange={onSearchChange}
+        suggestions={suggestions}
+        popoverContainer={({children, ...props}) => (
+          <Popover {...props}>
+            <div style={{ background: '#000', color: '#fff' }}>
+              {children}
+            </div>
+          </Popover>
+        )}
+      />
+    </div>
+  );
+};
+
+export default CustomMentionEditor;

--- a/stories/mentions-custom-container-component/src/editorStyles.css
+++ b/stories/mentions-custom-container-component/src/editorStyles.css
@@ -1,0 +1,14 @@
+.editor {
+  box-sizing: border-box;
+  border: 1px solid #ddd;
+  cursor: text;
+  padding: 16px;
+  border-radius: 2px;
+  margin-bottom: 2em;
+  box-shadow: inset 0px 1px 8px -3px #ABABAB;
+  background: #fefefe;
+}
+
+.editor :global(.public-DraftEditor-content) {
+  min-height: 140px;
+}

--- a/stories/mentions-custom-container-component/src/mentions.ts
+++ b/stories/mentions-custom-container-component/src/mentions.ts
@@ -1,0 +1,37 @@
+const mentions = [
+  {
+    name: 'matthew',
+    title: 'Senior Software Engineer',
+    avatar:
+      'https://pbs.twimg.com/profile_images/517863945/mattsailing_400x400.jpg',
+  },
+  {
+    name: 'julian',
+    title: 'United Kingdom',
+    avatar: 'https://avatars2.githubusercontent.com/u/1188186?v=3&s=400',
+  },
+  {
+    name: 'jyoti',
+    title: 'New Delhi, India',
+    avatar: 'https://avatars0.githubusercontent.com/u/2182307?v=3&s=400',
+  },
+  {
+    name: 'max',
+    title:
+      'Travels around the world, brews coffee, skis mountains and makes stuff on the web.',
+    avatar: 'https://avatars0.githubusercontent.com/u/7525670?s=200&v=4',
+  },
+  {
+    name: 'nik',
+    title: 'Passionate about Software Architecture, UX, Skiing & Triathlons',
+    avatar: 'https://avatars0.githubusercontent.com/u/223045?v=3&s=400',
+  },
+  {
+    name: 'pascal',
+    title: 'HeathIT hacker and researcher',
+    avatar:
+      'https://pbs.twimg.com/profile_images/688487813025640448/E6O6I011_400x400.png',
+  },
+];
+
+export default mentions;


### PR DESCRIPTION
## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem
When you want to overwrite the MentionSuggestions container with a custom style you lose Popper.js functionally which in some cases you want to overwrite the container only for styling without losing Popper.js functionally.
for that manner, you could wrap your container with a Popper component which will handle that for you.
Popper component currently privet, exporting that component will enable this feature.

## Implementation

Export Popover component for custom container usage without losing Popper functionally

```
<MentionSuggestions
        popoverContainer={({children, ...props}) => (
          <Popover {...props}>
            <div style={{ background: '#000', color: '#fff' }}>
              {children}
            </div>
          </Popover>
        )}
      />
```

## Demo

<img width="281" alt="image" src="https://user-images.githubusercontent.com/480868/161425305-7367e409-cbbc-4ecb-ae91-908178d9fca6.png">
