### PR TITLE
Autoclose emoji popover for multiple instance

### DIFF
--- a/packages/emoji/CHANGELOG.md
+++ b/packages/emoji/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To be released
 
+## 4.6.2
+
+- Autoclose emoji popover for multiple instance [#2875](https://github.com/draft-js-plugins/draft-js-plugins/issues/2875)
+
 ## 4.6.1
 
 - support react 18 in peer dependencies [#2701](https://github.com/draft-js-plugins/draft-js-plugins/issues/2701)

--- a/packages/emoji/package.json
+++ b/packages/emoji/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draft-js-plugins/emoji",
-  "version": "4.6.1",
+  "version": "4.6.2",
   "sideEffects": [
     "*.css"
   ],

--- a/packages/emoji/src/components/EmojiSelect/index.tsx
+++ b/packages/emoji/src/components/EmojiSelect/index.tsx
@@ -66,14 +66,17 @@ export default class EmojiSelect extends Component<EmojiSelectParams> {
     isOpen: false,
   };
 
+  // Emoji select ref
+  emojiSelectRef = React.createRef();
+
   // When the selector is open and users click anywhere on the page,
   // the selector should close
   componentDidMount(): void {
-    document.addEventListener('click', this.closePopover);
+    document.addEventListener('click', this.closeIfClickedOutside);
   }
 
   componentWillUnmount(): void {
-    document.removeEventListener('click', this.closePopover);
+    document.removeEventListener('click', this.closeIfClickedOutside);
   }
 
   onClick = (event: MouseEvent): void => {
@@ -108,6 +111,13 @@ export default class EmojiSelect extends Component<EmojiSelectParams> {
     }
   };
 
+  // To check if clicked outside of emoji popover
+  closeIfClickedOutside = (e: React.MouseEvent<HTMLElement>) => {
+    if (this.emojiSelectRef && !this.emojiSelectRef.current.contains(e.target)) {
+      this.closePopover();
+    }
+  }
+
   render(): ReactElement {
     const {
       theme = {},
@@ -123,7 +133,7 @@ export default class EmojiSelect extends Component<EmojiSelectParams> {
       ? theme.emojiSelectButtonPressed
       : theme.emojiSelectButton;
     return (
-      <div className={theme.emojiSelect} onClick={this.onClick}>
+      <div className={theme.emojiSelect} ref={this.emojiSelectRef}>
         <button
           className={buttonClassName}
           onMouseUp={this.onButtonMouseUp}

--- a/packages/emoji/src/components/EmojiSelect/index.tsx
+++ b/packages/emoji/src/components/EmojiSelect/index.tsx
@@ -1,20 +1,19 @@
+import PropTypes from 'prop-types';
 import React, {
   Component,
   ComponentType,
-  MouseEvent,
   ReactElement,
   ReactNode,
 } from 'react';
-import PropTypes from 'prop-types';
-import createEmojisFromStrategy from '../../utils/createEmojisFromStrategy';
 import defaultEmojiGroups from '../../constants/defaultEmojiGroups';
-import Popover from './Popover';
 import {
   EmojiImageProps,
   EmojiPluginStore,
   EmojiPluginTheme,
   EmojiSelectGroup,
 } from '../../index';
+import createEmojisFromStrategy from '../../utils/createEmojisFromStrategy';
+import Popover from './Popover';
 
 const emojis = createEmojisFromStrategy();
 
@@ -67,7 +66,7 @@ export default class EmojiSelect extends Component<EmojiSelectParams> {
   };
 
   // Emoji select ref
-  emojiSelectRef = React.createRef();
+  emojiSelectRef = React.createRef<HTMLDivElement>();
 
   // When the selector is open and users click anywhere on the page,
   // the selector should close
@@ -78,11 +77,6 @@ export default class EmojiSelect extends Component<EmojiSelectParams> {
   componentWillUnmount(): void {
     document.removeEventListener('click', this.closeIfClickedOutside);
   }
-
-  onClick = (event: MouseEvent): void => {
-    event.stopPropagation();
-    event.nativeEvent.stopImmediatePropagation();
-  };
 
   onButtonMouseUp = (): void =>
     this.state.isOpen ? this.closePopover() : this.openPopover();
@@ -112,11 +106,15 @@ export default class EmojiSelect extends Component<EmojiSelectParams> {
   };
 
   // To check if clicked outside of emoji popover
-  closeIfClickedOutside = (e: React.MouseEvent<HTMLElement>) => {
-    if (this.emojiSelectRef && !this.emojiSelectRef.current.contains(e.target)) {
+  closeIfClickedOutside = (e: MouseEvent): void => {
+    if (
+      this.emojiSelectRef.current &&
+      e.target instanceof Element &&
+      !this.emojiSelectRef.current.contains(e.target)
+    ) {
       this.closePopover();
     }
-  }
+  };
 
   render(): ReactElement {
     const {


### PR DESCRIPTION
Please check out Contributing Guidelines. By following this template you help us to review your code.
https://github.com/draft-js-plugins/draft-js-plugins/blob/master/CONTRIBUTING.md

## 

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

When using multiple emoji picker plugins on one page (imagine a list of posts like fb timeline that each have its own comment input and emoji picker button) there is an issue that already open emoji picker popover want close if you click on another instances popover trigger button.
The issue can be seen on demo page of emoji plugin https://www.draft-js-plugins.com/plugin/emoji

![80152072-676a6700-8591-11ea-9c60-c2348207c013](https://user-images.githubusercontent.com/97423936/181201951-ff851709-2c40-4750-b2b9-0a56a2b5f6d0.gif)

## Solution

As can be seen, in the change I have updated the event listener on the document to call a specific function `closeIfClickedOutside` which is simply checking if the click target element is something inside emoji popover component or no. And if no then it calls a function to close the popover and doing nothing otherwise.

``` 
closeIfClickedOutside = (e: React.MouseEvent<HTMLElement>) => {
    if (this.emojiSelectRef && !this.emojiSelectRef.contains(e.target)) {
      this.closePopover();
    }
}
```

## Demo

After fix the one popover instance will always close when opening another popover.
![80152781-a9e07380-8592-11ea-8c62-7ca858e343b8](https://user-images.githubusercontent.com/97423936/181202497-582a2aa9-cc2d-4ca0-a7dd-5cabc38fa1b8.gif)

