### PR TITLE
Improve emoji popover positioning

### DIFF
--- a/packages/docs/pages/plugin/emoji/index.js
+++ b/packages/docs/pages/plugin/emoji/index.js
@@ -331,13 +331,24 @@ export default class App extends Component {
           <div className={styles.paramBig}>
             <span className={styles.paramName}>positionSuggestions</span>
             <span>
-              The function can be used to manipulate the position of the popover
-              containing the suggestions. It receives one object as arguments
-              containing the visible rectangle surrounding the decorated search
-              string including the colon. In addition the object contains
-              prevProps, prevState, state & props. An object should be returned
-              which can contain all sorts of styles. The defined properties will
-              be applied as inline-styles.
+              <b>Deprecated, use popperOptions instead</b> The function can be
+              used to manipulate the position of the popover containing the
+              suggestions. It receives one object as arguments containing the
+              visible rectangle surrounding the decorated search string
+              including the colon. In addition the object contains prevProps,
+              prevState, state & props. An object should be returned which can
+              contain all sorts of styles. The defined properties will be
+              applied as inline-styles.
+            </span>
+          </div>
+          <div className={styles.paramBig}>
+            <span className={styles.paramName}>popperOptions</span>
+            <span>
+              This options will be used to initialize popper.js. Read in detail
+              about it{' '}
+              <ExternalLink href=" https://popper.js.org/docs/v2/">
+                here.
+              </ExternalLink>
             </span>
           </div>
           <div className={styles.paramBig}>

--- a/packages/emoji/CHANGELOG.md
+++ b/packages/emoji/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To be released
 
+- change EmojiSuggestions to popper.js with option `popperOptions` and deprecate `positionSuggestions` [TBD](https://github.com/draft-js-plugins/draft-js-plugins/issues/TBD)
+
 ## 4.6.6
 - added basic keyboard navigation to fix [#3233](https://github.com/draft-js-plugins/draft-js-plugins/issues/3233)
 

--- a/packages/emoji/package.json
+++ b/packages/emoji/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "@draft-js-plugins/buttons": "^4.0.0",
     "@draft-js-plugins/utils": "^4.2.0",
+    "@popperjs/core": "^2.11.8",
     "@types/lodash": "^4.14.195",
     "clsx": "^1.2.1",
     "emoji-toolkit": "^7.0",
@@ -51,6 +52,7 @@
     "prop-types": "^15.8.1",
     "react-custom-scrollbars-2": "^4.5.0",
     "react-icons": "^4.9.0",
+    "react-popper": "^2.3.0",
     "to-style": "^1.3.3"
   },
   "peerDependencies": {

--- a/packages/emoji/src/__test__/EmojiSelect.test.tsx
+++ b/packages/emoji/src/__test__/EmojiSelect.test.tsx
@@ -34,6 +34,8 @@ describe('EmojiSelect', (): void => {
       register: jest.fn(),
       updatePortalClientRect: jest.fn(),
       unregister: jest.fn(),
+      getReferenceElement: jest.fn(),
+      setReferenceElement: jest.fn(),
     };
 
     const props = {

--- a/packages/emoji/src/components/EmojiSuggestions/Popover.tsx
+++ b/packages/emoji/src/components/EmojiSuggestions/Popover.tsx
@@ -1,0 +1,42 @@
+import clsx from 'clsx';
+import React, { ReactElement, ReactNode, useEffect, useState } from 'react';
+import { usePopper } from 'react-popper';
+import { EmojiPluginStore, EmojiPluginTheme, PopperOptions } from '../../index';
+
+export interface PopoverProps {
+  store: EmojiPluginStore;
+  children: ReactNode;
+  popperOptions?: PopperOptions;
+  theme: EmojiPluginTheme;
+}
+
+export default function Popover({
+  store,
+  children,
+  theme,
+  popperOptions = { placement: 'bottom-start' },
+}: PopoverProps): ReactElement {
+  const [className, setClassName] = useState(() =>
+    clsx(theme.emojiSuggestions)
+  );
+  const [popperElement, setPopperElement] = useState<HTMLElement | null>(null);
+  const { styles, attributes } = usePopper(
+    store.getReferenceElement(),
+    popperElement,
+    popperOptions
+  );
+  useEffect(() => {
+    requestAnimationFrame(() => setClassName(clsx(theme.emojiSuggestions)));
+  }, [theme]);
+  return (
+    <div
+      ref={setPopperElement}
+      style={styles.popper}
+      {...attributes.popper}
+      className={className}
+      role="listbox"
+    >
+      {children}
+    </div>
+  );
+}

--- a/packages/emoji/src/components/EmojiSuggestionsPortal/index.tsx
+++ b/packages/emoji/src/components/EmojiSuggestionsPortal/index.tsx
@@ -29,12 +29,14 @@ export default function EmojiSuggestionsPortal({
   useEffect(() => {
     store.register(offsetKey);
     updatePortalClientRect();
+    store.setReferenceElement(ref.current);
 
     // trigger a re-render so the EmojiSuggestions becomes active
     store.setEditorState!(store.getEditorState!());
 
     return () => {
       store.unregister(offsetKey);
+      store.setReferenceElement(null);
     };
   }, [updatePortalClientRect, store]);
 

--- a/packages/emoji/src/theme.ts
+++ b/packages/emoji/src/theme.ts
@@ -159,7 +159,6 @@ export const defaultTheme: EmojiPluginTheme = {
 
   emojiSuggestions: css`
     border: 1px solid #eee;
-    margin-top: 1.75em;
     position: absolute;
     min-width: 220px;
     max-width: 440px;

--- a/packages/emoji/src/utils/warning.ts
+++ b/packages/emoji/src/utils/warning.ts
@@ -1,0 +1,8 @@
+import { once } from 'lodash';
+
+export const warning = once((text: string): void => {
+  if (process.env.NODE_ENV === 'development') {
+    // eslint-disable-next-line no-console
+    console.warn(text);
+  }
+});


### PR DESCRIPTION
Please check out Contributing Guidelines. By following this template you help us to review your code.
https://github.com/draft-js-plugins/draft-js-plugins/blob/master/CONTRIBUTING.md

## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

Issue #3254
The emoji plugins suggestions popover can overflow the viewport when it pops up near the bottom.

## Implementation

This follows the precedent set in the `mention` plugin, and follows that example by using [popper.js](https://popper.js.org/docs/v2/) to implement the popover. It also deprecates the `positionSuggestions` prop and introduces `popperOptions`, again trying to align with the example set in the mention plugin (PR #2029).

## Demo

After:
![emoji_suggestions_popover](https://github.com/draft-js-plugins/draft-js-plugins/assets/515609/0baf65d6-67ec-424a-b62a-7ec5cc8d8242)
