### PR TITLE
Inline toolbar plugin should account for ancestor scrollTop

### DIFF
--- a/packages/inline-toolbar/CHANGELOG.md
+++ b/packages/inline-toolbar/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 #4.1.4
 
-- Account for scroll offsets in parent elements of DraftEditor-root
+- Account for scroll offsets in parent elements of DraftEditor-root [#2766](https://github.com/draft-js-plugins/draft-js-plugins/issues/2766)
 
 ## 4.1.3
 

--- a/packages/inline-toolbar/CHANGELOG.md
+++ b/packages/inline-toolbar/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To be released
 
+#4.1.4
+
+- Account for scroll offsets in parent elements of DraftEditor-root
+
 ## 4.1.3
 
 - support react 18 in peer dependencies [#2701](https://github.com/draft-js-plugins/draft-js-plugins/issues/2701)

--- a/packages/inline-toolbar/package.json
+++ b/packages/inline-toolbar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draft-js-plugins/inline-toolbar",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "sideEffects": [
     "*.css"
   ],

--- a/packages/inline-toolbar/src/components/Toolbar/index.tsx
+++ b/packages/inline-toolbar/src/components/Toolbar/index.tsx
@@ -112,9 +112,18 @@ export default class Toolbar extends React.Component<ToolbarProps> {
       // but rather with a small offset so the caret doesn't overlap with the text.
       const extraTopOffset = -5;
 
+      // Account for scrollTop of all ancestors
+      let scrollOffset = 0;
+      let ancestorNode = editorRoot.parentNode as HTMLElement;
+      while (ancestorNode !== null && !! ancestorNode.scrollTop) {
+        scrollOffset += ancestorNode.scrollTop;
+        ancestorNode = ancestorNode.parentNode as HTMLElement;
+      }
+
       const position = {
         top:
           editorRoot.offsetTop -
+          scrollOffset -
           this.toolbar.offsetHeight +
           (selectionRect.top - editorRootRect.top) +
           extraTopOffset,


### PR DESCRIPTION
## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [ ] Add/Update tests if you add/change new functionality
- [ ] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

If an ancestor of DraftEditor-root has a max height and overflow: auto set, we don't position the inline toolbar correctly because we don't account for scrollTop on ancestor nodes. As a result, the toolbar can appear far down the screen and even off page in these scenarios.

## Implementation

Aggregate scrollTop on all ancestor nodes and include it in positioning calculation for the inline toolbar.

## Demo

If you're implementing or changing a feature, please add a gif to demo the change, thanks!
