### PR TITLE
Add support for defining mention prefix based on the trigger.

### DIFF
--- a/packages/docs/components/Examples/mention/MultiMentionTriggers/Mentions.ts
+++ b/packages/docs/components/Examples/mention/MultiMentionTriggers/Mentions.ts
@@ -45,4 +45,4 @@ const topics = [
   },
 ];
 
-export default { '@': mentions, '(': topics };
+export default { '@': mentions, '#': topics };

--- a/packages/docs/components/Examples/mention/MultiMentionTriggers/MultiMentionTriggers.tsx
+++ b/packages/docs/components/Examples/mention/MultiMentionTriggers/MultiMentionTriggers.tsx
@@ -7,7 +7,10 @@ import createMentionPlugin, {
 import editorStyles from './MultiMentionTriggers.module.css';
 import mentions from './Mentions';
 
-const mentionPlugin = createMentionPlugin({ mentionTrigger: ['@', '('] });
+const mentionPlugin = createMentionPlugin({
+  mentionTrigger: ['@', '#'],
+  mentionPrefix: (trigger) => trigger,
+});
 const { MentionSuggestions } = mentionPlugin;
 const plugins = [mentionPlugin];
 

--- a/packages/mention/CHANGELOG.md
+++ b/packages/mention/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## To Be Released
 
+## 5.2.3
+
+- Add support for defining `mentionPrefix` as a callback function that takes the `mentionTrigger` as an argument and returns the prefix.
+
 ## 5.2.2
 
 - adjust react peer dependency

--- a/packages/mention/src/MentionSuggestions/MentionSuggestions.tsx
+++ b/packages/mention/src/MentionSuggestions/MentionSuggestions.tsx
@@ -60,7 +60,7 @@ export interface MentionSuggestionsProps extends MentionSuggestionsPubProps {
   positionSuggestions?: PositionSuggestionsFn;
   ariaProps: AriaProps;
   theme: MentionPluginTheme;
-  mentionPrefix: string;
+  mentionPrefix: string | ((trigger: string) => string);
   mentionTriggers: string[];
   entityMutability: 'SEGMENTED' | 'IMMUTABLE' | 'MUTABLE';
   popperOptions?: PopperOptions;

--- a/packages/mention/src/index.tsx
+++ b/packages/mention/src/index.tsx
@@ -64,7 +64,7 @@ export interface MentionPluginStore {
 }
 
 export interface MentionPluginConfig {
-  mentionPrefix?: string;
+  mentionPrefix?: string | ((trigger: string) => string);
   theme?: MentionPluginTheme;
   positionSuggestions?: PositionSuggestionsFn;
   mentionComponent?: ComponentType<SubMentionComponentProps>;
@@ -154,7 +154,8 @@ export default (
     theme = defaultTheme,
     positionSuggestions,
     mentionComponent,
-    mentionSuggestionsComponent: MentionSuggestionsComponent = MentionSuggestions,
+    mentionSuggestionsComponent:
+      MentionSuggestionsComponent = MentionSuggestions,
     entityMutability = 'SEGMENTED',
     mentionTrigger = '@',
     mentionRegExp = defaultRegExp,

--- a/packages/mention/src/modifiers/addMention.ts
+++ b/packages/mention/src/modifiers/addMention.ts
@@ -6,7 +6,7 @@ import getTypeByTrigger from '../utils/getTypeByTrigger';
 export default function addMention(
   editorState: EditorState,
   mention: MentionData,
-  mentionPrefix: string,
+  mentionPrefix: string | ((trigger: string) => string),
   mentionTrigger: string,
   entityMutability: 'SEGMENTED' | 'IMMUTABLE' | 'MUTABLE'
 ): EditorState {
@@ -31,7 +31,7 @@ export default function addMention(
   let mentionReplacedContent = Modifier.replaceText(
     editorState.getCurrentContent(),
     mentionTextSelection,
-    `${mentionPrefix}${mention.name}`,
+    `${typeof mentionPrefix === 'string' ? mentionPrefix : mentionPrefix(mentionTrigger)}${mention.name}`,
     editorState.getCurrentInlineStyle(),
     entityKey
   );


### PR DESCRIPTION
Please check out Contributing Guidelines. By following this template you help us to review your code.
https://github.com/draft-js-plugins/draft-js-plugins/blob/master/CONTRIBUTING.md

## Checklist

- [x] Fix any eslint errors that occur
- [x] Update change-log for every plugin you touch
- [x] Add/Update tests if you add/change new functionality
- [x] Add/Update docs if you add/change functionality
- [x] Enable "Allow edits from maintainers" for this PR

## Use-case/Problem

Mention plugin lets one define multiple triggers to add mentions but is restrictive when it comes to defining prefixes for these mentions. Currently, the plugin only a allows a single static prefix for all mentions. 

It's a very common use-case to have different prefixes for different mention types. 
Ex: 

- `@` prefix for a user mention - `@Aman Saryal`
- `#` prefix for a channel mention - `#random`


## Implementation

This PR allows a function to be passed as mention prefix to the plugin. The function takes the trigger for the selected mention and returns a string prefix. 

```
{
    ...
    mentionPrefix: string | ((trigger: string) => string);
    ...
}
```

## Demo

![multi-mention-prefix](https://github.com/draft-js-plugins/draft-js-plugins/assets/5456671/f54635ba-f51a-4758-8c6b-2bfbf0aa7183)
