### PR TITLE
Improve CONTRIBUTING.md for first-time steps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,9 +13,10 @@ You must have [Node.js v5](https://nodejs.org/en/download/package-manager/) or l
 ```sh
 npm install --global yarn
 yarn install
-cd docs
+yarn build
+cd packages/docs
 yarn install
-npm start
+yarn dev
 ```
 
 ## Linting


### PR DESCRIPTION
## Checklist

- [ ] Fix any eslint errors that occur
- [ ] Update change-log for every plugin you touch
- [ ] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [ ] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

The CONTRIBUTING.md contribution setup steps are insufficient to
being contributing.

## Implementation

Upon first pull of the repository, the steps specified in
CONTRIBUTING.md to get started were not enough to actually
load the `docs` package and begin hacking away. This updates
those steps to bring the documentation up to snuff.

