### PR TITLE
Improve Accessibility on MentionSuggestions

### DIFF
--- a/packages/mention/src/MentionSuggestions/Entry/DefaultEntryComponent.tsx
+++ b/packages/mention/src/MentionSuggestions/Entry/DefaultEntryComponent.tsx
@@ -17,7 +17,7 @@ export default function DefaultEntryComponent(
   } = props;
 
   return (
-    <div {...parentProps}>
+    <div {...parentProps} aria-selected={isFocused}>
       <Avatar mention={mention} theme={theme} />
       <span className={theme?.mentionSuggestionsEntryText}>{mention.name}</span>
     </div>

--- a/packages/mention/src/MentionSuggestions/Popover.tsx
+++ b/packages/mention/src/MentionSuggestions/Popover.tsx
@@ -45,6 +45,7 @@ export default function Popover({
       style={styles.popper}
       {...attributes.popper}
       className={className}
+      role="listbox"
     >
       {children}
     </div>


### PR DESCRIPTION
Please check out Contributing Guidelines. By following this template you help us to review your code.
https://github.com/draft-js-plugins/draft-js-plugins/blob/master/CONTRIBUTING.md

## Checklist

- [x] Fix any eslint errors that occur
- [ ] Update change-log for every plugin you touch
- [ ] Add/Update tests if you add/change new functionality
- [ ] Add/Update docs if you add/change functionality
- [ ] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

#### Whether you're fixing a bug or writing a new feature, please open an issue first and discuss with us. We're also reachable on [the draft js slack](https://draftjs.herokuapp.com/)

- https://github.com/draft-js-plugins/draft-js-plugins/issues/2900

#### Briefly describe the use-case/problem you're solving, reference the issue for this bug/feature here

I would love to see the Mention plugin provide more context for users interacting with editors via VoiceOver or other, non-visual means.

## Implementation

This change aims to improve tha accessibility of the MentionSuggestions
component (and its Entry(ies)) by providing more context clues to the
a11y engine. There are two parts here:

1. Specify `role="listbox"` on the Popover
   - This tells the user that the container they're in is a list-box
     and thus hints that it's navigable
   - It also tells the user how many items are displayed (e.g. `Item 1,
     selected, (2 of 5)`)
2. Keep the `aria-selected` attribute in sync with Entry-`isFocused`
   - This moves the a11y engine's selection window with the keyboard
     shortcuts in the Suggestions popver.

Altogether, these two changes provide an experience very similar to
Slack's mention component when read through Apple's VoiceOver utility.

## Demo

