### PR TITLE
incremental step using popper.js for emoji select popover position

### DIFF
--- a/packages/emoji/CHANGELOG.md
+++ b/packages/emoji/CHANGELOG.md
@@ -5,7 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To be released
 
-- change EmojiSuggestions to popper.js with option `popperOptions` and deprecate `positionSuggestions` [TBD](https://github.com/draft-js-plugins/draft-js-plugins/issues/TBD)
+- change EmojiSuggestions to popper.js with option `suggestionsPopperOptions` and deprecate `positionSuggestions` [TBD](https://github.com/draft-js-plugins/draft-js-plugins/issues/TBD)
+- change EmojiSelect to use popper.js with option `selectPopperOptions` [#3260](https://github.com/draft-js-plugins/draft-js-plugins/issues/3260)
 
 ## 4.6.6
 - added basic keyboard navigation to fix [#3233](https://github.com/draft-js-plugins/draft-js-plugins/issues/3233)

--- a/packages/emoji/src/components/EmojiSelect/Popover/index.tsx
+++ b/packages/emoji/src/components/EmojiSelect/Popover/index.tsx
@@ -23,6 +23,7 @@ interface PopoverProps {
   emojiImage: ComponentType<EmojiImageProps>;
   onEmojiSelect(): void;
   menuPosition?: 'top' | 'bottom';
+  setPopperRef(element: HTMLDivElement): void;
 }
 
 export default class Popover extends Component<PopoverProps> {
@@ -206,8 +207,9 @@ export default class Popover extends Component<PopoverProps> {
       <div
         className={className}
         onMouseDown={this.onMouseDown}
-        ref={element => {
+        ref={(element) => {
           this.container = element;
+          this.props.setPopperRef(this.container!);
         }}
       >
         {isOpen && (
@@ -224,7 +226,7 @@ export default class Popover extends Component<PopoverProps> {
               onEmojiSelect={this.onEmojiSelect}
               onEmojiMouseDown={this.onEmojiMouseDown}
               onGroupScroll={this.onGroupScroll}
-              ref={element => {
+              ref={(element) => {
                 this.groupsElement = element;
               }}
               emojiImage={emojiImage}

--- a/packages/emoji/src/components/EmojiSelect/index.tsx
+++ b/packages/emoji/src/components/EmojiSelect/index.tsx
@@ -12,6 +12,7 @@ import {
   EmojiPluginStore,
   EmojiPluginTheme,
   EmojiSelectGroup,
+  PopperOptions,
 } from '../../index';
 import createEmojisFromStrategy from '../../utils/createEmojisFromStrategy';
 import Popover from './Popover';
@@ -32,7 +33,7 @@ interface EmojiSelectParams extends EmojiSelectPubParams {
   toneSelectOpenDelay?: number;
   emojiImage: ComponentType<EmojiImageProps>;
   menuPosition?: 'top' | 'bottom';
-  popperOptions?: Options;
+  popperOptions?: PopperOptions;
 }
 
 export default class EmojiSelect extends Component<EmojiSelectParams> {
@@ -102,7 +103,7 @@ export default class EmojiSelect extends Component<EmojiSelectParams> {
       this.popperInstance = createPopper(
         this.buttonRef.current,
         this.popoverContainer,
-        this.props.popperOptions
+        this.props.popperOptions as Options
       );
     }
   };

--- a/packages/emoji/src/components/EmojiSelect/index.tsx
+++ b/packages/emoji/src/components/EmojiSelect/index.tsx
@@ -5,6 +5,7 @@ import React, {
   ReactElement,
   ReactNode,
 } from 'react';
+import { createPopper, Instance } from '@popperjs/core';
 import defaultEmojiGroups from '../../constants/defaultEmojiGroups';
 import {
   EmojiImageProps,
@@ -67,6 +68,9 @@ export default class EmojiSelect extends Component<EmojiSelectParams> {
 
   // Emoji select ref
   emojiSelectRef = React.createRef<HTMLDivElement>();
+  buttonRef = React.createRef<HTMLButtonElement>();
+  popoverContainer: HTMLDivElement | null = null;
+  popperInstance: Instance | null = null;
 
   // When the selector is open and users click anywhere on the page,
   // the selector should close
@@ -91,6 +95,13 @@ export default class EmojiSelect extends Component<EmojiSelectParams> {
     if (this.props.onOpen) {
       this.props.onOpen();
     }
+    if (this.buttonRef.current && this.popoverContainer) {
+      this.popperInstance = createPopper(
+        this.buttonRef.current,
+        this.popoverContainer,
+        { placement: 'bottom-start' }
+      );
+    }
   };
 
   // Close the popover
@@ -103,6 +114,8 @@ export default class EmojiSelect extends Component<EmojiSelectParams> {
     if (this.props.onClose) {
       this.props.onClose();
     }
+    this.popperInstance?.destroy();
+    this.popperInstance = null;
   };
 
   // To check if clicked outside of emoji popover
@@ -133,6 +146,7 @@ export default class EmojiSelect extends Component<EmojiSelectParams> {
     return (
       <div className={theme.emojiSelect} ref={this.emojiSelectRef}>
         <button
+          ref={this.buttonRef}
           className={buttonClassName}
           onClick={this.onButtonClick}
           type="button"
@@ -140,6 +154,9 @@ export default class EmojiSelect extends Component<EmojiSelectParams> {
           {selectButtonContent}
         </button>
         <Popover
+          setPopperRef={(element) => {
+            this.popoverContainer = element;
+          }}
           theme={theme}
           store={store}
           groups={selectGroups!}

--- a/packages/emoji/src/components/EmojiSelect/index.tsx
+++ b/packages/emoji/src/components/EmojiSelect/index.tsx
@@ -5,7 +5,7 @@ import React, {
   ReactElement,
   ReactNode,
 } from 'react';
-import { createPopper, Instance } from '@popperjs/core';
+import { createPopper, Instance, Options } from '@popperjs/core';
 import defaultEmojiGroups from '../../constants/defaultEmojiGroups';
 import {
   EmojiImageProps,
@@ -32,6 +32,7 @@ interface EmojiSelectParams extends EmojiSelectPubParams {
   toneSelectOpenDelay?: number;
   emojiImage: ComponentType<EmojiImageProps>;
   menuPosition?: 'top' | 'bottom';
+  popperOptions?: Options;
 }
 
 export default class EmojiSelect extends Component<EmojiSelectParams> {
@@ -53,12 +54,14 @@ export default class EmojiSelect extends Component<EmojiSelectParams> {
     ]),
     toneSelectOpenDelay: PropTypes.number,
     menuPosition: PropTypes.oneOf(['top', 'bottom']),
+    popperOptions: PropTypes.object,
   };
 
   static defaultProps = {
     selectButtonContent: '☺',
     selectGroups: defaultEmojiGroups,
     toneSelectOpenDelay: 500,
+    popperOptions: { placement: 'bottom-start' },
   };
 
   // Start the selector closed
@@ -99,7 +102,7 @@ export default class EmojiSelect extends Component<EmojiSelectParams> {
       this.popperInstance = createPopper(
         this.buttonRef.current,
         this.popoverContainer,
-        { placement: 'bottom-start' }
+        this.props.popperOptions
       );
     }
   };

--- a/packages/emoji/src/index.tsx
+++ b/packages/emoji/src/index.tsx
@@ -89,7 +89,7 @@ export interface EmojiPluginConfig {
   emojiImage?: ComponentType<EmojiImageProps>;
   emojiInlineText?: ComponentType<EmojiInlineTextProps>;
   disableInlineEmojis?: boolean;
-  popperOptions?: PopperOptions;
+  suggestionsPopperOptions?: PopperOptions;
 }
 
 interface GetClientRectFn {
@@ -190,7 +190,7 @@ export default (config: EmojiPluginConfig = {}): EmojiPlugin => {
     emojiInlineText = useNativeArt
       ? NativeEmojiInlineText
       : JoyPixelEmojiInlineText,
-    popperOptions,
+    suggestionsPopperOptions,
   } = config;
 
   // if priorityList is configured in config then set priorityList
@@ -205,7 +205,7 @@ export default (config: EmojiPluginConfig = {}): EmojiPlugin => {
     positionSuggestions,
     shortNames: List(keys(emojiList.list)),
     emojiImage,
-    popperOptions,
+    popperOptions: suggestionsPopperOptions,
   };
   const selectProps = {
     theme,

--- a/packages/emoji/src/index.tsx
+++ b/packages/emoji/src/index.tsx
@@ -90,6 +90,7 @@ export interface EmojiPluginConfig {
   emojiInlineText?: ComponentType<EmojiInlineTextProps>;
   disableInlineEmojis?: boolean;
   suggestionsPopperOptions?: PopperOptions;
+  selectPopperOptions?: PopperOptions;
 }
 
 interface GetClientRectFn {
@@ -191,6 +192,7 @@ export default (config: EmojiPluginConfig = {}): EmojiPlugin => {
       ? NativeEmojiInlineText
       : JoyPixelEmojiInlineText,
     suggestionsPopperOptions,
+    selectPopperOptions,
   } = config;
 
   // if priorityList is configured in config then set priorityList
@@ -214,6 +216,7 @@ export default (config: EmojiPluginConfig = {}): EmojiPlugin => {
     selectButtonContent,
     toneSelectOpenDelay,
     emojiImage,
+    popperOptions: selectPopperOptions,
   };
   const DecoratedEmojiSuggestions = (
     props: EmojiSuggestionsPubParams


### PR DESCRIPTION
Please check out Contributing Guidelines. By following this template you help us to review your code.
https://github.com/draft-js-plugins/draft-js-plugins/blob/master/CONTRIBUTING.md

## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

Issue #3260
The emoji plugins select popover can overflow the viewport when it pops up near the bottom.

## Implementation

We made an incremental change to the EmojiSelect component to use [popper.js](https://popper.js.org/docs/v2/) to implement its popover.

We explored the probably preferred approach of changing the EmojiSelect/Popover component to be a functional component so that we could the `usePopper` hook but found the level of effort to convert both the parent and child components to the functional style to be a bit high. 

What we did here instead makes the code a bit worse, but does improve the user experience immediately and buys time for any future class-based to functional react component conversions to happen.

## Demo

after:
https://github.com/draft-js-plugins/draft-js-plugins/assets/515609/cb9d1839-dbf1-4b1a-ac80-4e190abeb31c

