### PR TITLE
Speed up initial opening of select

### DIFF
--- a/packages/emoji/CHANGELOG.md
+++ b/packages/emoji/CHANGELOG.md
@@ -5,7 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To be released
 
-- fix performance issue with shortname to unicode translation
+## 4.6.3
+
+- fix performance issue with shortname to unicode translation [#2915](https://github.com/draft-js-plugins/draft-js-plugins/issues/2915)
 
 ## 4.6.2
 

--- a/packages/emoji/CHANGELOG.md
+++ b/packages/emoji/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To be released
 
-- fix performance issue with shortnameToUnicode translation
+- fix performance issue with shortname to unicode translation
 
 ## 4.6.2
 

--- a/packages/emoji/CHANGELOG.md
+++ b/packages/emoji/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To be released
 
+- fix performance issue with shortnameToUnicode translation
+
 ## 4.6.2
 
 - Autoclose emoji popover for multiple instance [#2875](https://github.com/draft-js-plugins/draft-js-plugins/issues/2875)

--- a/packages/emoji/package.json
+++ b/packages/emoji/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draft-js-plugins/emoji",
-  "version": "4.6.2",
+  "version": "4.6.3",
   "sideEffects": [
     "*.css"
   ],

--- a/packages/emoji/src/components/EmojiSelect/Popover/Entry/index.tsx
+++ b/packages/emoji/src/components/EmojiSelect/Popover/Entry/index.tsx
@@ -1,7 +1,7 @@
-import { shortnameToUnicode } from 'emoji-toolkit';
 import PropTypes from 'prop-types';
 import React, { Component, ComponentType, ReactElement } from 'react';
 import { EmojiImageProps, EmojiPluginTheme } from '../../../../index';
+import shortnameToUnicode from '../../../../utils/shortnameToUnicode';
 
 interface EntryProps {
   mouseDown?: boolean;

--- a/packages/emoji/src/components/EmojiSuggestions/Entry/index.tsx
+++ b/packages/emoji/src/components/EmojiSuggestions/Entry/index.tsx
@@ -1,4 +1,3 @@
-import { shortnameToUnicode } from 'emoji-toolkit';
 import { EmojiImageProps } from 'packages/emoji/src';
 import React, {
   // PropTypes,
@@ -8,6 +7,7 @@ import React, {
   ReactElement,
 } from 'react';
 import { EmojiPluginTheme } from '../../../theme';
+import shortnameToUnicode from '../../../utils/shortnameToUnicode';
 
 interface EntryProps {
   emoji: string;

--- a/packages/emoji/src/modifiers/addEmoji.ts
+++ b/packages/emoji/src/modifiers/addEmoji.ts
@@ -1,5 +1,5 @@
 import { Modifier, EditorState } from 'draft-js';
-import { shortnameToUnicode } from 'emoji-toolkit';
+import shortnameToUnicode from '../utils/shortnameToUnicode';
 import getSearchText from '../utils/getSearchText';
 
 // This modifier can inserted emoji to current cursor position (with replace selected fragment),

--- a/packages/emoji/src/utils/__test__/shortnameToUnicode.test.ts
+++ b/packages/emoji/src/utils/__test__/shortnameToUnicode.test.ts
@@ -1,0 +1,10 @@
+import shortnameToUnicode from '../shortnameToUnicode';
+
+describe('shortnameToUnicode', () => {
+  it('executes in less than 100ms', () => {
+    const start = performance.now();
+    shortnameToUnicode(':grinning:');
+    const executionMs = performance.now() - start;
+    expect(executionMs).toBeLessThan(100);
+  });
+});

--- a/packages/emoji/src/utils/__test__/shortnameToUnicode.test.ts
+++ b/packages/emoji/src/utils/__test__/shortnameToUnicode.test.ts
@@ -1,10 +1,15 @@
 import shortnameToUnicode from '../shortnameToUnicode';
 
 describe('shortnameToUnicode', () => {
-  it('executes in less than 100ms', () => {
-    const start = performance.now();
-    shortnameToUnicode(':grinning:');
-    const executionMs = performance.now() - start;
-    expect(executionMs).toBeLessThan(100);
+  it('empty shortname -> undefined', () => {
+    expect(shortnameToUnicode('')).toBeUndefined();
+  });
+
+  it('invalid shortname -> undefined', () => {
+    expect(shortnameToUnicode('obviously not an emoji name')).toBeUndefined();
+  });
+
+  it('valid shortname -> emoji', () => {
+    expect(shortnameToUnicode(':grinning:')).toBe('😀');
   });
 });

--- a/packages/emoji/src/utils/shortnameToUnicode.ts
+++ b/packages/emoji/src/utils/shortnameToUnicode.ts
@@ -1,0 +1,10 @@
+import { toShort } from 'emoji-toolkit';
+import data from 'emojibase-data/en/compact.json';
+
+const mapShortnameToUnicode: Record<string, string> = Object.fromEntries(
+  data.map((item) => [toShort(item.unicode), item.unicode])
+);
+
+export default function shortnameToUnicode(str: string): string {
+  return mapShortnameToUnicode[str];
+}


### PR DESCRIPTION
## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [ ] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

Opening the Emoji Select or the Emoji Suggestion for the first time is extremely slow, ca. 3 seconds.
Subsequent usage is fast though.

The reason for that is, that `shortnameToUnicode` (from the `emoji-toolkit` library) uses a really huge RegEx, which is slow for the first call.

## Implementation
Instead of using this library method, we create a mapping from shortname to unicode from the same data used to build the EmojiStrategy.
