### PR TITLE
Resolves current accessibility issues - Aria roles and labels to buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "email": "nik@nikgraf.com",
     "url": "http://www.nikgraf.com"
   },
-  "draft-js-plugins": "virtrujakev/draft-js-plugins",
   "dependencies": {
     "draft-js": "^0.11.0",
     "eslint-plugin-import": "^2.26.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "email": "nik@nikgraf.com",
     "url": "http://www.nikgraf.com"
   },
+  "draft-js-plugins": "virtrujakev/draft-js-plugins",
   "dependencies": {
     "draft-js": "^0.11.0",
     "eslint-plugin-import": "^2.26.0",

--- a/packages/buttons/CHANGELOG.md
+++ b/packages/buttons/CHANGELOG.md
@@ -5,6 +5,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To be released
 
+## 4.3.2
+
+- add Aria roles and labels to buttons to improve accessibility
+- [React Accessibility](https://reactjs.org/docs/accessibility.html)
+- [WCAG Accessibility Standards](http://web-accessibility.carnegiemuseums.org/foundations/aria/)
+
 ## 4.3.1
 
 - support react 18 in peer dependencies [#2701](https://github.com/draft-js-plugins/draft-js-plugins/issues/2701)

--- a/packages/buttons/CHANGELOG.md
+++ b/packages/buttons/CHANGELOG.md
@@ -8,8 +8,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## 4.3.2
 
 - add Aria roles and labels to buttons to improve accessibility
-- [React Accessibility](https://reactjs.org/docs/accessibility.html)
-- [WCAG Accessibility Standards](http://web-accessibility.carnegiemuseums.org/foundations/aria/)
+  - [React Accessibility](https://reactjs.org/docs/accessibility.html)
+  - [WCAG Accessibility Standards](http://web-accessibility.carnegiemuseums.org/foundations/aria/)
 
 ## 4.3.1
 

--- a/packages/buttons/package.json
+++ b/packages/buttons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draft-js-plugins/buttons",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "sideEffects": [
     "*.css"
   ],

--- a/packages/buttons/src/utils/createBlockAlignmentButton.tsx
+++ b/packages/buttons/src/utils/createBlockAlignmentButton.tsx
@@ -37,6 +37,8 @@ export default function createBlockAlignmentButton({
           className={className}
           onClick={activate}
           type="button"
+          role="button"
+          aria-label={`block align text ${alignment}`}
         />
       </div>
     );

--- a/packages/buttons/src/utils/createBlockStyleButton.tsx
+++ b/packages/buttons/src/utils/createBlockStyleButton.tsx
@@ -52,6 +52,8 @@ export default function createBlockStyleButton({
           className={className}
           onClick={toggleStyle}
           type="button"
+          role="button"
+          aria-label={`create ${blockType}`}
         />
       </div>
     );

--- a/packages/buttons/src/utils/createInlineStyleButton.tsx
+++ b/packages/buttons/src/utils/createInlineStyleButton.tsx
@@ -43,6 +43,8 @@ export default function createInlineStyleButton({
           className={className}
           onClick={toggleStyle}
           type="button"
+          role="button"
+          aria-label={`${style} text`}
         />
       </div>
     );

--- a/packages/buttons/src/utils/createTextAlignmentButton.tsx
+++ b/packages/buttons/src/utils/createTextAlignmentButton.tsx
@@ -81,6 +81,8 @@ export default function createTextAlignmentButton({
           className={className}
           onClick={toggleStyle}
           type="button"
+          role="button"
+          aria-label={`text align ${alignment}`}
         />
       </div>
     );


### PR DESCRIPTION

## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

Accessibility matters and is increasingly relevant as more of the world moves online. The plugins were not labeled in a way screen readers could interpret, and this has a negative impact on accessibility. Applications using these plugin buttons were inaccessible by default without labels provided, as they cannot be applied at the component level without being rendered through JSX into the final parsed HTML on the actual DOM. 

See: 
- [React Accessibility](https://reactjs.org/docs/accessibility.html)
- [WCAG Accessibility Standards](http://web-accessibility.carnegiemuseums.org/foundations/aria/)

## Implementation

Added button-type specific aria roles and aria labels to the plugin buttons via their generator functions. 

## Demo

Not necessary. 