### PR TITLE
fix: Upload placeholder does not get removed after finish upload #2849

### DIFF
--- a/packages/drag-n-drop-upload/CHANGELOG.md
+++ b/packages/drag-n-drop-upload/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To be released
 
+## 4.2.3
+
+- fix drop upload placeholder does not get removed [#2849](https://github.com/draft-js-plugins/draft-js-plugins/issues/2849)
+
 ## 4.2.2
 
 - support react 18 in peer dependencies [#2701](https://github.com/draft-js-plugins/draft-js-plugins/issues/2701)

--- a/packages/drag-n-drop-upload/package.json
+++ b/packages/drag-n-drop-upload/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draft-js-plugins/drag-n-drop-upload",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "sideEffects": [
     "*.css"
   ],

--- a/packages/drag-n-drop-upload/src/components/insertPlaceholder.ts
+++ b/packages/drag-n-drop-upload/src/components/insertPlaceholder.ts
@@ -21,18 +21,23 @@ export const insertPlaceholder = (editorState:EditorState, text:string): InsertP
     ' '
   );
 
+  const insertedAtomicBlock = newEditorState
+    .getCurrentContent()
+    .getBlockBefore(newEditorState.getSelection().getAnchorKey());
+
+  if (insertedAtomicBlock === undefined) {
+    throw new Error('Unable to locate the block-key of inserted-atomic-block.');
+  }
+
   const stateSelected = EditorState.forceSelection(
     newEditorState,
     newEditorState.getCurrentContent().getSelectionAfter()
   );
 
-  const blockArrayMap = newEditorState.getCurrentContent().getBlocksAsArray().map(b => b.getKey());
-  const nextToLastBlock = newEditorState.getCurrentContent().getBlockForKey(blockArrayMap[blockArrayMap.length-2]);
-
   return {
     state: stateSelected,
-    blockKey: nextToLastBlock.getKey(),
+    blockKey: insertedAtomicBlock.getKey(),
     key: entityKey,
-    text
-  }
+    text,
+  };
 };


### PR DESCRIPTION
This PR fixes a known bug #2849, the fix uses a more dynamic method to pick the right inserted block-key which is used in order to remove the upload-placeholder...

in the previous version the InsertPlaceholder function just picks statically the second-last block which results in wrong block-key for deletion.

I just removed this method and replaced it a dynamic method by reading the inserted atomic block after the creation using the `getSelection().getAnchorKey()`. 

![Peek 2022-09-16 15-33](https://user-images.githubusercontent.com/4742067/190639695-411fae7f-d1ea-4f16-83af-5d70ee1063fd.gif)

