### PR TITLE
Improve Accessibility for LinkButton with appropriate descriptive Aria Label

### DIFF
--- a/packages/anchor/CHANGELOG.md
+++ b/packages/anchor/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To be released
 
+## 4.2.0
+
+- adds accessibility aria label to LinkButton
+
 ## 4.1.4
 
 - support react 18 in peer dependencies [#2701](https://github.com/draft-js-plugins/draft-js-plugins/issues/2701)

--- a/packages/anchor/package.json
+++ b/packages/anchor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draft-js-plugins/anchor",
-  "version": "4.1.4",
+  "version": "4.2.0",
   "sideEffects": [
     "*.css"
   ],

--- a/packages/anchor/src/components/DefaultLinkButton.tsx
+++ b/packages/anchor/src/components/DefaultLinkButton.tsx
@@ -28,6 +28,7 @@ export default function DefaultLinkButton({
         className={className}
         onClick={hasLinkSelected ? onRemoveLinkAtSelection : onAddLinkClick}
         type="button"
+        aria-label="create hypertext link"
       >
         <svg
           height="24"


### PR DESCRIPTION
Please check out Contributing Guidelines. By following this template you help us to review your code.

## Checklist

- [X] Fix any eslint errors that occur
- [X] Update change-log for every plugin you touch
- [X] Add/Update tests if you add/change new functionality
- [X] Add/Update docs if you add/change functionality
- [X] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

LinkButton component lacked an accessibility label. It was out of WCAG compliance and recent PR's have upgraded other RichText Draft.js plugin buttons to add accessibility labeling via aria-label. This means users who are visually disabled or navigate with screen readers are unable to fully utilize the functionality of this button and have a challenging experience.

## Implementation

React accepts a prop 'aria-label' in JSX that will result in an HTML 'aria-label'. An aria-label prop of "create hypertext link" was added so the rendered HTML button has the same aria-label, meets accessibility guidelines, and is not problematic for users navigating with screen readers. See WCAG guidelines: [WCAG label documentation](https://www.w3.org/WAI/WCAG21/Understanding/labels-or-instructions.html).

