### PR TITLE
Improve emoji keyboard navigability

### DIFF
--- a/packages/emoji/CHANGELOG.md
+++ b/packages/emoji/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To be released
 
+## 4.7.0
+- added basic keyboard navigation to fix [#3233](https://github.com/draft-js-plugins/draft-js-plugins/issues/3233)
+- Removed support for the `emojiSelectPopoverEntryFocused` theme prop in favor of using `:focus` on emojiSelectPopoverEntry
+
 ## 4.6.5
 
 - fix performance issue searching shortname to unicode translation not using shortNameToUnicode from emoji-toolkit at all (really slow regex) [#3045](https://github.com/draft-js-plugins/draft-js-plugins/issues/3045)

--- a/packages/emoji/CHANGELOG.md
+++ b/packages/emoji/CHANGELOG.md
@@ -5,9 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To be released
 
-## 4.7.0
+## 4.6.6
 - added basic keyboard navigation to fix [#3233](https://github.com/draft-js-plugins/draft-js-plugins/issues/3233)
-- Removed support for the `emojiSelectPopoverEntryFocused` theme prop in favor of using `:focus` on emojiSelectPopoverEntry
 
 ## 4.6.5
 

--- a/packages/emoji/package.json
+++ b/packages/emoji/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draft-js-plugins/emoji",
-  "version": "4.7.0",
+  "version": "4.6.6",
   "sideEffects": [
     "*.css"
   ],

--- a/packages/emoji/package.json
+++ b/packages/emoji/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@draft-js-plugins/emoji",
-  "version": "4.6.5",
+  "version": "4.7.0",
   "sideEffects": [
     "*.css"
   ],

--- a/packages/emoji/src/__test__/EmojiSelect.test.tsx
+++ b/packages/emoji/src/__test__/EmojiSelect.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render, RenderResult } from '@testing-library/react';
+import { EmojiPluginStore } from 'packages/emoji/lib';
+import EmojiSelect from '../components/EmojiSelect/index';
+import NativeEmojiImage from '../components/Emoji/NativeEmojiImage';
+
+describe('EmojiSelect', (): void => {
+  const renderComponent = (
+    propOverrides = {}
+  ): { screen: RenderResult; store: EmojiPluginStore } => {
+    const store: EmojiPluginStore = {
+      setEditorState: jest.fn(),
+      getPortalClientRect: jest.fn(),
+      getAllSearches: jest.fn(),
+      isEscaped: jest.fn(),
+      escapeSearch: jest.fn(),
+      resetEscapedSearch: jest.fn(),
+      register: jest.fn(),
+      updatePortalClientRect: jest.fn(),
+      unregister: jest.fn(),
+    };
+
+    const props = {
+      store,
+      theme: {},
+      emojiImage: NativeEmojiImage,
+      ...propOverrides,
+    };
+
+    const screen = render(<EmojiSelect {...props} />);
+
+    return { screen, store };
+  };
+
+  it('Renders a button', async () => {
+    const { screen } = renderComponent();
+    expect(await screen.getByRole('button')).toBeInTheDocument();
+  });
+});

--- a/packages/emoji/src/__test__/EmojiSelect.test.tsx
+++ b/packages/emoji/src/__test__/EmojiSelect.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { render, RenderResult } from '@testing-library/react';
-import { EmojiPluginStore } from 'packages/emoji/lib';
+import { fireEvent, render, RenderResult } from '@testing-library/react';
+import { EmojiPluginStore } from '../index';
 import EmojiSelect from '../components/EmojiSelect/index';
 import NativeEmojiImage from '../components/Emoji/NativeEmojiImage';
 
@@ -35,5 +35,14 @@ describe('EmojiSelect', (): void => {
   it('Renders a button', async () => {
     const { screen } = renderComponent();
     expect(await screen.getByRole('button')).toBeInTheDocument();
+  });
+
+  it('should open the EmojiSelect menu with a click event', async () => {
+    const { screen } = renderComponent();
+    const button = await screen.getByRole('button');
+    fireEvent.click(button);
+
+    const grinEmoji = await screen.getByRole('button', { name: ':grinning:' });
+    expect(grinEmoji).toBeInTheDocument();
   });
 });

--- a/packages/emoji/src/components/EmojiSelect/Popover/Entry/index.tsx
+++ b/packages/emoji/src/components/EmojiSelect/Popover/Entry/index.tsx
@@ -54,13 +54,13 @@ export default class Entry extends Component<EntryProps> {
     }
   };
 
-  onMouseEnter = (): void => {
+  onFocusOrHover = (): void => {
     if (!this.props.checkMouseDown()) {
       this.setState({ isFocused: true });
     }
   };
 
-  onMouseLeave = (): void => {
+  onBlur = (): void => {
     if (!this.props.checkMouseDown()) {
       this.setState({ isFocused: false });
     }
@@ -91,8 +91,10 @@ export default class Entry extends Component<EntryProps> {
             : theme.emojiSelectPopoverEntry
         }
         onMouseDown={this.onMouseDown}
-        onMouseEnter={this.onMouseEnter}
-        onMouseLeave={this.onMouseLeave}
+        onMouseEnter={this.onFocusOrHover}
+        onMouseLeave={this.onBlur}
+        onFocus={this.onFocusOrHover}
+        onBlur={this.onBlur}
         onMouseUp={this.onMouseUp}
         onKeyDown={this.onKeyDown}
         ref={(element) => {

--- a/packages/emoji/src/components/EmojiSelect/Popover/Entry/index.tsx
+++ b/packages/emoji/src/components/EmojiSelect/Popover/Entry/index.tsx
@@ -1,5 +1,10 @@
 import PropTypes from 'prop-types';
-import React, { Component, ComponentType, ReactElement } from 'react';
+import React, {
+  Component,
+  ComponentType,
+  KeyboardEvent,
+  ReactElement,
+} from 'react';
 import { EmojiImageProps, EmojiPluginTheme } from '../../../../index';
 import shortnameToUnicode from '../../../../utils/shortnameToUnicode';
 
@@ -65,6 +70,12 @@ export default class Entry extends Component<EntryProps> {
     this.setState({ isFocused: false });
   };
 
+  onKeyDown = (event: KeyboardEvent): void => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      this.props.onEmojiSelect(this.props.emoji);
+    }
+  };
+
   mouseDown = this.props.mouseDown;
 
   render(): ReactElement {
@@ -83,6 +94,7 @@ export default class Entry extends Component<EntryProps> {
         onMouseEnter={this.onMouseEnter}
         onMouseLeave={this.onMouseLeave}
         onMouseUp={this.onMouseUp}
+        onKeyDown={this.onKeyDown}
         ref={(element) => {
           this.button = element;
         }}

--- a/packages/emoji/src/components/EmojiSelect/index.tsx
+++ b/packages/emoji/src/components/EmojiSelect/index.tsx
@@ -78,7 +78,7 @@ export default class EmojiSelect extends Component<EmojiSelectParams> {
     document.removeEventListener('click', this.closeIfClickedOutside);
   }
 
-  onButtonMouseUp = (): void =>
+  onButtonClick = (): void =>
     this.state.isOpen ? this.closePopover() : this.openPopover();
 
   // Open the popover
@@ -134,7 +134,7 @@ export default class EmojiSelect extends Component<EmojiSelectParams> {
       <div className={theme.emojiSelect} ref={this.emojiSelectRef}>
         <button
           className={buttonClassName}
-          onMouseUp={this.onButtonMouseUp}
+          onClick={this.onButtonClick}
           type="button"
         >
           {selectButtonContent}

--- a/packages/emoji/src/theme.ts
+++ b/packages/emoji/src/theme.ts
@@ -206,6 +206,10 @@ export const defaultTheme: EmojiPluginTheme = {
 
   emojiSelectButton: css`
     ${selectButtonSharedStyle}
+
+    &:hover, &:active, &:focus {
+      background: #ededed;
+    }
   `,
   emojiSelectButtonPressed: css`
     ${selectButtonSharedStyle}


### PR DESCRIPTION
Please check out Contributing Guidelines. By following this template you help us to review your code.
https://github.com/draft-js-plugins/draft-js-plugins/blob/master/CONTRIBUTING.md
## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem
Issue [#3233](https://github.com/draft-js-plugins/draft-js-plugins/issues/3233)
The emoji plugin lacks keyboard navigation ability

## Implementation

This creates the appropriate styles and keyboard handlers to allow the EmojiSelect menu to be navigable via keyboard.

## Demo
After:

https://github.com/draft-js-plugins/draft-js-plugins/assets/11545784/3eab1edd-a776-4c9b-a11a-4c6d645a8ed2









