### PR TITLE
Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -5,8 +5,13 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   auto-merge:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:

--- a/.github/workflows/deployWebsite.yml
+++ b/.github/workflows/deployWebsite.yml
@@ -2,8 +2,13 @@ name: deployWebsite
 
 on: workflow_dispatch
 
+permissions:
+  contents: read
+
 jobs:
   deployWebsite:
+    permissions:
+      contents: write  # for JamesIves/github-pages-deploy-action to push changes in repo
     name: Deploy Website
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>
