### PR TITLE
add missing emojie

### DIFF
--- a/packages/emoji/CHANGELOG.md
+++ b/packages/emoji/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To be released
 
+## 4.6.4
+
+- fix issue with shortname to unicode translation [#3045](https://github.com/draft-js-plugins/draft-js-plugins/issues/3045)
+
 ## 4.6.3
 
 - fix performance issue with shortname to unicode translation [#2915](https://github.com/draft-js-plugins/draft-js-plugins/issues/2915)

--- a/packages/emoji/package.json
+++ b/packages/emoji/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draft-js-plugins/emoji",
-  "version": "4.6.3",
+  "version": "4.6.4",
   "sideEffects": [
     "*.css"
   ],

--- a/packages/emoji/src/utils/__test__/shortnameToUnicode.test.ts
+++ b/packages/emoji/src/utils/__test__/shortnameToUnicode.test.ts
@@ -1,15 +1,15 @@
 import shortnameToUnicode from '../shortnameToUnicode';
 
 describe('shortnameToUnicode', () => {
-  it('empty shortname -> undefined', () => {
-    expect(shortnameToUnicode('')).toBeUndefined();
+  test('empty shortname -> undefined', () => {
+    expect(shortnameToUnicode('')).toBe('');
   });
 
-  it('invalid shortname -> undefined', () => {
-    expect(shortnameToUnicode('obviously not an emoji name')).toBeUndefined();
-  });
-
-  it('valid shortname -> emoji', () => {
+  test('valid shortname -> emoji', () => {
     expect(shortnameToUnicode(':grinning:')).toBe('😀');
+  });
+
+  test('valid shortname -> emoji', () => {
+    expect(shortnameToUnicode(':thumbsup:')).toBe('👍');
   });
 });

--- a/packages/emoji/src/utils/shortnameToUnicode.ts
+++ b/packages/emoji/src/utils/shortnameToUnicode.ts
@@ -1,6 +1,6 @@
 import {
-  toShort,
   shortnameToUnicode as emojiToolkitShortnameToUnicode,
+  toShort,
 } from 'emoji-toolkit';
 import data from 'emojibase-data/en/compact.json';
 

--- a/packages/emoji/src/utils/shortnameToUnicode.ts
+++ b/packages/emoji/src/utils/shortnameToUnicode.ts
@@ -1,4 +1,7 @@
-import { toShort } from 'emoji-toolkit';
+import {
+  toShort,
+  shortnameToUnicode as emojiToolkitShortnameToUnicode,
+} from 'emoji-toolkit';
 import data from 'emojibase-data/en/compact.json';
 
 const mapShortnameToUnicode: Record<string, string> = Object.fromEntries(
@@ -6,5 +9,5 @@ const mapShortnameToUnicode: Record<string, string> = Object.fromEntries(
 );
 
 export default function shortnameToUnicode(str: string): string {
-  return mapShortnameToUnicode[str];
+  return mapShortnameToUnicode[str] || emojiToolkitShortnameToUnicode(str);
 }


### PR DESCRIPTION
There are some emojis missing in 'emojibase-data' library which are present in 'emoji-toolkit' library. adding these emojis leads to undefined. There is an existing function in 'emoji-toolkit' library to get unicode from the shortName so I have used that function in case emojis not found in the existing map.