### PR TITLE
improve `shortnameToUnicode` performance not using `emoji-toolkit` function anymore

### DIFF
--- a/packages/emoji/CHANGELOG.md
+++ b/packages/emoji/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To be released
 
+## 4.6.5
+
+- fix performance issue searching shortname to unicode translation not using shortNameToUnicode from emoji-toolkit at all (really slow regex) [#3045](https://github.com/draft-js-plugins/draft-js-plugins/issues/3045)
+
 ## 4.6.4
 
 - fix issue with shortname to unicode translation [#3045](https://github.com/draft-js-plugins/draft-js-plugins/issues/3045)

--- a/packages/emoji/package.json
+++ b/packages/emoji/package.json
@@ -44,7 +44,7 @@
     "@draft-js-plugins/utils": "^4.2.0",
     "@types/lodash": "^4.14.191",
     "clsx": "^1.2.1",
-    "emoji-toolkit": "^6.6.0",
+    "emoji-toolkit": "^7.0",
     "emojibase": "^6.1.0",
     "emojibase-data": "^7.0.1",
     "immutable": "~3.7.4",

--- a/packages/emoji/package.json
+++ b/packages/emoji/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draft-js-plugins/emoji",
-  "version": "4.6.4",
+  "version": "4.6.5",
   "sideEffects": [
     "*.css"
   ],

--- a/packages/emoji/src/utils/__test__/shortnameToUnicode.test.ts
+++ b/packages/emoji/src/utils/__test__/shortnameToUnicode.test.ts
@@ -1,15 +1,15 @@
 import shortnameToUnicode from '../shortnameToUnicode';
 
 describe('shortnameToUnicode', () => {
-  test('empty shortname -> undefined', () => {
+  test('empty shortname -> default', () => {
     expect(shortnameToUnicode('')).toBe('');
   });
-
   test('valid shortname -> emoji', () => {
     expect(shortnameToUnicode(':grinning:')).toBe('😀');
+    expect(shortnameToUnicode(':thumbsup:')).toBe('👍️');
   });
 
-  test('valid shortname -> emoji', () => {
-    expect(shortnameToUnicode(':thumbsup:')).toBe('👍');
+  test('NOT valid shortname -> emoji', () => {
+    expect(shortnameToUnicode(':not_an_emoji:')).toBeUndefined();
   });
 });

--- a/packages/emoji/src/utils/__test__/shortnameToUnicode.test.ts
+++ b/packages/emoji/src/utils/__test__/shortnameToUnicode.test.ts
@@ -1,15 +1,32 @@
+import { toShort } from 'emoji-toolkit';
+import data from 'emojibase-data/en/compact.json';
 import shortnameToUnicode from '../shortnameToUnicode';
 
 describe('shortnameToUnicode', () => {
-  test('empty shortname -> default', () => {
-    expect(shortnameToUnicode('')).toBe('');
-  });
-  test('valid shortname -> emoji', () => {
-    expect(shortnameToUnicode(':grinning:')).toBe('😀');
-    expect(shortnameToUnicode(':thumbsup:')).toBe('👍️');
+  it('should return the correct Unicode value for a given shortname', () => {
+    expect(shortnameToUnicode(':smile:')).toEqual('😄');
+    expect(shortnameToUnicode(':heart:')).toEqual('❤️');
   });
 
-  test('NOT valid shortname -> emoji', () => {
-    expect(shortnameToUnicode(':not_an_emoji:')).toBeUndefined();
+  it('should return an empty string for an invalid shortname', () => {
+    expect(shortnameToUnicode(':invalid:')).toEqual('');
+    expect(shortnameToUnicode(':not-a-shortname:')).toEqual('');
+  });
+
+  it('should return an empty string for an empty input', () => {
+    expect(shortnameToUnicode('')).toEqual('');
+  });
+
+  it('should return the correct Unicode value for all emojis', () => {
+    data.forEach((item) => {
+      const expectedUnicode = item.unicode;
+      const shortname = toShort(expectedUnicode);
+      expect(shortnameToUnicode(shortname)).toEqual(expectedUnicode);
+    });
+  });
+
+  // This test case checks if the function can correctly handle the :thumbsup: shortname which contains a utf-16 character and if it can find the correct matching Unicode value for that shortname.
+  it('should handle utf-16 strings correctly', () => {
+    expect(shortnameToUnicode(':thumbsup:')).toEqual('👍️');
   });
 });

--- a/packages/emoji/src/utils/shortnameToUnicode.ts
+++ b/packages/emoji/src/utils/shortnameToUnicode.ts
@@ -3,24 +3,25 @@ import data from 'emojibase-data/en/compact.json';
 
 const mapShortnameToUnicode: { key: string; value: string }[] = [];
 
-for (const item of data) {
+data.forEach((item) => {
   mapShortnameToUnicode.push({
     key: toShort(item.unicode),
     value: item.unicode,
   });
   if (item.skins) {
-    for (const skin of item.skins) {
+    item.skins.forEach((skin) => {
       mapShortnameToUnicode.push({
         key: toShort(skin.unicode),
         value: skin.unicode,
       });
-    }
+    });
   }
-}
+});
 
 export default function shortnameToUnicode(str: string): string {
   return str.length
-    ? // Somehow encoding is different, checking with indexOf instead of === works
-      mapShortnameToUnicode.find((x) => x.key.indexOf(str) > -1)?.value || ''
+    ? // We need to use localeCompare because the unicode item may be a utf-16 string
+      mapShortnameToUnicode.find((x) => str.localeCompare(x.key) === 0)
+        ?.value || ''
     : '';
 }

--- a/packages/emoji/src/utils/shortnameToUnicode.ts
+++ b/packages/emoji/src/utils/shortnameToUnicode.ts
@@ -2,20 +2,22 @@ import { toShort } from 'emoji-toolkit';
 import data from 'emojibase-data/en/compact.json';
 
 const mapShortnameToUnicode: { key: string; value: string }[] = [];
-data.forEach((item) => {
+
+for (const item of data) {
   mapShortnameToUnicode.push({
     key: toShort(item.unicode),
     value: item.unicode,
   });
   if (item.skins) {
-    item.skins.forEach((skin) => {
+    for (const skin of item.skins) {
       mapShortnameToUnicode.push({
         key: toShort(skin.unicode),
         value: skin.unicode,
       });
-    });
+    }
   }
-});
+}
+
 export default function shortnameToUnicode(str: string): string {
   return str.length
     ? // Somehow encoding is different, checking with indexOf instead of === works

--- a/packages/emoji/src/utils/shortnameToUnicode.ts
+++ b/packages/emoji/src/utils/shortnameToUnicode.ts
@@ -1,13 +1,24 @@
-import {
-  shortnameToUnicode as emojiToolkitShortnameToUnicode,
-  toShort,
-} from 'emoji-toolkit';
+import { toShort } from 'emoji-toolkit';
 import data from 'emojibase-data/en/compact.json';
 
-const mapShortnameToUnicode: Record<string, string> = Object.fromEntries(
-  data.map((item) => [toShort(item.unicode), item.unicode])
-);
-
+const mapShortnameToUnicode: { key: string; value: string }[] = [];
+data.forEach((item) => {
+  mapShortnameToUnicode.push({
+    key: toShort(item.unicode),
+    value: item.unicode,
+  });
+  if (item.skins) {
+    item.skins.forEach((skin) => {
+      mapShortnameToUnicode.push({
+        key: toShort(skin.unicode),
+        value: skin.unicode,
+      });
+    });
+  }
+});
 export default function shortnameToUnicode(str: string): string {
-  return mapShortnameToUnicode[str] || emojiToolkitShortnameToUnicode(str);
+  return str.length
+    ? // Somehow encoding is different, checking with indexOf instead of === works
+      mapShortnameToUnicode.find((x) => x.key.indexOf(str) > -1)?.value || ''
+    : '';
 }


### PR DESCRIPTION
Somehow, `shortnameToUnicode` was not finding all the shortcodes and was using `shortnameToUnicode` from emoji-toolkit, which is using a very slow regex.
Now it's very much faster 💯 

Some `toShort(item.unicode)` are UTF-16 encoded strings, while `str` is UTF-8. So I use `localeCompare` to compare this correctly.

Also, `mapShortnameToUnicode` was not including skins.


## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR


